### PR TITLE
leverage LRU caching for scheduled checks and expr/rule tests

### DIFF
--- a/_third_party/github.com/golang/groupcache/lru/lru.go
+++ b/_third_party/github.com/golang/groupcache/lru/lru.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2013 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package lru implements an LRU cache.
+package lru
+
+import "container/list"
+
+// Cache is an LRU cache. It is not safe for concurrent access.
+type Cache struct {
+	// MaxEntries is the maximum number of cache entries before
+	// an item is evicted. Zero means no limit.
+	MaxEntries int
+
+	// OnEvicted optionally specificies a callback function to be
+	// executed when an entry is purged from the cache.
+	OnEvicted func(key Key, value interface{})
+
+	ll    *list.List
+	cache map[interface{}]*list.Element
+}
+
+// A Key may be any value that is comparable. See http://golang.org/ref/spec#Comparison_operators
+type Key interface{}
+
+type entry struct {
+	key   Key
+	value interface{}
+}
+
+// New creates a new Cache.
+// If maxEntries is zero, the cache has no limit and it's assumed
+// that eviction is done by the caller.
+func New(maxEntries int) *Cache {
+	return &Cache{
+		MaxEntries: maxEntries,
+		ll:         list.New(),
+		cache:      make(map[interface{}]*list.Element),
+	}
+}
+
+// Add adds a value to the cache.
+func (c *Cache) Add(key Key, value interface{}) {
+	if c.cache == nil {
+		c.cache = make(map[interface{}]*list.Element)
+		c.ll = list.New()
+	}
+	if ee, ok := c.cache[key]; ok {
+		c.ll.MoveToFront(ee)
+		ee.Value.(*entry).value = value
+		return
+	}
+	ele := c.ll.PushFront(&entry{key, value})
+	c.cache[key] = ele
+	if c.MaxEntries != 0 && c.ll.Len() > c.MaxEntries {
+		c.RemoveOldest()
+	}
+}
+
+// Get looks up a key's value from the cache.
+func (c *Cache) Get(key Key) (value interface{}, ok bool) {
+	if c.cache == nil {
+		return
+	}
+	if ele, hit := c.cache[key]; hit {
+		c.ll.MoveToFront(ele)
+		return ele.Value.(*entry).value, true
+	}
+	return
+}
+
+// Remove removes the provided key from the cache.
+func (c *Cache) Remove(key Key) {
+	if c.cache == nil {
+		return
+	}
+	if ele, hit := c.cache[key]; hit {
+		c.removeElement(ele)
+	}
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *Cache) RemoveOldest() {
+	if c.cache == nil {
+		return
+	}
+	ele := c.ll.Back()
+	if ele != nil {
+		c.removeElement(ele)
+	}
+}
+
+func (c *Cache) removeElement(e *list.Element) {
+	c.ll.Remove(e)
+	kv := e.Value.(*entry)
+	delete(c.cache, kv.key)
+	if c.OnEvicted != nil {
+		c.OnEvicted(kv.key, kv.value)
+	}
+}
+
+// Len returns the number of items in the cache.
+func (c *Cache) Len() int {
+	if c.cache == nil {
+		return 0
+	}
+	return c.ll.Len()
+}

