### PR TITLE
cmd/scollector: Riak - fix total available memory metric

### DIFF
--- a/cmd/scollector/collectors/riak.go
+++ b/cmd/scollector/collectors/riak.go
@@ -175,7 +175,7 @@ var riakMeta = map[string]MetricMeta{
 	},
 	"mem_total": {
 		Metric:   "memory",
-		TagSet:   opentsdb.TagSet{"type": "total"},
+		TagSet:   opentsdb.TagSet{"type": "available"},
 		RateType: metadata.Gauge,
 		Unit:     metadata.Bytes,
 		Desc:     "Total available system memory.",


### PR DESCRIPTION
I've made a mistake in riak.go collector, there're `mem_total` and `memory_total` that go into same `riak.memory` metric with `total` tag. `mem_total` should be better described as `riak.memory` tag: `available` to the system.