### PR TITLE
cmd/bosun: add test for unknown notifications

### DIFF
--- a/cmd/bosun/sched/notify.go
+++ b/cmd/bosun/sched/notify.go
@@ -96,8 +96,7 @@ func (s *Schedule) sendNotifications(silenced map[expr.AlertKey]Silence) {
 					continue
 				}
 				ustates[ak] = st
-			}
-			if silenced {
+			} else if silenced {
 				log.Println("silencing", ak)
 			} else {
 				s.notify(st, n)


### PR DESCRIPTION
We recently got 9 empty emails at exactly the same time that 9 unknown
alerts triggered. I thought it might be something with the unknown
template, but this test doesn't yet trigger the bug.