--- a/_third_party/github.com/golang/groupcache/lru/lru_test.go
+++ b/_third_party/github.com/golang/groupcache/lru/lru_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2013 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lru
+
+import (
+	"testing"
+)
+
+type simpleStruct struct {
+	int
+	string
+}
+
+type complexStruct struct {
+	int
+	simpleStruct
+}
+
+var getTests = []struct {
+	name       string
+	keyToAdd   interface{}
+	keyToGet   interface{}
+	expectedOk bool
+}{
+	{"string_hit", "myKey", "myKey", true},
+	{"string_miss", "myKey", "nonsense", false},
+	{"simple_struct_hit", simpleStruct{1, "two"}, simpleStruct{1, "two"}, true},
+	{"simeple_struct_miss", simpleStruct{1, "two"}, simpleStruct{0, "noway"}, false},
+	{"complex_struct_hit", complexStruct{1, simpleStruct{2, "three"}},
+		complexStruct{1, simpleStruct{2, "three"}}, true},
+}
+
+func TestGet(t *testing.T) {
+	for _, tt := range getTests {
+		lru := New(0)
+		lru.Add(tt.keyToAdd, 1234)
+		val, ok := lru.Get(tt.keyToGet)
+		if ok != tt.expectedOk {
+			t.Fatalf("%s: cache hit = %v; want %v", tt.name, ok, !ok)
+		} else if ok && val != 1234 {
+			t.Fatalf("%s expected get to return 1234 but got %v", tt.name, val)
+		}
+	}
+}
+
+func TestRemove(t *testing.T) {
+	lru := New(0)
+	lru.Add("myKey", 1234)
+	if val, ok := lru.Get("myKey"); !ok {
+		t.Fatal("TestRemove returned no match")
+	} else if val != 1234 {
+		t.Fatalf("TestRemove failed.  Expected %d, got %v", 1234, val)
+	}
+
+	lru.Remove("myKey")
+	if _, ok := lru.Get("myKey"); ok {
+		t.Fatal("TestRemove returned a removed entry")
+	}
+}

--- a/_third_party/github.com/golang/groupcache/singleflight/singleflight.go
+++ b/_third_party/github.com/golang/groupcache/singleflight/singleflight.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2012 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package singleflight provides a duplicate function call suppression
+// mechanism.
+package singleflight
+
+import "sync"
+
+// call is an in-flight or completed Do call
+type call struct {
+	wg  sync.WaitGroup
+	val interface{}
+	err error
+}
+
+// Group represents a class of work and forms a namespace in which
+// units of work can be executed with duplicate suppression.
+type Group struct {
+	mu sync.Mutex       // protects m
+	m  map[string]*call // lazily initialized
+}
+
+// Do executes and returns the results of the given function, making
+// sure that only one execution is in-flight for a given key at a
+// time. If a duplicate comes in, the duplicate caller waits for the
+// original to complete and receives the same results.
+func (g *Group) Do(key string, fn func() (interface{}, error)) (interface{}, error) {
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
+	if c, ok := g.m[key]; ok {
+		g.mu.Unlock()
+		c.wg.Wait()
+		return c.val, c.err
+	}
+	c := new(call)
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	c.val, c.err = fn()
+	c.wg.Done()
+
+	g.mu.Lock()
+	delete(g.m, key)
+	g.mu.Unlock()
+
+	return c.val, c.err
+}

--- a/_third_party/github.com/golang/groupcache/singleflight/singleflight_test.go
+++ b/_third_party/github.com/golang/groupcache/singleflight/singleflight_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2012 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package singleflight
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestDo(t *testing.T) {
+	var g Group
+	v, err := g.Do("key", func() (interface{}, error) {
+		return "bar", nil
+	})
+	if got, want := fmt.Sprintf("%v (%T)", v, v), "bar (string)"; got != want {
+		t.Errorf("Do = %v; want %v", got, want)
+	}
+	if err != nil {
+		t.Errorf("Do error = %v", err)
+	}
+}
+
+func TestDoErr(t *testing.T) {
+	var g Group
+	someErr := errors.New("Some error")
+	v, err := g.Do("key", func() (interface{}, error) {
+		return nil, someErr
+	})
+	if err != someErr {
+		t.Errorf("Do error = %v; want someErr", err, someErr)
+	}
+	if v != nil {
+		t.Errorf("unexpected non-nil value %#v", v)
+	}
+}
+
+func TestDoDupSuppress(t *testing.T) {
+	var g Group
+	c := make(chan string)
+	var calls int32
+	fn := func() (interface{}, error) {
+		atomic.AddInt32(&calls, 1)
+		return <-c, nil
+	}
+
+	const n = 10
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			v, err := g.Do("key", fn)
+			if err != nil {
+				t.Errorf("Do error: %v", err)
+			}
+			if v.(string) != "bar" {
+				t.Errorf("got %q; want %q", v, "bar")
+			}
+			wg.Done()
+		}()
+	}
+	time.Sleep(100 * time.Millisecond) // let goroutines above block
+	c <- "bar"
+	wg.Wait()
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("number of calls = %d; want 1", got)
+	}
+}

