### PR TITLE
On linux, spawn processes with pdeathsig

### DIFF
--- a/cmd/scollector/collectors/program.go
+++ b/cmd/scollector/collectors/program.go
@@ -99,8 +99,11 @@ func (c *ProgramCollector) Run(dpchan chan<- *opentsdb.DataPoint) {
 func (c *ProgramCollector) Init() {
 }
 
+var setupExternalCommand = func(cmd *exec.Cmd) {}
+
 func (c *ProgramCollector) runProgram(dpchan chan<- *opentsdb.DataPoint) (progError error) {
 	cmd := exec.Command(c.Path)
+	setupExternalCommand(cmd)
 	pr, pw := io.Pipe()
 	s := bufio.NewScanner(pr)
 	cmd.Stdout = pw

--- a/cmd/scollector/collectors/program_linux.go
+++ b/cmd/scollector/collectors/program_linux.go
@@ -1,0 +1,12 @@
+package collectors
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func init() {
+	setupExternalCommand = func(cmd *exec.Cmd) {
+		cmd.SysProcAttr = &syscall.SysProcAttr{Pdeathsig: syscall.SIGKILL}
+	}
+}


### PR DESCRIPTION
This may or may not help external collectors shut down when scollector does.