### PR TITLE
cmd/bosun: Limit unknown emails sent in a single check

### DIFF
--- a/cmd/bosun/expr/expr.go
+++ b/cmd/bosun/expr/expr.go
@@ -129,14 +129,14 @@ func marshalFloat(n float64) ([]byte, error) {
 
 type Number float64
 
-func (n Number) Type() parse.FuncType { return parse.TypeNumber }
-func (n Number) Value() interface{}   { return n }
+func (n Number) Type() parse.FuncType         { return parse.TypeNumber }
+func (n Number) Value() interface{}           { return n }
 func (n Number) MarshalJSON() ([]byte, error) { return marshalFloat(float64(n)) }
 
 type Scalar float64
 
-func (s Scalar) Type() parse.FuncType { return parse.TypeScalar }
-func (s Scalar) Value() interface{}   { return s }
+func (s Scalar) Type() parse.FuncType         { return parse.TypeScalar }
+func (s Scalar) Value() interface{}           { return s }
 func (s Scalar) MarshalJSON() ([]byte, error) { return marshalFloat(float64(s)) }
 
 type Series map[time.Time]float64

--- a/cmd/bosun/sched/notify.go
+++ b/cmd/bosun/sched/notify.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"text/template"
 	"time"
 
 	"bosun.org/cmd/bosun/conf"
@@ -102,11 +103,46 @@ func (s *Schedule) sendNotifications(rh *RunHistory, silenced map[expr.AlertKey]
 				s.AddNotification(ak, n, time.Now().UTC())
 			}
 		}
-		for name, group := range ustates.GroupSets() {
-			s.unotify(name, group, n)
+		var c int
+		tHit := false
+		oTSets := make(map[string]expr.AlertKeys)
+		groupSets := ustates.GroupSets()
+		for name, group := range groupSets {
+			c++
+			if c >= s.Conf.UnknownThreshold && s.Conf.UnknownThreshold > 0 {
+				if !tHit && len(groupSets) == 0 {
+					// If the threshold is hit but only 1 email remains, just send the normal unknown
+					s.unotify(name, group, n)
+					break
+				}
+				tHit = true
+				oTSets[name] = group
+			} else {
+				s.unotify(name, group, n)
+			}
+		}
+		if len(oTSets) > 0 {
+			s.utnotify(oTSets, n)
 		}
 	}
 }
+
+var unknownMultiGroup = template.Must(template.New("unknownMultiGroup").Parse(`
+	<p>Threshold of {{ .Threshold }} reached for unknown notifications. The following unknown
+	group emails were not sent.
+	<ul>
+	{{ range $group, $alertKeys := .Groups }}
+		<li>
+			{{ $group }}
+			<ul>
+				{{ range $ak := $alertKeys }}
+				<li>{{ $ak }}</li>
+				{{ end }}
+			<ul>
+		</li>
+	{{ end }}
+	</ul>
+	`))
 
 func (s *Schedule) notify(rh *RunHistory, st *State, n *conf.Notification) {
 	rh = rh.AtTime(st.AbnormalEvent().Time)
@@ -129,6 +165,29 @@ func (s *Schedule) notify(rh *RunHistory, st *State, n *conf.Notification) {
 		}
 	}
 	n.Notify(subject.Bytes(), body.Bytes(), s.Conf, string(st.AlertKey()), attachments...)
+}
+
+// utnotify is single notification for N unknown groups into a single notification
+func (s *Schedule) utnotify(groups map[string]expr.AlertKeys, n *conf.Notification) {
+	var total int
+	now := time.Now().UTC()
+	for _, group := range groups {
+		// Don't know what the following line does, just copied from unotify
+		s.Group[now] = group
+		total += len(group)
+	}
+	subject := fmt.Sprintf("%v unknown alert instances suppressed", total)
+	body := new(bytes.Buffer)
+	if err := unknownMultiGroup.Execute(body, struct {
+		Groups    map[string]expr.AlertKeys
+		Threshold int
+	}{
+		groups,
+		s.Conf.UnknownThreshold,
+	}); err != nil {
+		log.Println(err)
+	}
+	n.Notify([]byte(subject), body.Bytes(), s.Conf, "unknown_treshold")
 }
 
 func (s *Schedule) unotify(name string, group expr.AlertKeys, n *conf.Notification) {


### PR DESCRIPTION
This helps limit unknown spam when something goes bad. If there are more than Threshold email groups in a single check run, it will roll the remaining unknown emails into a single email that lists all the groups and their alert instances.

![image](https://cloud.githubusercontent.com/assets/1692624/6097369/de19f8f4-af89-11e4-87c7-3849d9080185.png)

![image](https://cloud.githubusercontent.com/assets/1692624/6097370/e33b4220-af89-11e4-95b8-109f171321b2.png)