--- a/cmd/bosun/cache/cache.go
+++ b/cmd/bosun/cache/cache.go
@@ -1,0 +1,46 @@
+package cache // import "bosun.org/cmd/bosun/cache"
+
+import (
+	"sync"
+
+	"bosun.org/_third_party/github.com/golang/groupcache/lru"
+	"bosun.org/_third_party/github.com/golang/groupcache/singleflight"
+)
+
+type Cache struct {
+	g singleflight.Group
+
+	sync.Mutex
+	lru *lru.Cache
+}
+
+// obj is an LRU object tracking data and a corresponding error.
+type obj struct {
+	Val interface{}
+	Err error
+}
+
+func New(MaxEntries int) *Cache {
+	return &Cache{
+		lru: lru.New(MaxEntries),
+	}
+}
+
+func (c *Cache) Get(key string, getFn func() (interface{}, error)) (interface{}, error) {
+	c.Lock()
+	result, ok := c.lru.Get(key)
+	c.Unlock()
+	if ok {
+		res := result.(*obj)
+		return res.Val, res.Err
+	}
+	// our lock only serves to protect the lru.
+	// we can (and should!) do singleflight requests concurently
+	return c.g.Do(key, func() (interface{}, error) {
+		v, err := getFn()
+		c.Lock()
+		c.lru.Add(key, &obj{v, err})
+		c.Unlock()
+		return v, err
+	})
+}

--- a/cmd/bosun/conf/conf.go
+++ b/cmd/bosun/conf/conf.go
@@ -85,13 +85,13 @@ func (authorizedIPs AuthorizedIPs) Authorized(ip net.IP) (authorized bool) {
 	return
 }
 
-// TSDBCacheContext returns an OpenTSDB context with caching and limited to
+// TSDBContext returns an OpenTSDB context limited to
 // c.ResponseLimit. A nil context is returned if TSDBHost is not set.
