### PR TITLE
slog: Include severity when writing to event log in Windows

### DIFF
--- a/slog/slog_windows.go
+++ b/slog/slog_windows.go
@@ -1,6 +1,10 @@
 package slog
 
-import "bosun.org/_third_party/code.google.com/p/winsvc/debug"
+import (
+	"fmt"
+
+	"bosun.org/_third_party/code.google.com/p/winsvc/debug"
+)
 
 type eventLog struct {
 	l  debug.Log
@@ -15,16 +19,16 @@ func SetEventLog(l debug.Log, eid uint32) {
 }
 
 func (e *eventLog) Fatal(v string) {
-	e.Error(v)
+	e.l.Error(e.id, fmt.Sprintf("fatal: %s", v))
 }
 
 func (e *eventLog) Info(v string) {
-	e.l.Info(e.id, v)
+	e.l.Info(e.id, fmt.Sprintf("info: %s", v))
 }
 
 func (e *eventLog) Warning(v string) {
-	e.l.Warning(e.id, v)
+	e.l.Warning(e.id, fmt.Sprintf("warning: %s", v))
 }
 func (e *eventLog) Error(v string) {
-	e.l.Error(e.id, v)
+	e.l.Error(e.id, fmt.Sprintf("error: %s", v))
 }


### PR DESCRIPTION
our scollector.log.errors logstash alert isn't working for Windows because the event log messages don't include the severity level. This change prepends the severity level to the message so they appear the same as those sent to syslog on Linux.