### PR TITLE
cmd/bosun: add alert log feature

### DIFF
--- a/cmd/bosun/conf/conf_test.go
+++ b/cmd/bosun/conf/conf_test.go
@@ -68,6 +68,8 @@ func TestInvalid(t *testing.T) {
 		"lookup-key-pairs-dup": `conf: lookup-key-pairs-dup:3:1: at <entry b=2,a=1 { }>: duplicate entry`,
 		"crit-warn-unmatching-tags": `conf: crit-warn-unmatching-tags:3:0: at <alert broken {\n	cri...>: crit tags (a,c) and warn tags (c) must be equal`,
 		"depends-no-overlap": `conf: depends-no-overlap:3:0: at <alert broken {\n	dep...>: Depends and crit/warn must share at least one tag.`,
+		"log-no-notification": `conf: log-no-notification:1:0: at <alert a {\n	crit = 1...>: log + crit specified, but no critNotification`,
+		"crit-notification-no-template": `conf: crit-notification-no-template:5:0: at <alert a {\n	crit = 1...>: critNotification specified, but no template`,
 	}
 	for fname, reason := range names {
 		path := filepath.Join("invalid", fname)

--- a/cmd/bosun/conf/invalid/crit-notification-no-template
+++ b/cmd/bosun/conf/invalid/crit-notification-no-template
@@ -1,0 +1,8 @@
+notification n {
+	print = true
+}
+
+alert a {
+	crit = 1
+	critNotification = n
+}

--- a/cmd/bosun/conf/invalid/log-no-notification
+++ b/cmd/bosun/conf/invalid/log-no-notification
@@ -1,0 +1,4 @@
+alert a {
+	crit = 1
+	log = true
+}

--- a/cmd/bosun/conf/test.conf
+++ b/cmd/bosun/conf/test.conf
@@ -129,6 +129,7 @@ alert nc {
 	crit = 1
 	critNotification = default,nc4
 	critNotification = lookup("nc", "v")
+	template = generic
 }
 
 # macros with variables and duplicates
@@ -137,6 +138,7 @@ macro macroVarMacro {
 	$a = 3
 	critNotification = default,nc3
 	critNotification = nc4
+	template = generic
 }
 
 alert macroVarAlert {

--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -115,6 +115,9 @@ func (s *Schedule) RunHistory(r *RunHistory) {
 				state.Attachments = attachments
 			}
 			state.Open = true
+			if a.Log {
+				state.Open = false
+			}
 		}
 		// On state increase, clear old notifications and notify current.
 		// On state decrease, and if the old alert was already acknowledged, notify current.

--- a/cmd/bosun/sched/sched.go
+++ b/cmd/bosun/sched/sched.go
@@ -458,7 +458,8 @@ func (s *Schedule) RestoreState() error {
 		log.Println(dbStatus, err)
 	}
 	for ak, st := range status {
-		if a, present := s.Conf.Alerts[ak.Name()]; !present {
+		a, present := s.Conf.Alerts[ak.Name()]
+		if !present {
 			log.Println("sched: alert no longer present, ignoring:", ak)
 			continue
 		} else if s.Conf.Squelched(a, st.Group) {
@@ -474,10 +475,18 @@ func (s *Schedule) RestoreState() error {
 			}
 		}
 		s.status[ak] = st
+		if a.Log && st.Open {
+			st.Open = false
+			log.Printf("sched: alert %s is now log, closing, was %s", ak, st.Status())
+		}
 		for name, t := range notifications[ak] {
 			n, present := s.Conf.Notifications[name]
 			if !present {
 				log.Println("sched: notification not present during restore:", name)
+				continue
+			}
+			if a.Log {
+				log.Println("sched: alert is now log, removing notification:", ak)
 				continue
 			}
 			s.AddNotification(ak, n, t)


### PR DESCRIPTION
This prevents alerts from appearing on the dashboard, but allows them to
notify every time they trigger.

Also improve strictness of conf checks for alerts, notifications, and
templates.