### PR TITLE
initial graphite support

### DIFF
--- a/cmd/bosun/conf/conf.go
+++ b/cmd/bosun/conf/conf.go
@@ -30,6 +30,7 @@ type Conf struct {
 	Name            string        // Config file name
 	CheckFrequency  time.Duration // Time between alert checks: 5m
 	TSDBHost        string        // OpenTSDB relay and query destination: ny-devtsdb04:4242
+	GraphiteHost    string        // host for graphite, like http://foo.bar.baz
 	HTTPListen      string        // Web server listen address: :80
 	Hostname        string
 	RelayListen     string // OpenTSDB relay listen address: :4242
@@ -359,6 +360,8 @@ func (c *Conf) loadGlobal(p *parse.PairNode) {
 			v += ":4242"
 		}
 		c.TSDBHost = v
+	case "graphiteHost":
+		c.GraphiteHost = v
 	case "httpListen":
 		c.HTTPListen = v
 	case "hostname":

--- a/cmd/bosun/sched/template.go
+++ b/cmd/bosun/sched/template.go
@@ -201,7 +201,7 @@ func (c *Context) eval(v interface{}, filter bool, series bool, autods int) (exp
 	if c.AbnormalEvent() != nil {
 		t = c.AbnormalEvent().Time
 	}
-	res, _, err := e.Execute(c.runHistory.Context, nil, t, autods, c.Alert.UnjoinedOK, c.schedule.Search, c.schedule.Conf.AlertSquelched(c.Alert))
+	res, _, err := e.Execute(c.runHistory.Context, c.runHistory.GraphiteContext, nil, t, autods, c.Alert.UnjoinedOK, c.schedule.Search, c.schedule.Conf.AlertSquelched(c.Alert))
 	if err != nil {
 		return nil, "", fmt.Errorf("%s: %v", v, err)
 	}

--- a/cmd/bosun/web/chart.go
+++ b/cmd/bosun/web/chart.go
@@ -19,6 +19,7 @@ import (
 	"bosun.org/cmd/bosun/expr"
 	"bosun.org/cmd/bosun/expr/parse"
 	"bosun.org/cmd/bosun/sched"
+	"bosun.org/graphite"
 	"bosun.org/metadata"
 	"bosun.org/opentsdb"
 )
@@ -193,7 +194,7 @@ func ExprGraph(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (in
 	} else if e.Root.Return() != parse.TypeSeries {
 		return nil, fmt.Errorf("egraph: requires an expression that returns a series")
 	}
-	res, _, err := e.Execute(opentsdb.NewCache(schedule.Conf.TSDBHost, schedule.Conf.ResponseLimit), t, now, autods, false, schedule.Search, nil)
+	res, _, err := e.Execute(opentsdb.NewCache(schedule.Conf.TSDBHost, schedule.Conf.ResponseLimit), graphite.Host(schedule.Conf.GraphiteHost), t, now, autods, false, schedule.Search, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/bosun/web/expr.go
+++ b/cmd/bosun/web/expr.go
@@ -17,6 +17,7 @@ import (
 	"bosun.org/cmd/bosun/conf"
 	"bosun.org/cmd/bosun/expr"
 	"bosun.org/cmd/bosun/sched"
+	"bosun.org/graphite"
 	"bosun.org/opentsdb"
 )
 
@@ -29,7 +30,7 @@ func Expr(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (interfa
 	if err != nil {
 		return nil, err
 	}
-	res, queries, err := e.Execute(opentsdb.NewCache(schedule.Conf.TSDBHost, schedule.Conf.ResponseLimit), t, now, 0, false, schedule.Search, nil)
+	res, queries, err := e.Execute(opentsdb.NewCache(schedule.Conf.TSDBHost, schedule.Conf.ResponseLimit), graphite.Host(schedule.Conf.GraphiteHost), t, now, 0, false, schedule.Search, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -223,6 +224,7 @@ func Rule(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (interfa
 	}
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "tsdbHost = %s\n", schedule.Conf.TSDBHost)
+	fmt.Fprintf(&buf, "graphiteHost = %s\n", schedule.Conf.GraphiteHost)
 	fmt.Fprintf(&buf, "smtpHost = %s\n", schedule.Conf.SMTPHost)
 	fmt.Fprintf(&buf, "emailFrom = %s\n", schedule.Conf.EmailFrom)
 	fmt.Fprintf(&buf, "responseLimit = %d\n", schedule.Conf.ResponseLimit)

--- a/graphite/tsdb.go
+++ b/graphite/tsdb.go
@@ -1,0 +1,132 @@
+// Package graphite defines structures for interacting with a Graphite server.
+package graphite // import "bosun.org/graphite"
+
+import (
+	"bosun.org/opentsdb"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+//request structs
+
+// Request holds query objects:
+// unlike the opentsdb package, this is not a 100% complete graphite package
+// and so we only support unix timestamps as from/until
+type Request struct {
+	Start   *uint32
+	End     *uint32
+	Targets []string
+}
+
+type Query struct {
+	Target string
+	Format []string
+	Tags   opentsdb.TagSet
+}
+
+type Response struct {
+	Series []Series
+}
+
+// response types
+type Series struct {
+	Datapoints []DataPoint
+	Target     string
+}
+type DataPoint []json.Number
+
+func ParseQuery(query, format string) (q *Query, err error) {
+	q = new(Query)
+	q.Target = query
+	q.Tags, q.Format = ParseFormat(format)
+	return
+}
+
+// convert a format like "..host..core" into
+// a tagset with host and core keys, and the structured repr.
+func ParseFormat(format string) (opentsdb.TagSet, []string) {
+	nodes := strings.Split(format, ".")
+	ts := make(opentsdb.TagSet)
+	for _, node := range nodes {
+		if node != "" {
+			ts[node] = ""
+		}
+	}
+	return ts, nodes
+}
+
+func (r *Request) Query(host string) (Response, error) {
+	v := url.Values{}
+	v.Set("format", "json")
+	// note that r.Start and r.End should != nil at this point.
+	// if not, a panic is in order.
+	v.Set("from", fmt.Sprintf("%d", *r.Start))
+	v.Set("until", fmt.Sprintf("%d", *r.End))
+	for _, target := range r.Targets {
+		v.Add("target", target)
+	}
+	url := fmt.Sprintf("%s/render/?%s", host, v.Encode())
+	resp, err := DefaultClient.Get(url)
+	if err != nil {
+		return Response{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return Response{}, errors.New(resp.Status)
+	}
+	decoder := json.NewDecoder(resp.Body)
+	var series []Series
+	err = decoder.Decode(&series)
+	return Response{series}, err
+}
+
+func ParseTime(i uint32) (time.Time, error) {
+	return time.Unix(int64(i), 0).UTC(), nil
+}
+
+// SetTime adjusts the start and end time of the request to assume t is now.
+// Relative times ("1m-ago") are changed to absolute times. Existing absolute
+// times are adjusted by the difference between time.Now() and t.
+// note that r.Start should != nil at this point. if not, a panic is in order.
+func (r *Request) SetTime(t time.Time) error {
+	diff := -time.Since(t)
+	start, err := ParseTime(*r.Start)
+	if err != nil {
+		return err
+	}
+	newStart := uint32(start.Add(diff).Unix())
+	r.Start = &newStart
+	newEnd := uint32(t.UTC().Unix())
+	if r.End != nil {
+		end, err := ParseTime(*r.End)
+		if err != nil {
+			return err
+		}
+		newEnd = uint32(end.Add(diff).Unix())
+	}
+	r.End = &newEnd
+	return nil
+}
+
+// DefaultClient is the default http client for requests.
+var DefaultClient = &http.Client{
+	Timeout: time.Minute,
+}
+
+// Context is the interface for querying a graphite server
+type Context interface {
+	Query(*Request) (Response, error)
+}
+
+// Host is a simple Graphite Context with no additional features.
+type Host string
+
+// Query performs the request to the graphite server
+func (h Host) Query(r *Request) (Response, error) {
+	return r.Query(string(h))
+}


### PR DESCRIPTION
not meant for merging, but just for discussion, feedback, etc.
this just parses `graphite("graphite-expr")` in the config. right now there's only 1 arg, the expression.

i numbered the things i'ld like responses to.

1) i presume i should add a second arg to control timeframe to collect(i.e. `from=-2minutes`), which i presume is also what the `sduration` ("2m") does for opentsdb?  I checked http://bosun.org/configuration.html#opentsdb-query-functions but don't really understand what startduration and enddurations are, are they the start and end boundaries between which to collect data? (why are they called duration?) and endduration empty means "now", right?
2) I'm also not sure if i'm somehow supposed to enforce a certain datapoint interval, or is whatever graphite returns ok? (depending on series and timeframe the returned data might be secondly, 10-secondly, minutely, hourly, etc, based on how the user configured graphite).  should this be passed on as an argument via `graphite()`? (i hope not)

next step: actually having this query graphite, figuring out in which shape i should feed the timeseries data from graphite into bosun (3) any insights on this anyone?), and 4) figuring out whether or not it's a problem that there's no tags, ever, when using graphite (empty map of tags).
something that graphite does is if you query for "foo.bar.*" and it returns a series "foo.bar.web1", "foo.bar.web2", "foo.bar.web3" i could probably somehow automatically compute tags node3=web1, node3=web2, node3=web3, but i'm not sure if this is needed, and it might be much effort if i need to add "tag awareness" in several places i didn't expect.

also 5) i hope it won't be a problem that i'm not using scollector and not feeding any data into scollector? i just want bosun to query graphite and use the data it returns