### PR TITLE
align check start/done messages

### DIFF
--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -196,7 +196,7 @@ func (s *Schedule) CheckUnknown() {
 }
 
 func (s *Schedule) CheckAlert(T miniprofiler.Timer, r *RunHistory, a *conf.Alert) {
-	log.Printf("checking alert %v", a.Name)
+	log.Printf("check alert %v start", a.Name)
 	start := time.Now()
 	var warns expr.AlertKeys
 	crits, err := s.CheckExpr(T, r, a, a.Crit, StCritical, nil)
@@ -204,7 +204,7 @@ func (s *Schedule) CheckAlert(T miniprofiler.Timer, r *RunHistory, a *conf.Alert
 		warns, _ = s.CheckExpr(T, r, a, a.Warn, StWarning, crits)
 	}
 	collect.Put("check.duration", opentsdb.TagSet{"name": a.Name}, time.Since(start).Seconds())
-	log.Printf("done checking alert %v (%s): %v crits, %v warns", a.Name, time.Since(start), len(crits), len(warns))
+	log.Printf("check alert %v done (%s): %v crits, %v warns", a.Name, time.Since(start), len(crits), len(warns))
 }
 
 func (s *Schedule) CheckExpr(T miniprofiler.Timer, rh *RunHistory, a *conf.Alert, e *expr.Expr, checkStatus Status, ignore expr.AlertKeys) (alerts expr.AlertKeys, err error) {


### PR DESCRIPTION
clearer to see them against each other, and other messages.
it's easier on the eyes.
and also on the brain for people with OCD like myself.

before:
2015/02/10 17:30:51 done checking alert os.cpu.idle.web (5.452389916s): 0 crits, 0 warns
2015/02/10 17:30:51 checking alert s3_buffer
2015/02/10 17:30:52 done checking alert s3_buffer (967.57502ms): 0 crits, 0 warns
2015/02/10 17:30:52 checking alert bi
2015/02/10 17:31:00 checkUnknown
2015/02/10 17:31:05 done checking alert bi (12.668303453s): 0 crits, 0 warns
2015/02/10 17:31:05 checking alert requests_by_country

after

2015/02/10 17:32:04 check alert requests_by_country done (26.833528339s): 0 crits, 0 warns
2015/02/10 17:32:04 check alert os.cpu.idle.web start
2015/02/10 17:32:09 check alert os.cpu.idle.web done (5.092954017s): 0 crits, 0 warns
2015/02/10 17:32:09 check alert s3_buffer start
2015/02/10 17:32:10 check alert s3_buffer done (1.088852618s): 0 crits, 0 warns
2015/02/10 17:32:10 check took 44.672477519s
2015/02/10 17:32:10 checkUnknown