### PR TITLE
cmd/bosun: Add epoch() func, which returns the current Unix epoch in sec...

### DIFF
--- a/cmd/bosun/expr/funcs.go
+++ b/cmd/bosun/expr/funcs.go
@@ -132,6 +132,11 @@ var builtins = map[string]parse.Func{
 		parse.TYPE_SCALAR,
 		Duration,
 	},
+	"epoch": {
+		[]parse.FuncType{},
+		parse.TYPE_SCALAR,
+		Epoch,
+	},
 	"dropna": {
 		[]parse.FuncType{parse.TYPE_SERIES},
 		parse.TYPE_SERIES,
@@ -147,6 +152,14 @@ var builtins = map[string]parse.Func{
 		parse.TYPE_NUMBER,
 		NV,
 	},
+}
+
+func Epoch(e *state, T miniprofiler.Timer) (*Results, error) {
+	return &Results{
+		Results: []*Result{
+			{Value: Scalar(float64(time.Now().Unix()))},
+		},
+	}, nil
 }
 
 func NV(e *state, T miniprofiler.Timer, series *Results, v float64) (results *Results, err error) {

--- a/cmd/bosun/expr/parse/parse.go
+++ b/cmd/bosun/expr/parse/parse.go
@@ -310,6 +310,8 @@ func (t *Tree) Func() (f *FuncNode) {
 				t.error(err)
 			}
 			f.append(newString(token.pos, token.val, s))
+		case itemRightParen:
+			return
 		}
 		switch token = t.next(); token.typ {
 		case itemComma:


### PR DESCRIPTION
...onds

Also required change parse.Tree.func() to support the case of a function with no arguments.

Use Case (Alert when warranty will expire):

![image](https://cloud.githubusercontent.com/assets/1692624/5416477/f7f4bd5e-81fd-11e4-9670-733670d6ddb8.png)
