### PR TITLE
cmd/bosun: Change sleep to only sleep the unknown checks

### DIFF
--- a/cmd/bosun/main.go
+++ b/cmd/bosun/main.go
@@ -40,7 +40,6 @@ var (
 	flagWatch    = flag.Bool("w", false, "watch .go files below current directory and exit; also build typescript files on change")
 	flagReadonly = flag.Bool("r", false, "readonly-mode: don't write or relay any OpenTSDB metrics")
 	flagQuiet    = flag.Bool("q", false, "quiet-mode: don't send any notifications except from the rule test page")
-	flagNoSleep  = flag.Bool("no-sleep", false, "don't sleep the length of check frequency before running the first run of checks after startup")
 	flagDev      = flag.Bool("dev", false, "enable dev mode: use local resources")
 	flagVersion  = flag.Bool("version", false, "Prints the version and exits")
 )
@@ -107,9 +106,6 @@ func main() {
 	}
 	go func() { log.Fatal(web.Listen(c.HTTPListen, *flagDev, c.TSDBHost)) }()
 	go func() {
-		if !*flagNoSleep && !c.NoSleep {
-			time.Sleep(c.CheckFrequency)
-		}
 		log.Fatal(sched.Run())
 	}()
 	sc := make(chan os.Signal, 1)

--- a/cmd/bosun/sched/sched.go
+++ b/cmd/bosun/sched/sched.go
@@ -589,7 +589,13 @@ func (s *Schedule) Run() error {
 		go s.PingHosts()
 	}
 	go s.Poll()
-	go s.CheckUnknown()
+	go func() {
+		// Sleep before starting unknown checks. If Bosun was down for a little
+		// while then all the state.Touched times will be old and a bunch of
+		// unknowns will go off because it hasn't run all the checks yet.
+		time.Sleep(s.Conf.CheckFrequency)
+		go s.CheckUnknown()
+	}()
 	for {
 		wait := time.After(s.Conf.CheckFrequency)
 		if s.Conf == nil {


### PR DESCRIPTION
Also remove the -no-sleep option since I can't think of a reason I would want to change this now that the normal check still runs right away.