-func (c *Conf) TSDBCacheContext() opentsdb.Context {
+func (c *Conf) TSDBContext() opentsdb.Context {
 	if c.TSDBHost == "" {
 		return nil
 	}
-	return opentsdb.NewCache(c.TSDBHost, c.ResponseLimit)
+	return opentsdb.NewLimitContext(c.TSDBHost, c.ResponseLimit)
 }
 
 // GraphiteContext returns a Graphite context. A nil context is returned if

--- a/cmd/bosun/expr/expr.go
+++ b/cmd/bosun/expr/expr.go
@@ -12,6 +12,7 @@ import (
 	"bosun.org/_third_party/github.com/olivere/elastic"
 
 	"bosun.org/_third_party/github.com/MiniProfiler/go/miniprofiler"
+	"bosun.org/cmd/bosun/cache"
 	"bosun.org/cmd/bosun/expr/parse"
 	"bosun.org/cmd/bosun/search"
 	"bosun.org/graphite"
@@ -20,7 +21,8 @@ import (
 
 type State struct {
 	*Expr
-	now time.Time
+	now   time.Time
+	cache *cache.Cache
 
 	// OpenTSDB
 	Search      *search.Search
@@ -63,7 +65,7 @@ func New(expr string, funcs ...map[string]parse.Func) (*Expr, error) {
 
 // Execute applies a parse expression to the specified OpenTSDB context, and
 // returns one result per group. T may be nil to ignore timings.
-func (e *Expr) Execute(c opentsdb.Context, g graphite.Context, logstashElasticHost string, T miniprofiler.Timer, now time.Time, autods int, unjoinedOk bool, search *search.Search, squelched func(tags opentsdb.TagSet) bool) (r *Results, queries []opentsdb.Request, err error) {
+func (e *Expr) Execute(c opentsdb.Context, g graphite.Context, logstashElasticHost string, cache *cache.Cache, T miniprofiler.Timer, now time.Time, autods int, unjoinedOk bool, search *search.Search, squelched func(tags opentsdb.TagSet) bool) (r *Results, queries []opentsdb.Request, err error) {
 	if squelched == nil {
 		squelched = func(tags opentsdb.TagSet) bool {
 			return false
@@ -71,6 +73,7 @@ func (e *Expr) Execute(c opentsdb.Context, g graphite.Context, logstashElasticHo
 	}
 	s := &State{
 		Expr:                e,
+		cache:               cache,
 		tsdbContext:         c,
 		graphiteContext:     g,
 		logstashElasticHost: logstashElasticHost,

--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -194,7 +194,7 @@ func (s *Schedule) RunHistory(r *RunHistory) {
 func (s *Schedule) CheckUnknown() {
 	for range time.Tick(s.Conf.CheckFrequency / 4) {
 		log.Println("checkUnknown")
-		r := s.NewRunHistory(time.Now(), cache.New(100))
+		r := s.NewRunHistory(time.Now(), nil)
 		s.Lock()
 		for ak, st := range s.status {
 			if st.Forgotten {

--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"bosun.org/_third_party/github.com/MiniProfiler/go/miniprofiler"
+	"bosun.org/cmd/bosun/cache"
 	"bosun.org/cmd/bosun/conf"
 	"bosun.org/cmd/bosun/expr"
 	"bosun.org/collect"
@@ -35,6 +36,7 @@ func (s *Schedule) Status(ak expr.AlertKey) *State {
 }
 
 type RunHistory struct {
+	Cache           *cache.Cache
 	Start           time.Time
 	Context         opentsdb.Context
 	GraphiteContext graphite.Context
@@ -49,11 +51,12 @@ func (rh *RunHistory) AtTime(t time.Time) *RunHistory {
 	return &n
 }
 
-func (s *Schedule) NewRunHistory(start time.Time) *RunHistory {
+func (s *Schedule) NewRunHistory(start time.Time, cache *cache.Cache) *RunHistory {
 	return &RunHistory{
+		Cache:           cache,
 		Start:           start,
 		Events:          make(map[expr.AlertKey]*Event),
-		Context:         s.Conf.TSDBCacheContext(),
+		Context:         s.Conf.TSDBContext(),
 		GraphiteContext: s.Conf.GraphiteContext(),
 	}
 }
@@ -67,7 +70,7 @@ func (s *Schedule) Check(T miniprofiler.Timer, now time.Time) (time.Duration, er
 	default:
 		return 0, fmt.Errorf("check already running")
 	}
-	r := s.NewRunHistory(now)
+	r := s.NewRunHistory(now, cache.New(0))
 	start := time.Now()
 	for _, a := range s.Conf.Alerts {
 		s.CheckAlert(T, r, a)
@@ -191,7 +194,7 @@ func (s *Schedule) RunHistory(r *RunHistory) {
 func (s *Schedule) CheckUnknown() {
 	for range time.Tick(s.Conf.CheckFrequency / 4) {
 		log.Println("checkUnknown")
-		r := s.NewRunHistory(time.Now())
+		r := s.NewRunHistory(time.Now(), cache.New(100))
 		s.Lock()
 		for ak, st := range s.status {
 			if st.Forgotten {
@@ -238,7 +241,7 @@ func (s *Schedule) CheckExpr(T miniprofiler.Timer, rh *RunHistory, a *conf.Alert
 		collect.Add("check.errs", opentsdb.TagSet{"metric": a.Name}, 1)
 		log.Println(err)
 	}()
-	results, _, err := e.Execute(rh.Context, rh.GraphiteContext, s.Conf.LogstashElasticHost, T, rh.Start, 0, a.UnjoinedOK, s.Search, s.Conf.AlertSquelched(a))
+	results, _, err := e.Execute(rh.Context, rh.GraphiteContext, s.Conf.LogstashElasticHost, rh.Cache, T, rh.Start, 0, a.UnjoinedOK, s.Search, s.Conf.AlertSquelched(a))
 	if err != nil {
 		ak := expr.NewAlertKey(a.Name, nil)
 		state := s.Status(ak)

--- a/cmd/bosun/sched/notify.go
+++ b/cmd/bosun/sched/notify.go
@@ -7,7 +7,6 @@ import (
 	"text/template"
 	"time"
 
-	"bosun.org/cmd/bosun/cache"
 	"bosun.org/cmd/bosun/conf"
 	"bosun.org/cmd/bosun/expr"
 )
@@ -15,8 +14,7 @@ import (
 // Poll dispatches notification checks when needed.
 func (s *Schedule) Poll() {
 	for {
-		rh := s.NewRunHistory(time.Now(), cache.New(100))
-		timeout := s.CheckNotifications(rh)
+		timeout := s.CheckNotifications()
 		s.Save()
 		// Wait for one of these two.
 		select {
@@ -35,7 +33,7 @@ func (s *Schedule) Notify(st *State, n *conf.Notification) {
 
 // CheckNotifications processes past notification events. It returns the
 // duration until the soonest notification triggers.
-func (s *Schedule) CheckNotifications(rh *RunHistory) time.Duration {
+func (s *Schedule) CheckNotifications() time.Duration {
 	silenced := s.Silenced()
 	s.Lock()
 	defer s.Unlock()
@@ -63,7 +61,7 @@ func (s *Schedule) CheckNotifications(rh *RunHistory) time.Duration {
 			s.Notify(st, n)
 		}
 	}
-	s.sendNotifications(rh, silenced)
+	s.sendNotifications(silenced)
 	s.notifications = nil
 	timeout := time.Hour
 	now := time.Now()
@@ -82,7 +80,7 @@ func (s *Schedule) CheckNotifications(rh *RunHistory) time.Duration {
 	return timeout
 }
 
-func (s *Schedule) sendNotifications(rh *RunHistory, silenced map[expr.AlertKey]Silence) {
+func (s *Schedule) sendNotifications(silenced map[expr.AlertKey]Silence) {
 	if s.Conf.Quiet {
 		log.Println("quiet mode prevented", len(s.notifications), "notifications")
 		return
@@ -98,7 +96,7 @@ func (s *Schedule) sendNotifications(rh *RunHistory, silenced map[expr.AlertKey]
 				}
 				ustates[ak] = st
 			} else {
-				s.notify(rh, st, n)
+				s.notify(st, n)
 			}
 			if n.Next != nil {
 				s.AddNotification(ak, n.Next, time.Now().UTC())
@@ -145,7 +143,7 @@ var unknownMultiGroup = template.Must(template.New("unknownMultiGroup").Parse(`
 	</ul>
 	`))
 
-func (s *Schedule) notify(rh *RunHistory, st *State, n *conf.Notification) {
+func (s *Schedule) notify(st *State, n *conf.Notification) {
 	n.Notify([]byte(st.Subject), st.EmailBody, s.Conf, string(st.AlertKey()), st.Attachments...)
 }
 

--- a/cmd/bosun/sched/notify.go
+++ b/cmd/bosun/sched/notify.go
@@ -7,6 +7,7 @@ import (
 	"text/template"
 	"time"
 
+	"bosun.org/cmd/bosun/cache"
 	"bosun.org/cmd/bosun/conf"
 	"bosun.org/cmd/bosun/expr"
 )
@@ -14,7 +15,7 @@ import (
 // Poll dispatches notification checks when needed.
 func (s *Schedule) Poll() {
 	for {
-		rh := s.NewRunHistory(time.Now())
+		rh := s.NewRunHistory(time.Now(), cache.New(100))
 		timeout := s.CheckNotifications(rh)
 		s.Save()
 		// Wait for one of these two.

--- a/cmd/bosun/sched/template.go
+++ b/cmd/bosun/sched/template.go
@@ -202,7 +202,7 @@ func (c *Context) eval(v interface{}, filter bool, series bool, autods int) (exp
 	if series && e.Root.Return() != parse.TypeSeries {
 		return nil, "", fmt.Errorf("egraph: requires an expression that returns a series")
 	}
-	res, _, err := e.Execute(c.runHistory.Context, c.runHistory.GraphiteContext, c.schedule.Conf.LogstashElasticHost, nil, c.runHistory.Start, autods, c.Alert.UnjoinedOK, c.schedule.Search, c.schedule.Conf.AlertSquelched(c.Alert))
+	res, _, err := e.Execute(c.runHistory.Context, c.runHistory.GraphiteContext, c.schedule.Conf.LogstashElasticHost, c.runHistory.Cache, nil, c.runHistory.Start, autods, c.Alert.UnjoinedOK, c.schedule.Search, c.schedule.Conf.AlertSquelched(c.Alert))
 	if err != nil {
 		return nil, "", fmt.Errorf("%s: %v", v, err)
 	}

--- a/cmd/bosun/web/chart.go
+++ b/cmd/bosun/web/chart.go
@@ -200,7 +200,11 @@ func ExprGraph(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (in
 	} else if e.Root.Return() != parse.TypeSeries {
 		return nil, fmt.Errorf("egraph: requires an expression that returns a series")
 	}
-	res, _, err := e.Execute(schedule.Conf.TSDBCacheContext(), schedule.Conf.GraphiteContext(), schedule.Conf.LogstashElasticHost, t, now, autods, false, schedule.Search, nil)
+	// it may not strictly be necessary to recreate the contexts each time, but we do to be safe
+	tsdbContext := schedule.Conf.TSDBContext()
+	graphiteContext := schedule.Conf.GraphiteContext()
+	lsContext := schedule.Conf.LogstashElasticHost
+	res, _, err := e.Execute(tsdbContext, graphiteContext, lsContext, cacheObj, t, now, autods, false, schedule.Search, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/graphite/graphite.go
+++ b/graphite/graphite.go
@@ -26,6 +26,11 @@ type Series struct {
 
 type DataPoint []json.Number
 
+func (r *Request) CacheKey() string {
+	targets, _ := json.Marshal(r.Targets)
+	return fmt.Sprintf("graphite-%d-%d-%s", r.Start.Unix(), r.End.Unix(), targets)
+}
+
 func (r *Request) Query(host string) (Response, error) {
 	v := url.Values{
 		"format": []string{"json"},


### PR DESCRIPTION
* for executing expressions/rules via the web UI, we use
a cache that we retain during the lifetime of bosun
Matt and I decided not to expire the cache at given points (such as
reloading rule page), but I forgot why. ?
the only risk is that if you query your store for data -5m to now
and your store doesn't have the latest points up to date,
and then 5m from now you query -10min to -5m you'll get the same
cached data, including the incomplete last points

* for scheduled alert checking, the cache lifetime is only each
specific run so that different queries of the same
data for different templates are optimized and values reused in
templates are guaranteed to be in sync.
we don't make the lifetime longer to prevent affecting
future queries (perhaps a band() a week
from now which queries now-current data we just queried and might be
incomplete)
also there's likely less benefit (low hit rate) in keeping the cache
across alerting runs

note that Schedule.Check(), Schedule.Poll() and
Schedule.CheckUnknown() currently use their own caches for each run.
Schedule.Poll() runs on its own schedule and Schedule.CheckUnknown()
runs every checkinterval/4..
We should probably reuse the caching more across these checking
functions.  But I leave this up to Matt who knows more about this.

Note:
* graphite is tested, opentsdb is not.
* i did not work on logstash
