### PR TITLE
cmd/bosun: Show description metadata on graph page

### DIFF
--- a/cmd/bosun/sched/sched.go
+++ b/cmd/bosun/sched/sched.go
@@ -75,13 +75,13 @@ type MetadataDescription struct {
 	Text string
 }
 
-func (s *Schedule) MetadataMetrics() map[string]*MetadataMetric {
+func (s *Schedule) MetadataMetrics(metric string) map[string]*MetadataMetric {
 	s.metalock.Lock()
 	m := make(map[string]*MetadataMetric)
 	for k, mv := range s.Metadata {
 		tags := k.TagSet()
 		delete(tags, "host")
-		if k.Metric == "" {
+		if k.Metric == "" || (metric != "" && k.Metric != metric) {
 			continue
 		}
 		val, _ := mv.Value.(string)

--- a/cmd/bosun/web/static/js/bosun.js
+++ b/cmd/bosun/web/static/js/bosun.js
@@ -1378,16 +1378,27 @@ bosunControllers.controller('GraphCtrl', ['$scope', '$http', '$location', '$rout
         return;
     }
     var autods = $scope.autods ? '&autods=' + $('#chart').width() : '';
+    function getMetricMeta(metric) {
+        $http.get('/api/metadata/metrics?metric=' + encodeURIComponent(metric)).success(function (data) {
+            if (Object.keys(data).length == 1) {
+                $scope.meta[metric] = data[metric];
+            }
+        }).error(function (error) {
+            console.log("Error getting metadata for metric " + metric);
+        });
+    }
     function get(noRunning) {
         $timeout.cancel(graphRefresh);
         if (!noRunning) {
             $scope.running = 'Running';
         }
         var autorate = '';
+        $scope.meta = {};
         for (var i = 0; i < request.queries.length; i++) {
             if (request.queries[i].derivative == 'auto') {
                 autorate += '&autorate=' + i;
             }
+            getMetricMeta(request.queries[i].metric);
         }
         var min = angular.isNumber($scope.min) ? '&min=' + encodeURIComponent($scope.min.toString()) : '';
         var max = angular.isNumber($scope.max) ? '&max=' + encodeURIComponent($scope.max.toString()) : '';

--- a/cmd/bosun/web/static/js/graph.ts
+++ b/cmd/bosun/web/static/js/graph.ts
@@ -145,6 +145,7 @@ interface IGraphScope extends ng.IScope {
 	animate: () => any;
 	stop: () => any;
 	canAuto: {};
+	meta: {};
 	y_labels: string[];
 	min: number;
 	max: number;
@@ -344,16 +345,29 @@ bosunControllers.controller('GraphCtrl', ['$scope', '$http', '$location', '$rout
 		return;
 	}
 	var autods = $scope.autods ? '&autods=' + $('#chart').width() : '';
+	function getMetricMeta(metric: string) {
+		$http.get('/api/metadata/metrics?metric=' + encodeURIComponent(metric))
+			.success((data) => {
+				if (Object.keys(data).length == 1) {
+					$scope.meta[metric] = data[metric];
+				}
+			})
+			.error((error) => {
+				console.log("Error getting metadata for metric " + metric)
+			})
+	}
 	function get(noRunning: boolean) {
 		$timeout.cancel(graphRefresh);
 		if (!noRunning) {
 			$scope.running = 'Running';
 		}
 		var autorate = '';
+		$scope.meta = {};
 		for(var i = 0; i < request.queries.length; i++) {
 			if (request.queries[i].derivative == 'auto') {
 				autorate += '&autorate=' + i;
 			}
+			getMetricMeta(request.queries[i].metric);
 		}
 		var min = angular.isNumber($scope.min) ? '&min=' + encodeURIComponent($scope.min.toString()) : '';
 		var max = angular.isNumber($scope.max) ? '&max=' + encodeURIComponent($scope.max.toString()) : '';

--- a/cmd/bosun/web/static/partials/graph.html
+++ b/cmd/bosun/web/static/partials/graph.html
@@ -160,3 +160,14 @@
 		</table>
 	</div>
 </div>
+<div class="row">
+	<div class="col-lg-12">
+		<h4>Metric Descriptions</h4>
+		<div ng-repeat="(k, v) in meta">
+			<h5>{{k}}</h5>
+			<ul ng-repeat="d in v.Description">
+				<li><span ng-show="d.Tags">{{d.Tags}}: </span>{{d.Text}}</li>
+			</ul>
+		</div>
+	</div>
+</div>

--- a/cmd/bosun/web/web.go
+++ b/cmd/bosun/web/web.go
@@ -266,7 +266,8 @@ func GetMetadata(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (
 }
 
 func MetadataMetrics(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (interface{}, error) {
-	return schedule.MetadataMetrics(), nil
+	metric := r.FormValue("metric")
+	return schedule.MetadataMetrics(metric), nil
 }
 
 func Alerts(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (interface{}, error) {


### PR DESCRIPTION
Adds support to the MetadataMetrics API for specifying the metric