### PR TITLE
cmd/bosun: Sort numbered results.

### DIFF
--- a/cmd/bosun/expr/expr.go
+++ b/cmd/bosun/expr/expr.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"reflect"
 	"runtime"
+	"sort"
 	"time"
 
 	"bosun.org/_third_party/github.com/MiniProfiler/go/miniprofiler"
@@ -139,7 +140,7 @@ type Result struct {
 }
 
 type Results struct {
-	Results []*Result
+	Results ResultSlice
 	// If true, ungrouped joins from this set will be ignored.
 	IgnoreUnjoined bool
 	// If true, ungrouped joins from the other set will be ignored.
@@ -148,12 +149,29 @@ type Results struct {
 	NaNValue *float64
 }
 
+type ResultSlice []*Result
+
 func (r *Results) NaN() Number {
 	if r.NaNValue != nil {
 		return Number(*r.NaNValue)
 	}
 	return Number(math.NaN())
 }
+
+func (r ResultSlice) DescByValue() ResultSlice {
+	for _, v := range r {
+		if _, ok := v.Value.(Number); !ok {
+			return r
+		}
+	}
+	c := r[:]
+	sort.Sort(c)
+	return c
+}
+
+func (r ResultSlice) Len() int           { return len(r) }
+func (r ResultSlice) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
+func (r ResultSlice) Less(i, j int) bool { return r[i].Value.(Number) > r[j].Value.(Number) }
 
 type Computations []Computation
 

--- a/cmd/bosun/sched/template.go
+++ b/cmd/bosun/sched/template.go
@@ -174,7 +174,7 @@ func (s *Schedule) ExecuteBadTemplate(s_err, b_err error, rh *RunHistory, a *con
 	return bytes.NewBufferString(sub), body, nil
 }
 
-func (c *Context) eval(v interface{}, filter bool, series bool, autods int) ([]*expr.Result, string, error) {
+func (c *Context) eval(v interface{}, filter bool, series bool, autods int) (expr.ResultSlice, string, error) {
 	var e *expr.Expr
 	var err error
 	switch v := v.(type) {


### PR DESCRIPTION
Useful for tables in templates:

```
    <h3>CPU For Monitored Processes</h3>
     <table>
    <tr><th>Process</th><th>Avg CPU in past 10m</th></tr>
    {{range $r := (.EvalAll .Alert.Vars.win_process).Sort}}
      {{if eq $.Group.host $r.Group.host}} 
            <tr>
              <td>{{$r.Group.name}}</td>
```

![image](https://cloud.githubusercontent.com/assets/1692624/5463391/71590638-854a-11e4-839c-54a015d50915.png)
