### PR TITLE
Update to use openjdk-7

### DIFF
--- a/cmd/bosun/docker/run/Dockerfile
+++ b/cmd/bosun/docker/run/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:wheezy
 RUN apt-get update && apt-get install -y \
 	gnuplot \
 	make \
-	openjdk-6-jre-headless \
+	openjdk-7-jre-headless \
 	supervisor \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
@@ -13,7 +13,7 @@ RUN mkdir -p /tsdb /hbase /bosun /scollector /data
 ENV TSDB /tsdb
 ENV HBASE /hbase/hbase
 ENV HBASE_HOME $HBASE
-ENV JAVA_HOME /usr/lib/jvm/java-6-openjdk-amd64
+ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
 
 COPY bosun.conf /data/
 COPY hbase-site.xml $HBASE/conf/


### PR DESCRIPTION
Doesn't look like there's any reason to stay on openjdk-6?
http://opentsdb.net/docs/build/html/installation.html#runtime-requirements
https://github.com/dockerfile/java/blob/master/openjdk-7-jdk/Dockerfile