### PR TITLE
cmd/bosun: Add the d() func, i.e. d("1h")

### DIFF
--- a/cmd/bosun/expr/funcs.go
+++ b/cmd/bosun/expr/funcs.go
@@ -127,6 +127,11 @@ var builtins = map[string]parse.Func{
 		parse.TYPE_NUMBER,
 		Abs,
 	},
+	"d": {
+		[]parse.FuncType{parse.TYPE_STRING},
+		parse.TYPE_SCALAR,
+		Duration,
+	},
 	"dropna": {
 		[]parse.FuncType{parse.TYPE_SERIES},
 		parse.TYPE_SERIES,
@@ -147,6 +152,18 @@ var builtins = map[string]parse.Func{
 func NV(e *state, T miniprofiler.Timer, series *Results, v float64) (results *Results, err error) {
 	series.NaNValue = &v
 	return series, nil
+}
+
+func Duration(e *state, T miniprofiler.Timer, d string) (*Results, error) {
+	duration, err := opentsdb.ParseDuration(d)
+	if err != nil {
+		return nil, err
+	}
+	return &Results{
+		Results: []*Result{
+			{Value: Scalar(duration.Seconds())},
+		},
+	}, nil
 }
 
 func DropNA(e *state, T miniprofiler.Timer, series *Results) (*Results, error) {


### PR DESCRIPTION
d() returns the number of seconds for that opentsdb duration string. Currently this will just be nice when doing things like forecastlr(q("avg:6h-avg:os.disk.fs.percent_free{$filter}", "7d", ""), 0) / 60 / 60 / 24 or using the since function. However, we might consider changing the arguments to query functions to be scalars and use this function.
