### PR TITLE
fix #716 divergence of "now" when executing templates

### DIFF
--- a/cmd/bosun/sched/template.go
+++ b/cmd/bosun/sched/template.go
@@ -202,11 +202,7 @@ func (c *Context) eval(v interface{}, filter bool, series bool, autods int) (exp
 	if series && e.Root.Return() != parse.TypeSeries {
 		return nil, "", fmt.Errorf("egraph: requires an expression that returns a series")
 	}
-	t := time.Now().UTC()
-	if c.AbnormalEvent() != nil {
-		t = c.AbnormalEvent().Time
-	}
-	res, _, err := e.Execute(c.runHistory.Context, c.runHistory.GraphiteContext, c.schedule.Conf.LogstashElasticHost, nil, t, autods, c.Alert.UnjoinedOK, c.schedule.Search, c.schedule.Conf.AlertSquelched(c.Alert))
+	res, _, err := e.Execute(c.runHistory.Context, c.runHistory.GraphiteContext, c.schedule.Conf.LogstashElasticHost, nil, c.runHistory.Start, autods, c.Alert.UnjoinedOK, c.schedule.Search, c.schedule.Conf.AlertSquelched(c.Alert))
 	if err != nil {
 		return nil, "", fmt.Errorf("%s: %v", v, err)
 	}


### PR DESCRIPTION
"now" was higher during execution of body/subject templates.
it should remain the exact same as warn/crit expressions
for consistency and caching.