### PR TITLE
clean up extraneous whitespace in email subjects

### DIFF
--- a/cmd/bosun/conf/notify.go
+++ b/cmd/bosun/conf/notify.go
@@ -78,7 +78,10 @@ func (n *Notification) DoEmail(subject, body []byte, c *Conf, ak string, attachm
 	for _, a := range n.Email {
 		e.To = append(e.To, a.Address)
 	}
-	e.Subject = string(subject)
+
+	// remove various extraneous whitespace that can get accidentally introduced by templates.
+	e.Subject = strings.Join(strings.Fields(string(subject)), " ")
+
 	e.HTML = body
 	for _, a := range attachments {
 		e.Attach(bytes.NewBuffer(a.Data), a.Filename, a.ContentType)


### PR DESCRIPTION
otherwise the subjects can be unreadable due to
whitespace introduced in templates