### PR TITLE
CheckUnknown should not panic on nil alert.

### DIFF
--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -198,6 +198,10 @@ func (s *Schedule) CheckUnknown() {
 				continue
 			}
 			a := s.Conf.Alerts[ak.Name()]
+			//alert doesn't exist anymore. Maybe status loaded from old db state.
+			if a == nil {
+				continue
+			}
 			t := a.Unknown
 			if t == 0 {
 				t = s.Conf.CheckFrequency * 2


### PR DESCRIPTION
I think this should only be needed if you remove an alert and restart bosun. This will prevent a panic.