### PR TITLE
function to get the longest streak of a given value, e.g. 0

### DIFF
--- a/cmd/bosun/expr/expr.go
+++ b/cmd/bosun/expr/expr.go
@@ -139,6 +139,7 @@ func (s Scalar) Type() parse.FuncType { return parse.TypeScalar }
 func (s Scalar) Value() interface{}   { return s }
 func (s Scalar) MarshalJSON() ([]byte, error) { return marshalFloat(float64(s)) }
 
+// Series is the standard form within bosun to represent timeseries data.
 type Series map[time.Time]float64
 
 func (s Series) Type() parse.FuncType { return parse.TypeSeries }
@@ -150,6 +151,29 @@ func (s Series) MarshalJSON() ([]byte, error) {
 		r[fmt.Sprint(k.Unix())] = Scalar(v)
 	}
 	return json.Marshal(r)
+}
+
+type SortablePoint struct {
+	T time.Time
+	V float64
+}
+
+// SortableSeries is an alternative datastructure for timeseries data,
+// which stores points in a time-ordered fashion instead of a map.
+// see discussion at https://github.com/bosun-monitor/bosun/pull/699
+type SortableSeries []SortablePoint
+
+func (s SortableSeries) Len() int           { return len(s) }
+func (s SortableSeries) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s SortableSeries) Less(i, j int) bool { return s[i].T.Before(s[j].T) }
+
+func NewSortedSeries(dps Series) SortableSeries {
+	series := make(SortableSeries, 0, len(dps))
+	for t, v := range dps {
+		series = append(series, SortablePoint{t, v})
+	}
+	sort.Sort(series)
+	return series
 }
 
 type Result struct {

--- a/cmd/bosun/expr/funcs.go
+++ b/cmd/bosun/expr/funcs.go
@@ -226,6 +226,12 @@ var builtins = map[string]parse.Func{
 		tagFirst,
 		Sum,
 	},
+	"streak": {
+		[]parse.FuncType{parse.TypeSeries},
+		parse.TypeNumber,
+		tagFirst,
+		Streak,
+	},
 
 	// Group functions
 	"rename": {
@@ -776,6 +782,34 @@ func sum(dps Series, args ...float64) (a float64) {
 		a += float64(v)
 	}
 	return
+}
+
+func Streak(e *State, T miniprofiler.Timer, series *Results) (*Results, error) {
+	return reduce(e, T, series, streak)
+}
+
+func streak(dps Series, args ...float64) (a float64) {
+	max := func(a, b int) int {
+		if a > b {
+			return a
+		}
+		return b
+	}
+
+	series := NewSortedSeries(dps)
+
+	current := 0
+	longest := 0
+	for _, p := range series {
+		if p.V != 0 {
+			current++
+		} else {
+			longest = max(current, longest)
+			current = 0
+		}
+	}
+	longest = max(current, longest)
+	return float64(longest)
 }
 
 func Dev(e *State, T miniprofiler.Timer, series *Results) (*Results, error) {


### PR DESCRIPTION
@mjibson @kylebrandt we might want to revisit storing series as map[time.Time]float64.
databases like graphite and influxdb return their data time ordered, and i presume opentsdb and ES do the same.  but we lose the ordering, and in some places (like first and last function) and now also here, it's clunky to have to make up for it.  an array of struct{time.Time, float64} seems like a more suitable datastructure for Series.

do we do exact-key lookups anywhere ? (give me the value at given timestamp), that's something we'd have to implement again (with binary search or so) if we were to move away from maps.