### PR TITLE
cmd/bosun: fix "normal" notifications

### DIFF
--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -94,6 +94,8 @@ func (s *Schedule) RunHistory(r *RunHistory) {
 			s.status[ak] = state
 		}
 		a := s.Conf.Alerts[ak.Name()]
+		last := state.AbnormalStatus()
+		state.Append(event)
 		wasOpen := state.Open
 		if event.Status > StNormal {
 			if event.Status != StUnknown {
@@ -167,8 +169,6 @@ func (s *Schedule) RunHistory(r *RunHistory) {
 			state.NeedAck = false
 			delete(s.Notifications, ak)
 		}
-		last := state.AbnormalStatus()
-		state.Append(event)
 		// last could be StNone if it is new. Set it to normal if so because StNormal >
 		// StNone. If the state is not open (closed), then the last state we care about
 		// isn't the last abnormal state, it's just normal.


### PR DESCRIPTION
We have been getting lots of notification emails with the status of
normal in them. This was because we were rendering the subject and body
before adding the new abnormal state (as we used to).