### PR TITLE
cmd/scollector: fix issues with c_network_team_windows and NETCLRMemory

### DIFF
--- a/cmd/scollector/collectors/network_windows.go
+++ b/cmd/scollector/collectors/network_windows.go
@@ -16,24 +16,25 @@ import (
 func init() {
 	collectors = append(collectors, &IntervalCollector{F: c_network_windows, init: winNetworkInit})
 
-	c := &IntervalCollector{
+	c_winnetteam := &IntervalCollector{
 		F: c_network_team_windows,
 	}
 	// Make sure MSFT_NetImPlatAdapter and MSFT_NetAdapterStatisticsSettingData
 	// are valid WMI classes when initializing c_network_team_windows
-	c.init = func() {
+	c_winnetteam.init = func() {
 		var dstTeamNic []MSFT_NetLbfoTeamNic
 		var dstStats []MSFT_NetAdapterStatisticsSettingData
 		queryTeamAdapter = wmi.CreateQuery(&dstTeamNic, "")
 		queryTeamStats = wmi.CreateQuery(&dstStats, "")
-		c.Enable = func() bool {
+		c_winnetteam.Enable = func() bool {
 			errTeamNic := queryWmiNamespace(queryTeamAdapter, &dstTeamNic, namespaceStandardCimv2)
 			errStats := queryWmiNamespace(queryTeamStats, &dstStats, namespaceStandardCimv2)
-			return errTeamNic == nil && errStats == nil
+			result := errTeamNic == nil && errStats == nil
+			return result
 		}
 	}
-	collectors = append(collectors, c)
-	c = &IntervalCollector{
+	collectors = append(collectors, c_winnetteam)
+	c := &IntervalCollector{
 		F: c_network_windows_tcp,
 	}
 	c.init = wmiInit(c, func() interface{} { return &[]Win32_PerfRawData_Tcpip_TCPv4{} }, "", &winNetTCPQuery)


### PR DESCRIPTION
I found some scollector errors in the Windows log files using Kibana:

The c.Enable variable in c_network_team_windows init function was not being updated correctly, probably due to a closure issue. This caused the collector to become active on or-dc02 and ny-dc05 (and others) and produce errors. Renaming the IntervalCollector variable (so it is not shared/reused) appears to solve the closure issue and stop the errors.

Also the PercentTimeinGC values were overflowing uint32, even though that is what WMI says they are. See http://goo.gl/x6om5l for example of error.

These changes are already running in a test build on a handful of systems pointed at prod bosun.