### PR TITLE
Add ability to disable unknown for certain alerts

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -196,7 +196,7 @@ type Alert struct {
 	CritNotification *Notifications
 	WarnNotification *Notifications
 	Unknown          time.Duration
-	NoUnknown        bool
+	IgnoreUnknown    bool
 	Macros           []string `json:"-"`
 	UnjoinedOK       bool     `json:",omitempty"`
 
@@ -748,8 +748,8 @@ func (c *Conf) loadAlert(s *parse.SectionNode) {
 			a.Unknown = d
 		case "unjoinedOk":
 			a.UnjoinedOK = true
-		case "noUnknown":
-			a.NoUnknown = true
+		case "ignoreUnknown":
+			a.IgnoreUnknown = true
 		default:
 			c.errorf("unknown key %s", p.key)
 		}

--- a/sched/check.go
+++ b/sched/check.go
@@ -44,7 +44,7 @@ func (s *Schedule) Check(T miniprofiler.Timer, start time.Time) {
 	s.RunHistory(r)
 }
 
-// RunHistory processes an event history and triggers notifications if needed.
+// RunHistory processes an event history and trisggers notifications if needed.
 func (s *Schedule) RunHistory(r RunHistory) {
 	checkNotify := false
 	silenced := s.Silenced()
@@ -117,7 +117,7 @@ func (s *Schedule) CheckUnknown() {
 				continue
 			}
 			a := s.Conf.Alerts[ak.Name()]
-			if a.NoUnknown {
+			if a.IgnoreUnknown {
 				continue
 			}
 			t := a.Unknown

--- a/sched/sched.go
+++ b/sched/sched.go
@@ -383,7 +383,7 @@ func (s *Schedule) RestoreState() {
 		} else if s.Conf.Squelched(a, st.Group) {
 			log.Println("sched: alert now squelched:", ak)
 			continue
-		} else if st.Status().IsUnknown() && a.NoUnknown {
+		} else if st.Status().IsUnknown() && a.IgnoreUnknown {
 			log.Println("sched: alert now disregards unknown:", ak)
 			continue
 		} else {


### PR DESCRIPTION
This is useful for things that come and go. We currently have two examples in our environment:
- Drives (Temporary mounts, in particular in Windows)
- Haproxylog Routes
