### PR TITLE
Diff

### DIFF
--- a/expr/funcs.go
+++ b/expr/funcs.go
@@ -183,6 +183,9 @@ func Query(e *state, T miniprofiler.Timer, query, duration string) (r []*Result,
 
 func Diff(e *state, T miniprofiler.Timer, query, duration string) (r []*Result, err error) {
 	d, err := opentsdb.ParseDuration(duration)
+	if err != nil {
+		return
+	}
 	//is time.Duration(d) safe?
 	fd := float64(time.Duration(d) / time.Second)
 	if err != nil {


### PR DESCRIPTION
This is useful for instances where you want change over the period of time. It returns the chronologically last value minus the first value.

Because opentsdb might return a different period of time than requested, diff interpolates the value to be that of the time requested. For example if you request 60 seconds, but the query returns 30 seconds of data, the result will be multiplied by 2
