### PR TITLE
PR:812 adding the selection of http/https connection to graphitehost

### DIFF
--- a/graphite/graphite.go
+++ b/graphite/graphite.go
@@ -45,10 +45,8 @@ func (r *Request) Query(host string) (Response, error) {
 	}
 	u1, err := url.Parse(host)
 	if err != nil {
-		log.Printf("There was a problem parsing dev.conf: graphiteHost=" + host)
 		return nil, err
 	}
-	log.Printf("The scheme is : " + u1.Scheme + " and the host is : " + u1.Host)
 	if u1.Host == "" && u1.Scheme != "" {
 		u1.Host = u1.Scheme
 		u1.Scheme = "http"

--- a/graphite/graphite.go
+++ b/graphite/graphite.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"time"
-	"log"
 )
 
 // Request holds query objects. Currently only absolute times are supported.
@@ -44,22 +44,23 @@ func (r *Request) Query(host string) (Response, error) {
 		v.Add("until", fmt.Sprint(r.End.Unix()))
 	}
 
-  u1, err := url.Parse(host)
-  if err != nil {
-    log.Printf("There was a problem parsing dev.conf: graphiteHost=" + host)
-    return Response{}, err
-  }
-  if u1.Host == "" && u1.Scheme != ""{
-    u1.Host = u1.Scheme
-    u1.Scheme = "http"
-  } else if u1.Host == "" && u1.Scheme == ""{
-    u1.Host = host
-    u1.Scheme = "http"
-  }
+	u1, err := url.Parse(host)
+	if err != nil {
+		log.Printf("There was a problem parsing dev.conf: graphiteHost=" + host)
+		return Response{}, err
+	}
+	log.Printf("The scheme is : " + u1.Scheme + " and the host is : " + u1.Host)
+	if u1.Host == "" && u1.Scheme != "" {
+		u1.Host = u1.Scheme
+		u1.Scheme = "http"
+	} else if u1.Host == "" && u1.Scheme == "" {
+		u1.Host = host
+		u1.Scheme = "http"
+	}
 
 	u := url.URL{
-    Scheme:   u1.Scheme,
-    Host:     u1.Host,
+		Scheme:   u1.Scheme,
+		Host:     u1.Host,
 		Path:     "/render/",
 		RawQuery: v.Encode(),
 	}

--- a/graphite/graphite.go
+++ b/graphite/graphite.go
@@ -47,7 +47,7 @@ func (r *Request) Query(host string) (Response, error) {
 		return nil, err
 	}
 	if u1.Host == "" && u1.Scheme != "" && u1.Path != "" {
-		u1.Host = host
+		u1.Host =  host
 		u1.Scheme = "http"
 	} else if u1.Scheme == "" || u1.Host = "" || u1.Path != "" {
 		return nil, fmt.Errorf("bad URL format: %v", host)

--- a/graphite/graphite.go
+++ b/graphite/graphite.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"time"
-	"strings"
+	"log"
 )
 
 // Request holds query objects. Currently only absolute times are supported.
@@ -43,9 +43,23 @@ func (r *Request) Query(host string) (Response, error) {
 	if r.End != nil {
 		v.Add("until", fmt.Sprint(r.End.Unix()))
 	}
+
+  u1, err := url.Parse(host)
+  if err != nil {
+    log.Printf("There was a problem parsing dev.conf: graphiteHost=" + host)
+    return Response{}, err
+  }
+  if u1.Host == "" && u1.Scheme != ""{
+    u1.Host = u1.Scheme
+    u1.Scheme = "http"
+  } else if u1.Host == "" && u1.Scheme == ""{
+    u1.Host = host
+    u1.Scheme = "http"
+  }
+
 	u := url.URL{
-    Scheme:   strings.Split(host, ":")[0],
-    Host:     strings.Split(host,"//")[1],
+    Scheme:   u1.Scheme,
+    Host:     u1.Host,
 		Path:     "/render/",
 		RawQuery: v.Encode(),
 	}

--- a/graphite/graphite.go
+++ b/graphite/graphite.go
@@ -46,12 +46,11 @@ func (r *Request) Query(host string) (Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	if u1.Host == "" && u1.Scheme != "" {
-		u1.Host = u1.Scheme
-		u1.Scheme = "http"
-	} else if u1.Host == "" && u1.Scheme == "" {
+	if u1.Host == "" && u1.Scheme != "" && u1.Path != "" {
 		u1.Host = host
 		u1.Scheme = "http"
+	} else if u1.Scheme == "" || u1.Host = "" || u1.Path != "" {
+		return nil, fmt.Errorf("bad URL format: %v", host)
 	}
 	u := url.URL{
 		Scheme:   u1.Scheme,

--- a/graphite/graphite.go
+++ b/graphite/graphite.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"time"

--- a/graphite/graphite.go
+++ b/graphite/graphite.go
@@ -43,11 +43,10 @@ func (r *Request) Query(host string) (Response, error) {
 	if r.End != nil {
 		v.Add("until", fmt.Sprint(r.End.Unix()))
 	}
-
 	u1, err := url.Parse(host)
 	if err != nil {
 		log.Printf("There was a problem parsing dev.conf: graphiteHost=" + host)
-		return Response{}, err
+		return nil, err
 	}
 	log.Printf("The scheme is : " + u1.Scheme + " and the host is : " + u1.Host)
 	if u1.Host == "" && u1.Scheme != "" {
@@ -57,7 +56,6 @@ func (r *Request) Query(host string) (Response, error) {
 		u1.Host = host
 		u1.Scheme = "http"
 	}
-
 	u := url.URL{
 		Scheme:   u1.Scheme,
 		Host:     u1.Host,

--- a/graphite/graphite.go
+++ b/graphite/graphite.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+	"strings"
 )
 
 // Request holds query objects. Currently only absolute times are supported.
@@ -43,8 +44,8 @@ func (r *Request) Query(host string) (Response, error) {
 		v.Add("until", fmt.Sprint(r.End.Unix()))
 	}
 	u := url.URL{
-		Scheme:   "http",
-		Host:     host,
+    Scheme:   strings.Split(host, ":")[0],
+    Host:     strings.Split(host,"//")[1],
 		Path:     "/render/",
 		RawQuery: v.Encode(),
 	}


### PR DESCRIPTION
Adding the ability ot select https in the connection schema for graphite.
The idea is that we use the current documentation which specifies a 
graphiteHost = http://<hostname>
and work from there to separate the strings.The way it's setup now (after the pull) 
it can support non standard ports.  
MM