### PR TITLE
make LeftJoin also accept resultslices fix #753

### DIFF
--- a/cmd/bosun/expr/expr.go
+++ b/cmd/bosun/expr/expr.go
@@ -212,6 +212,17 @@ func (r ResultSlice) DescByValue() ResultSlice {
 	return c
 }
 
+// Filter returns a slice with only the results that have a tagset that conforms to the given key/value pair restrictions
+func (r ResultSlice) Filter(filter opentsdb.TagSet) ResultSlice {
+	output := make(ResultSlice, 0, len(r))
+	for _, res := range r {
+		if res.Group.Compatible(filter) {
+			output = append(output, res)
+		}
+	}
+	return output
+}
+
 func (r ResultSlice) Len() int           { return len(r) }
 func (r ResultSlice) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
 func (r ResultSlice) Less(i, j int) bool { return r[i].Value.(Number) > r[j].Value.(Number) }

--- a/opentsdb/tsdb.go
+++ b/opentsdb/tsdb.go
@@ -111,6 +111,16 @@ func (t TagSet) Subset(o TagSet) bool {
 	return true
 }
 
+// Compatible returns true if all keys that are in both o and t, have the same value.
+func (t TagSet) Compatible(o TagSet) bool {
+	for k, v := range o {
+		if tv, ok := t[k]; ok && tv != v {
+			return false
+		}
+	}
+	return true
+}
+
 // Intersection returns the intersection of t and o.
 func (t TagSet) Intersection(o TagSet) TagSet {
 	r := make(TagSet)


### PR DESCRIPTION
now you can do things like:

{{$sorted := (.EvalAll .Alert.Vars.foo).DescByValue}}
{{range $r := .LeftJoin $sorted_importance .Alert.Vars.bar}}
...
{{end}}

to sort by any arbitrary "dimension", in this case $foo.