### PR TITLE
support for querying graphite using its native sampling

### DIFF
--- a/cmd/bosun/expr/funcs.go
+++ b/cmd/bosun/expr/funcs.go
@@ -66,6 +66,12 @@ var Graphite = map[string]parse.Func{
 		graphiteTagQuery,
 		GraphiteQuery,
 	},
+	"graphiteSampled": {
+		[]parse.FuncType{parse.TypeString, parse.TypeString, parse.TypeString, parse.TypeString, parse.TypeScalar},
+		parse.TypeSeries,
+		graphiteTagQuery,
+		GraphiteQuerySampled,
+	},
 }
 
 // TSDB defines functions for use with an OpenTSDB backend.
@@ -351,14 +357,18 @@ func Band(e *State, T miniprofiler.Timer, query, duration, period string, num fl
 }
 
 func GraphiteQuery(e *State, T miniprofiler.Timer, query string, sduration, eduration, format string) (r *Results, err error) {
+	return GraphiteQuerySampled(e, T, query, sduration, eduration, format, -1)
+}
+func GraphiteQuerySampled(e *State, T miniprofiler.Timer, query string, sduration, eduration, format string, maxPoints float64) (r *Results, err error) {
 	sd, err := opentsdb.ParseDuration(sduration)
 	if err != nil {
 		return
 	}
 	st := e.now.Add(-time.Duration(sd))
 	req := &graphite.Request{
-		Targets: []string{query},
-		Start:   &st,
+		Targets:   []string{query},
+		Start:     &st,
+		MaxPoints: int(maxPoints),
 	}
 	if eduration != "" {
 		var ed opentsdb.Duration

--- a/graphite/graphite.go
+++ b/graphite/graphite.go
@@ -12,9 +12,10 @@ import (
 
 // Request holds query objects. Currently only absolute times are supported.
 type Request struct {
-	Start   *time.Time
-	End     *time.Time
-	Targets []string
+	Start     *time.Time
+	End       *time.Time
+	Targets   []string
+	MaxPoints int
 }
 
 type Response []Series
@@ -30,6 +31,9 @@ func (r *Request) Query(host string) (Response, error) {
 	v := url.Values{
 		"format": []string{"json"},
 		"target": r.Targets,
+	}
+	if r.MaxPoints > 0 {
+		v.Set("maxDataPoints", fmt.Sprintf("%d", r.MaxPoints))
 	}
 	if r.Start != nil {
 		v.Add("from", fmt.Sprint(r.Start.Unix()))


### PR DESCRIPTION
note: i don't actually use this. not sure yet if there will be a need for this once #638 is fixed