### PR TITLE
Add HAProxy collector

### DIFF
--- a/cmd/scollector/collectors/haproxy_unix.go
+++ b/cmd/scollector/collectors/haproxy_unix.go
@@ -1,0 +1,486 @@
+package collectors
+
+import (
+	"encoding/csv"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"bosun.org/metadata"
+	"bosun.org/opentsdb"
+)
+
+// HAProxy registers an HAProxy collector.
+func HAProxy(user, pwd, url, tier string) {
+	collectors = append(collectors, &IntervalCollector{
+		F: func() (opentsdb.MultiDataPoint, error) {
+			return c_haproxy_csv(user, pwd, url)
+		},
+		name: fmt.Sprintf("haproxy-%s", url, tier),
+	})
+}
+
+func c_haproxy_csv(user, pwd, url, tier string) (opentsdb.MultiDataPoint, error) {
+	var md opentsdb.MultiDataPoint
+	const metric = "haproxy"
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(user, pwd)
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	//csvFile, err := os.Open("/ha.csv")
+	if err != nil {
+		return nil, err
+	}
+	//defer csvFile.Close()
+	reader := csv.NewReader(resp.Body)
+	records, err := reader.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+	if len(records) < 2 {
+		return nil, nil
+	}
+	parse := func(v string) (int64, error) {
+		var i int64
+		if v != "" {
+			i, err = strconv.ParseInt(v, 10, 64)
+			if err != nil {
+				return 0, err
+			}
+			return i, nil
+		}
+		return i, nil
+	}
+	for _, rec := range records[1:] {
+		// There is a trailing comma in haproxy's csv
+		if len(rec) != len(haproxyCsvMeta)+1 {
+			return nil, fmt.Errorf("expected %v lines. got: %v",
+				len(haproxyCsvMeta)+1, len(rec))
+		}
+		hType := haproxyType[rec[32]]
+		pxname := rec[0]
+		svname := rec[1]
+		ts := opentsdb.TagSet{"pxname": pxname, "svname": svname}
+		// TODO MERGE IN INSTANCE TAG
+		for i, field := range haproxyCsvMeta {
+			m := strings.Join([]string{metric, hType, field.Name}, ".")
+			switch i {
+			case 0, 1, 26, 27, 28, 31, 32, 56, 57:
+				continue
+			case 39, 40, 41, 42, 43, 44:
+				sp := strings.Split(field.Name, "_")
+				if len(sp) != 2 {
+					return nil, fmt.Errorf("unexpected field name %v in hrsp", field.Name)
+				}
+				ts := ts.Copy().Merge(opentsdb.TagSet{"status_code": sp[1]})
+				m = strings.Join([]string{metric, hType, sp[0]}, ".")
+				v, err := parse(rec[i])
+				if err != nil {
+					return nil, err
+				}
+				Add(&md, m, v, ts, metadata.Counter, metadata.Response,
+					fmt.Sprintf("The number of http responses with a %v status code.", sp[1]))
+			case 17:
+				v, ok := haproxyStatus[rec[i]]
+				// Not distinging between MAINT and MAINT via...
+				if !ok {
+					v = 3
+				}
+				Add(&md, m, v, ts, field.RateType, field.Unit, field.Desc)
+			case 36:
+				if rec[i] == "" {
+					continue
+				}
+				v, ok := haproxyCheckStatus[rec[i]]
+				if !ok {
+					return nil, fmt.Errorf("unknown check status %v", rec[i])
+				}
+				Add(&md, m, v, ts, field.RateType, field.Unit, field.Desc)
+			default:
+				v, err := parse(rec[i])
+				if err != nil {
+					return nil, err
+				}
+				Add(&md, m, v, ts, field.RateType, field.Unit, field.Desc)
+			}
+		}
+	}
+	return md, nil
+}
+
+type MetricMetaName struct {
+	Name string
+	MetricMeta
+}
+
+var haproxyType = map[string]string{
+	"0": "frontend",
+	"1": "backend",
+	"2": "server",
+	"3": "listen",
+}
+
+var haproxyCheckStatus = map[string]float64{
+	"UNK":     0,
+	"INI":     1,
+	"SOCKERR": 2,
+	"L4OK":    3,
+	"L4TMOUT": 4,
+	"L4CON":   5,
+	"L6OK":    6,
+	"L6TOUT":  7,
+	"L6RSP":   8,
+	"L7OK":    9,
+	"L7OKC":   10,
+	"L7TOUT":  11,
+	"L7RSP":   12,
+	"L7STS":   13,
+}
+
+var haproxyStatus = map[string]float64{
+	"UP":    0,
+	"DOWN":  1,
+	"NOLB":  2,
+	"MAINT": 3,
+}
+
+var haproxyCsvMeta = []MetricMetaName{
+	MetricMetaName{
+		Name: "pxname",
+	},
+	MetricMetaName{
+		Name: "svname",
+	},
+	MetricMetaName{
+		Name: "qcur",
+		MetricMeta: MetricMeta{RateType: metadata.Gauge,
+			Unit: metadata.Request,
+			Desc: "The current queued requests. For the backend this reports the number queued without a server assigned.",
+		}},
+	MetricMetaName{
+		Name: "qmax",
+		MetricMeta: MetricMeta{RateType: metadata.Gauge,
+			Unit: metadata.Request,
+			Desc: "The max value of qcur.",
+		}},
+	MetricMetaName{
+		Name: "scur",
+		MetricMeta: MetricMeta{RateType: metadata.Gauge,
+			Unit: metadata.Session,
+			Desc: "The current number of sessions.",
+		}},
+	MetricMetaName{
+		Name: "smax",
+		MetricMeta: MetricMeta{RateType: metadata.Gauge,
+			Unit: metadata.Session,
+			Desc: "The maximum number of concurrent sessions seen.",
+		}},
+	MetricMetaName{
+		Name: "slim",
+		MetricMeta: MetricMeta{RateType: metadata.Gauge,
+			Unit: metadata.Session,
+			Desc: "The configured session limit.",
+		}},
+	MetricMetaName{
+		Name: "stot",
+		MetricMeta: MetricMeta{RateType: metadata.Counter,
+			Unit: metadata.Session,
+			Desc: "The total number of sessions.",
+		}},
+	MetricMetaName{
+		Name: "bin",
+		MetricMeta: MetricMeta{RateType: metadata.Counter,
+			Unit: metadata.Bytes,
+			Desc: "The number of bytes in.",
+		}},
+	MetricMetaName{
+		Name: "bout",
+		MetricMeta: MetricMeta{RateType: metadata.Counter,
+			Unit: metadata.Bytes,
+			Desc: "The number of bytes out.",
+		}},
+	MetricMetaName{
+		Name: "dreq",
+		MetricMeta: MetricMeta{RateType: metadata.Counter,
+			Unit: metadata.Request,
+			Desc: "The number of requests denied because of security concerns. For tcp this is because of a matched tcp-request content rule. For http this is because of a matched http-request or tarpit rule.",
+		}},
+	MetricMetaName{
+		Name: "dresp",
+		MetricMeta: MetricMeta{RateType: metadata.Counter,
+			Unit: metadata.Response,
+			Desc: "The number of responses denied because of security concerns. For http this is because of a matched http-request rule, or 'option checkcache'.",
+		}},
+	MetricMetaName{
+		Name: "ereq",
+		MetricMeta: MetricMeta{RateType: metadata.Counter,
+			Unit: metadata.Request,
+			Desc: "The number of request errors. Some of the possible causes are: Early termination from the client before the request has been sent, a read error from the client, a client timeout, a client closed connection, various bad requests from the client or the request was tarpitted.",
+		}},
+	MetricMetaName{
+		Name: "econ",
+		MetricMeta: MetricMeta{RateType: metadata.Counter,
+			Unit: metadata.Request,
+			Desc: "The number of number of requests that encountered an error trying to connect to a backend server. The backend stat is the sum of the stat for all servers of that backend, plus any connection errors not associated with a particular server (such as the backend having no active servers).",
+		}},
+	MetricMetaName{
+		Name: "eresp",
+		MetricMeta: MetricMeta{RateType: metadata.Counter,
+			Unit: metadata.Response,
+			Desc: " The number of response errors. srv_abrt will be counted here also. Some errors are: write error on the client socket (won't be counted for the server stat) and failure applying filters to the response.",
+		}},
+	MetricMetaName{
+		Name: "wretr",
+		MetricMeta: MetricMeta{RateType: metadata.Counter,
+			Unit: metadata.Retry,
+			Desc: "The number of times a connection to a server was retried.",
+		}},
+	MetricMetaName{
+		Name: "wredis",
+		MetricMeta: MetricMeta{RateType: metadata.Counter,
+			Unit: metadata.Redispatch,
+			Desc: "number of times a request was redispatched to another server. The server value counts the number of times that server was switched away from.",
+		}},
+	MetricMetaName{
+		Name: "status",
+		MetricMeta: MetricMeta{RateType: metadata.Gauge,
+			Unit: metadata.Weight,
+			Desc: "The current status: 0->UP, 1->Down, 2->NOLB, 3->Maintenance.",
+		}},
+	MetricMetaName{
+		Name: "weight",
+		MetricMeta: MetricMeta{RateType: metadata.Gauge,
+			Unit: metadata.Weight,
+			Desc: "The server weight (server), total weight (backend).",
+		}},
+	MetricMetaName{
+		Name: "act",
+		MetricMeta: MetricMeta{RateType: metadata.Gauge,
+			Unit: metadata.Server,
+			Desc: "If the server is active in the case of servers, or number of active servers in the case of a backend.",
+		}},
+	MetricMetaName{
+		Name: "bck",
+		MetricMeta: MetricMeta{RateType: metadata.Gauge,
+			Unit: metadata.Server,
+			Desc: "If the server is a backup in the case of servers, or number of backup servers in the case of a backend.",
+		}},
+	MetricMetaName{
+		Name: "chkfail",
+		MetricMeta: MetricMeta{RateType: metadata.Counter,
+			Unit: metadata.Check,
+			Desc: "The number of failed checks. (Only counts checks failed when the server is up.",
+		}},
+	MetricMetaName{
+		Name: "chkdown",
+		MetricMeta: MetricMeta{RateType: metadata.Counter,
+			Unit: metadata.Transition,
+			Desc: "The number of UP->DOWN transitions. The backend counter counts transitions to the whole backend being down, rather than the sum of the counters for each server.",
+		}},
+	MetricMetaName{
+		Name: "lastchg",
+		MetricMeta: MetricMeta{RateType: metadata.Gauge,
+			Unit: metadata.Second,
+			Desc: "The number of seconds since the last UP<->DOWN transition.",
+		}},
+	MetricMetaName{
+		Name: "downtime",
+		MetricMeta: MetricMeta{RateType: metadata.Counter,
+			Unit: metadata.Second,
+			Desc: "The total downtime in seconds. The value for the backend is the downtime for the whole backend, not the sum of the server downtime.",
+		}},
+	MetricMetaName{
+		Name: "qlimit",
+		MetricMeta: MetricMeta{RateType: metadata.Gauge,
+			//Don't know the unit
+			Desc: "The configured maxqueue for the server, or nothing in the value is 0 (default, meaning no limit)",
+		}},
+	MetricMetaName{
+		Name: "pid",
+		// Not a series or tag so skipping this.
+	},
+	MetricMetaName{
+		Name: "iid",
+		// Not a series or tag so skipping this.
+	},
+	MetricMetaName{
+		Name: "sid",
+		// Not a series or tag so skipping this.
+	},
+	MetricMetaName{
+		Name: "throttle",
+		MetricMeta: MetricMeta{RateType: metadata.Gauge,
+			Unit: metadata.Pct,
+			Desc: "The current throttle percentage for the server, when slowstart is active, or no value if not in slowstart.",
+		}},
+	MetricMetaName{
+		Name: "lbtot",
+		MetricMeta: MetricMeta{RateType: metadata.Counter,
+			//Don't know the unit
+			Desc: "The total number of times a server was selected, either for new sessions, or when re-dispatching. The server counter is the number of times that server was selected.",
+		}},
+	MetricMetaName{
+		Name: "tracked",
+		// This could be a tag, but I am have no use for it.
+	},
+	MetricMetaName{
+		Name: "type",
+		// This could be a tag, but I am have no use for it.
+	},
+	MetricMetaName{
+		Name: "rate",
+		// This could be a tag, but I am have no use for it.
+	},
+	MetricMetaName{
+		Name: "rate_lim",
+		MetricMeta: MetricMeta{RateType: metadata.Gauge,
+			Unit: metadata.Session,
+			Desc: "The configured limit on new sessions per second.",
+		}},
+	MetricMetaName{
+		Name: "rate_max",
+		MetricMeta: MetricMeta{RateType: metadata.Counter,
+			Unit: metadata.Session,
+			Desc: "The max number of new sessions per second.",
+		}},
+	MetricMetaName{
+		Name: "check_status",
+		MetricMeta: MetricMeta{RateType: metadata.Gauge,
+			Unit: metadata.StatusCode,
+			Desc: "The status of last health check, one of: 0 -> unknown, 1 -> initializing, 2 -> socket error, 3 -> The check passed on layer 4, but no upper layers testing enabled, 4 -> layer 1-4 timeout, 5 -> layer 1-4 connection problem for example 'Connection refused' (tcp rst) or 'No route to host' (icmp), 6 -> check passed on layer 6, 7 -> layer 6 (SSL) timeout, 8 -> layer 6 invalid response - protocol error, 9 -> check passed on layer 7, 10 -> check conditionally passed on layer 7 for example 404 with disable-on-404, 11 -> layer 7 (HTTP/SMTP) timeout, 12 -> layer 7 invalid response - protocol error, 13 -> layer 7 response error, for example HTTP 5xx.",
+		}},
+	MetricMetaName{
+		Name: "check_code",
+		MetricMeta: MetricMeta{RateType: metadata.Gauge,
+			Unit: metadata.StatusCode,
+			Desc: "The layer5-7 code, if available.",
+		}},
+	MetricMetaName{
+		Name: "check_duration",
+		MetricMeta: MetricMeta{RateType: metadata.Gauge,
+			Unit: metadata.MilliSecond,
+			Desc: "The time in ms it took to finish last health check.",
+		}},
+	MetricMetaName{
+		Name: "hrsp_1xx",
+		//These are transformed and aggregated: 1xx, 2xx, etc will be a tag.
+	},
+	MetricMetaName{
+		Name: "hrsp_2xx",
+	},
+	MetricMetaName{
+		Name: "hrsp_3xx",
+	},
+	MetricMetaName{
+		Name: "hrsp_4xx",
+	},
+	MetricMetaName{
+		Name: "hrsp_5xx",
+	},
+	MetricMetaName{
+		Name: "hrsp_other",
+	},
+	MetricMetaName{
+		Name: "hanafail",
+		// The docs just say "failed health check details", so skipping this
+		// for now
+	},
+	MetricMetaName{
+		Name: "req_rate",
+		// Not needed since data store can derive the rate from req_tot
+	},
+	MetricMetaName{
+		Name: "req_rate_max",
+		MetricMeta: MetricMeta{RateType: metadata.Gauge,
+			Unit: metadata.Request,
+			Desc: "The max number of HTTP requests per second observed.",
+		}},
+	MetricMetaName{
+		Name: "req_tot",
+		MetricMeta: MetricMeta{RateType: metadata.Counter,
+			Unit: metadata.Request,
+			Desc: "The number of HTTP requests recieved.",
+		}},
+	MetricMetaName{
+		Name: "cli_abrt",
+		MetricMeta: MetricMeta{RateType: metadata.Counter,
+			Unit: metadata.Abort,
+			Desc: "The number of data transfers aborted by the client.",
+		}},
+	MetricMetaName{
+		Name: "srv_abrt",
+		MetricMeta: MetricMeta{RateType: metadata.Counter,
+			Unit: metadata.Abort,
+			Desc: "The number of data transfers aborted by the server.",
+		}},
+	MetricMetaName{
+		Name: "comp_in",
+		MetricMeta: MetricMeta{RateType: metadata.Counter,
+			Unit: metadata.Bytes,
+			Desc: "The number of HTTP response bytes fed to the compressor.",
+		}},
+	MetricMetaName{
+		Name: "comp_out",
+		MetricMeta: MetricMeta{RateType: metadata.Counter,
+			Unit: metadata.Bytes,
+			Desc: "The number of HTTP response bytes emitted by the compressor.",
+		}},
+	MetricMetaName{
+		Name: "comp_byp",
+		MetricMeta: MetricMeta{RateType: metadata.Counter,
+			Unit: metadata.Bytes,
+			Desc: "The number of bytes that bypassed the HTTP compressor (CPU/BW limit).",
+		}},
+	MetricMetaName{
+		Name: "comp_rsp",
+		MetricMeta: MetricMeta{RateType: metadata.Counter,
+			Unit: metadata.Response,
+			Desc: "The number of HTTP responses that were compressed.",
+		}},
+	MetricMetaName{
+		Name: "lastsess",
+		MetricMeta: MetricMeta{RateType: metadata.Gauge,
+			Unit: metadata.Second,
+			Desc: "The number of seconds since last session assigned to server/backend.",
+		}},
+	MetricMetaName{
+		Name: "last_chk",
+		// Not a series or tag so skipping this.
+	},
+	MetricMetaName{
+		Name: "last_agt",
+		// Not a series or tag so skipping this.
+	},
+	MetricMetaName{
+		Name: "qtime",
+		MetricMeta: MetricMeta{RateType: metadata.Gauge,
+			Unit: metadata.MilliSecond,
+			Desc: "The average queue time in ms over the 1024 last requests.",
+		}},
+	MetricMetaName{
+		Name: "ctime",
+		MetricMeta: MetricMeta{RateType: metadata.Gauge,
+			Unit: metadata.MilliSecond,
+			Desc: "The average connect time in ms over the 1024 last requests.",
+		}},
+	MetricMetaName{
+		Name: "rtime",
+		MetricMeta: MetricMeta{RateType: metadata.Gauge,
+			Unit: metadata.MilliSecond,
+			Desc: "The average response time in ms over the 1024 last requests (0 for TCP).",
+		}},
+	MetricMetaName{
+		Name: "ttime",
+		MetricMeta: MetricMeta{RateType: metadata.Gauge,
+			Unit: metadata.MilliSecond,
+			Desc: "The average response time in ms over the 1024 last requests (0 for TCP).",
+		}},
+}

--- a/cmd/scollector/collectors/haproxy_unix.go
+++ b/cmd/scollector/collectors/haproxy_unix.go
@@ -11,43 +11,52 @@ import (
 	"bosun.org/opentsdb"
 )
 
+var trackedInstances = []*trackedInstance{}
+
+type trackedInstance struct {
+	Tier string
+	URL  string
+}
+
 // HAProxy registers an HAProxy collector.
-func HAProxy(user, pwd, url, tier string) {
+func HAProxy(user, pwd string) {
 	collectors = append(collectors, &IntervalCollector{
 		F: func() (opentsdb.MultiDataPoint, error) {
-			return c_haproxy_csv(user, pwd, url)
+			return cHAProxyCSV(user, pwd)
 		},
-		name: fmt.Sprintf("haproxy-%s", url, tier),
+		name: "haproxy",
 	})
 }
 
-func c_haproxy_csv(user, pwd, url, tier string) (opentsdb.MultiDataPoint, error) {
+// AddHAProxyInstance adds haproxy instances to be tracked.
+func AddHAProxyInstance(conf string) error {
+	sp := strings.SplitN(conf, ":", 2)
+	if len(sp) < 2 {
+		return fmt.Errorf("haproxy_instance requires two fields")
+	}
+	var instance trackedInstance
+	instance.Tier = sp[0]
+	instance.URL = sp[1]
+	trackedInstances = append(trackedInstances, &instance)
+
+	return nil
+}
+
+func cHAProxyCSV(user, pwd string) (opentsdb.MultiDataPoint, error) {
 	var md opentsdb.MultiDataPoint
+	var err error
+
+	for _, instance := range trackedInstances {
+		if e := instance.fetchHAProxyData(&md, user, pwd); e != nil {
+			err = e
+		}
+	}
+	return md, err
+}
+
+func (instance *trackedInstance) fetchHAProxyData(md *opentsdb.MultiDataPoint, user string, pwd string) error {
+	var err error
 	const metric = "haproxy"
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.SetBasicAuth(user, pwd)
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	//csvFile, err := os.Open("/ha.csv")
-	if err != nil {
-		return nil, err
-	}
-	//defer csvFile.Close()
-	reader := csv.NewReader(resp.Body)
-	records, err := reader.ReadAll()
-	if err != nil {
-		return nil, err
-	}
-	if len(records) < 2 {
-		return nil, nil
-	}
 	parse := func(v string) (int64, error) {
 		var i int64
 		if v != "" {
@@ -59,65 +68,86 @@ func c_haproxy_csv(user, pwd, url, tier string) (opentsdb.MultiDataPoint, error)
 		}
 		return i, nil
 	}
+
+	req, err := http.NewRequest("GET", instance.URL, nil)
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(user, pwd)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	reader := csv.NewReader(resp.Body)
+	records, err := reader.ReadAll()
+	if err != nil {
+		return err
+	}
+	if len(records) < 2 {
+		return nil
+	}
 	for _, rec := range records[1:] {
 		// There is a trailing comma in haproxy's csv
-		if len(rec) != len(haproxyCsvMeta)+1 {
-			return nil, fmt.Errorf("expected %v lines. got: %v",
-				len(haproxyCsvMeta)+1, len(rec))
+		if len(rec) != len(haproxyCSVMeta)+1 {
+			return fmt.Errorf("expected %v lines. got: %v",
+				len(haproxyCSVMeta)+1, len(rec))
 		}
 		hType := haproxyType[rec[32]]
 		pxname := rec[0]
 		svname := rec[1]
-		ts := opentsdb.TagSet{"pxname": pxname, "svname": svname}
-		// TODO MERGE IN INSTANCE TAG
-		for i, field := range haproxyCsvMeta {
+		ts := opentsdb.TagSet{"pxname": pxname, "svname": svname, "tier": instance.Tier}
+		for i, field := range haproxyCSVMeta {
 			m := strings.Join([]string{metric, hType, field.Name}, ".")
-			switch i {
-			case 0, 1, 26, 27, 28, 31, 32, 56, 57:
+			value := rec[i]
+			if field.Ignore == true {
 				continue
-			case 39, 40, 41, 42, 43, 44:
+			} else if strings.HasPrefix(field.Name, "hrsp") {
 				sp := strings.Split(field.Name, "_")
 				if len(sp) != 2 {
-					return nil, fmt.Errorf("unexpected field name %v in hrsp", field.Name)
+					return fmt.Errorf("unexpected field name %v in hrsp", field.Name)
 				}
 				ts := ts.Copy().Merge(opentsdb.TagSet{"status_code": sp[1]})
 				m = strings.Join([]string{metric, hType, sp[0]}, ".")
-				v, err := parse(rec[i])
+				v, err := parse(value)
 				if err != nil {
-					return nil, err
+					return err
 				}
-				Add(&md, m, v, ts, metadata.Counter, metadata.Response,
+				Add(md, m, v, ts, metadata.Counter, metadata.Response,
 					fmt.Sprintf("The number of http responses with a %v status code.", sp[1]))
-			case 17:
-				v, ok := haproxyStatus[rec[i]]
+			} else if field.Name == "status" {
+				v, ok := haproxyStatus[value]
 				// Not distinging between MAINT and MAINT via...
 				if !ok {
 					v = 3
 				}
-				Add(&md, m, v, ts, field.RateType, field.Unit, field.Desc)
-			case 36:
-				if rec[i] == "" {
+				Add(md, m, v, ts, field.RateType, field.Unit, field.Desc)
+			} else if field.Name == "check_status" {
+				if value == "" {
 					continue
 				}
-				v, ok := haproxyCheckStatus[rec[i]]
+				v, ok := haproxyCheckStatus[value]
 				if !ok {
-					return nil, fmt.Errorf("unknown check status %v", rec[i])
+					return fmt.Errorf("unknown check status %v", value)
 				}
-				Add(&md, m, v, ts, field.RateType, field.Unit, field.Desc)
-			default:
-				v, err := parse(rec[i])
+				Add(md, m, v, ts, field.RateType, field.Unit, field.Desc)
+			} else {
+				v, err := parse(value)
 				if err != nil {
-					return nil, err
+					return err
 				}
-				Add(&md, m, v, ts, field.RateType, field.Unit, field.Desc)
+				Add(md, m, v, ts, field.RateType, field.Unit, field.Desc)
 			}
 		}
 	}
-	return md, nil
+	return nil
 }
 
-type MetricMetaName struct {
-	Name string
+// MetricMetaHAProxy is a super-structure which adds a friendly Name,
+// as well as an indicator on if a metric is to be ignored.
+type MetricMetaHAProxy struct {
+	Name   string
+	Ignore bool
 	MetricMeta
 }
 
@@ -128,7 +158,7 @@ var haproxyType = map[string]string{
 	"3": "listen",
 }
 
-var haproxyCheckStatus = map[string]float64{
+var haproxyCheckStatus = map[string]int{
 	"UNK":     0,
 	"INI":     1,
 	"SOCKERR": 2,
@@ -145,339 +175,351 @@ var haproxyCheckStatus = map[string]float64{
 	"L7STS":   13,
 }
 
-var haproxyStatus = map[string]float64{
+var haproxyStatus = map[string]int{
 	"UP":    0,
 	"DOWN":  1,
 	"NOLB":  2,
 	"MAINT": 3,
 }
 
-var haproxyCsvMeta = []MetricMetaName{
-	MetricMetaName{
-		Name: "pxname",
+// A slice of fields which are presented by haproxy's CSV data.
+// See "CSV format" in http://www.haproxy.org/download/1.5/doc/configuration.txt
+var haproxyCSVMeta = []MetricMetaHAProxy{
+	MetricMetaHAProxy{
+		Name:   "pxname",
+		Ignore: true,
 	},
-	MetricMetaName{
-		Name: "svname",
+	MetricMetaHAProxy{
+		Name:   "svname",
+		Ignore: true,
 	},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "qcur",
 		MetricMeta: MetricMeta{RateType: metadata.Gauge,
 			Unit: metadata.Request,
 			Desc: "The current queued requests. For the backend this reports the number queued without a server assigned.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "qmax",
 		MetricMeta: MetricMeta{RateType: metadata.Gauge,
 			Unit: metadata.Request,
 			Desc: "The max value of qcur.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "scur",
 		MetricMeta: MetricMeta{RateType: metadata.Gauge,
 			Unit: metadata.Session,
 			Desc: "The current number of sessions.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "smax",
 		MetricMeta: MetricMeta{RateType: metadata.Gauge,
 			Unit: metadata.Session,
 			Desc: "The maximum number of concurrent sessions seen.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "slim",
 		MetricMeta: MetricMeta{RateType: metadata.Gauge,
 			Unit: metadata.Session,
 			Desc: "The configured session limit.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "stot",
 		MetricMeta: MetricMeta{RateType: metadata.Counter,
 			Unit: metadata.Session,
 			Desc: "The total number of sessions.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "bin",
 		MetricMeta: MetricMeta{RateType: metadata.Counter,
 			Unit: metadata.Bytes,
 			Desc: "The number of bytes in.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "bout",
 		MetricMeta: MetricMeta{RateType: metadata.Counter,
 			Unit: metadata.Bytes,
 			Desc: "The number of bytes out.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "dreq",
 		MetricMeta: MetricMeta{RateType: metadata.Counter,
 			Unit: metadata.Request,
 			Desc: "The number of requests denied because of security concerns. For tcp this is because of a matched tcp-request content rule. For http this is because of a matched http-request or tarpit rule.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "dresp",
 		MetricMeta: MetricMeta{RateType: metadata.Counter,
 			Unit: metadata.Response,
 			Desc: "The number of responses denied because of security concerns. For http this is because of a matched http-request rule, or 'option checkcache'.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "ereq",
 		MetricMeta: MetricMeta{RateType: metadata.Counter,
 			Unit: metadata.Request,
 			Desc: "The number of request errors. Some of the possible causes are: Early termination from the client before the request has been sent, a read error from the client, a client timeout, a client closed connection, various bad requests from the client or the request was tarpitted.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "econ",
 		MetricMeta: MetricMeta{RateType: metadata.Counter,
 			Unit: metadata.Request,
 			Desc: "The number of number of requests that encountered an error trying to connect to a backend server. The backend stat is the sum of the stat for all servers of that backend, plus any connection errors not associated with a particular server (such as the backend having no active servers).",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "eresp",
 		MetricMeta: MetricMeta{RateType: metadata.Counter,
 			Unit: metadata.Response,
 			Desc: " The number of response errors. srv_abrt will be counted here also. Some errors are: write error on the client socket (won't be counted for the server stat) and failure applying filters to the response.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "wretr",
 		MetricMeta: MetricMeta{RateType: metadata.Counter,
 			Unit: metadata.Retry,
 			Desc: "The number of times a connection to a server was retried.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "wredis",
 		MetricMeta: MetricMeta{RateType: metadata.Counter,
 			Unit: metadata.Redispatch,
 			Desc: "number of times a request was redispatched to another server. The server value counts the number of times that server was switched away from.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "status",
 		MetricMeta: MetricMeta{RateType: metadata.Gauge,
 			Unit: metadata.Weight,
 			Desc: "The current status: 0->UP, 1->Down, 2->NOLB, 3->Maintenance.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "weight",
 		MetricMeta: MetricMeta{RateType: metadata.Gauge,
 			Unit: metadata.Weight,
 			Desc: "The server weight (server), total weight (backend).",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "act",
 		MetricMeta: MetricMeta{RateType: metadata.Gauge,
 			Unit: metadata.Server,
 			Desc: "If the server is active in the case of servers, or number of active servers in the case of a backend.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "bck",
 		MetricMeta: MetricMeta{RateType: metadata.Gauge,
 			Unit: metadata.Server,
 			Desc: "If the server is a backup in the case of servers, or number of backup servers in the case of a backend.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "chkfail",
 		MetricMeta: MetricMeta{RateType: metadata.Counter,
 			Unit: metadata.Check,
 			Desc: "The number of failed checks. (Only counts checks failed when the server is up.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "chkdown",
 		MetricMeta: MetricMeta{RateType: metadata.Counter,
 			Unit: metadata.Transition,
 			Desc: "The number of UP->DOWN transitions. The backend counter counts transitions to the whole backend being down, rather than the sum of the counters for each server.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "lastchg",
 		MetricMeta: MetricMeta{RateType: metadata.Gauge,
 			Unit: metadata.Second,
 			Desc: "The number of seconds since the last UP<->DOWN transition.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "downtime",
 		MetricMeta: MetricMeta{RateType: metadata.Counter,
 			Unit: metadata.Second,
 			Desc: "The total downtime in seconds. The value for the backend is the downtime for the whole backend, not the sum of the server downtime.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "qlimit",
 		MetricMeta: MetricMeta{RateType: metadata.Gauge,
 			//Don't know the unit
 			Desc: "The configured maxqueue for the server, or nothing in the value is 0 (default, meaning no limit)",
 		}},
-	MetricMetaName{
-		Name: "pid",
+	MetricMetaHAProxy{
+		Name:   "pid",
+		Ignore: true,
 		// Not a series or tag so skipping this.
 	},
-	MetricMetaName{
-		Name: "iid",
+	MetricMetaHAProxy{
+		Name:   "iid",
+		Ignore: true,
 		// Not a series or tag so skipping this.
 	},
-	MetricMetaName{
-		Name: "sid",
+	MetricMetaHAProxy{
+		Name:   "sid",
+		Ignore: true,
 		// Not a series or tag so skipping this.
 	},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "throttle",
 		MetricMeta: MetricMeta{RateType: metadata.Gauge,
 			Unit: metadata.Pct,
 			Desc: "The current throttle percentage for the server, when slowstart is active, or no value if not in slowstart.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "lbtot",
 		MetricMeta: MetricMeta{RateType: metadata.Counter,
 			//Don't know the unit
 			Desc: "The total number of times a server was selected, either for new sessions, or when re-dispatching. The server counter is the number of times that server was selected.",
 		}},
-	MetricMetaName{
-		Name: "tracked",
+	MetricMetaHAProxy{
+		Name:   "tracked",
+		Ignore: true,
 		// This could be a tag, but I am have no use for it.
 	},
-	MetricMetaName{
-		Name: "type",
+	MetricMetaHAProxy{
+		Name:   "type",
+		Ignore: true,
 		// This could be a tag, but I am have no use for it.
 	},
-	MetricMetaName{
-		Name: "rate",
+	MetricMetaHAProxy{
+		Name:   "rate",
+		Ignore: true,
 		// This could be a tag, but I am have no use for it.
 	},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "rate_lim",
 		MetricMeta: MetricMeta{RateType: metadata.Gauge,
 			Unit: metadata.Session,
 			Desc: "The configured limit on new sessions per second.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "rate_max",
 		MetricMeta: MetricMeta{RateType: metadata.Counter,
 			Unit: metadata.Session,
 			Desc: "The max number of new sessions per second.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "check_status",
 		MetricMeta: MetricMeta{RateType: metadata.Gauge,
 			Unit: metadata.StatusCode,
 			Desc: "The status of last health check, one of: 0 -> unknown, 1 -> initializing, 2 -> socket error, 3 -> The check passed on layer 4, but no upper layers testing enabled, 4 -> layer 1-4 timeout, 5 -> layer 1-4 connection problem for example 'Connection refused' (tcp rst) or 'No route to host' (icmp), 6 -> check passed on layer 6, 7 -> layer 6 (SSL) timeout, 8 -> layer 6 invalid response - protocol error, 9 -> check passed on layer 7, 10 -> check conditionally passed on layer 7 for example 404 with disable-on-404, 11 -> layer 7 (HTTP/SMTP) timeout, 12 -> layer 7 invalid response - protocol error, 13 -> layer 7 response error, for example HTTP 5xx.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "check_code",
 		MetricMeta: MetricMeta{RateType: metadata.Gauge,
 			Unit: metadata.StatusCode,
 			Desc: "The layer5-7 code, if available.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "check_duration",
 		MetricMeta: MetricMeta{RateType: metadata.Gauge,
 			Unit: metadata.MilliSecond,
 			Desc: "The time in ms it took to finish last health check.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "hrsp_1xx",
 		//These are transformed and aggregated: 1xx, 2xx, etc will be a tag.
 	},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "hrsp_2xx",
 	},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "hrsp_3xx",
 	},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "hrsp_4xx",
 	},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "hrsp_5xx",
 	},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "hrsp_other",
 	},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "hanafail",
 		// The docs just say "failed health check details", so skipping this
 		// for now
 	},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "req_rate",
 		// Not needed since data store can derive the rate from req_tot
 	},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "req_rate_max",
 		MetricMeta: MetricMeta{RateType: metadata.Gauge,
 			Unit: metadata.Request,
 			Desc: "The max number of HTTP requests per second observed.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "req_tot",
 		MetricMeta: MetricMeta{RateType: metadata.Counter,
 			Unit: metadata.Request,
 			Desc: "The number of HTTP requests recieved.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "cli_abrt",
 		MetricMeta: MetricMeta{RateType: metadata.Counter,
 			Unit: metadata.Abort,
 			Desc: "The number of data transfers aborted by the client.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "srv_abrt",
 		MetricMeta: MetricMeta{RateType: metadata.Counter,
 			Unit: metadata.Abort,
 			Desc: "The number of data transfers aborted by the server.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "comp_in",
 		MetricMeta: MetricMeta{RateType: metadata.Counter,
 			Unit: metadata.Bytes,
 			Desc: "The number of HTTP response bytes fed to the compressor.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "comp_out",
 		MetricMeta: MetricMeta{RateType: metadata.Counter,
 			Unit: metadata.Bytes,
 			Desc: "The number of HTTP response bytes emitted by the compressor.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "comp_byp",
 		MetricMeta: MetricMeta{RateType: metadata.Counter,
 			Unit: metadata.Bytes,
 			Desc: "The number of bytes that bypassed the HTTP compressor (CPU/BW limit).",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "comp_rsp",
 		MetricMeta: MetricMeta{RateType: metadata.Counter,
 			Unit: metadata.Response,
 			Desc: "The number of HTTP responses that were compressed.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "lastsess",
 		MetricMeta: MetricMeta{RateType: metadata.Gauge,
 			Unit: metadata.Second,
 			Desc: "The number of seconds since last session assigned to server/backend.",
 		}},
-	MetricMetaName{
-		Name: "last_chk",
+	MetricMetaHAProxy{
+		Name:   "last_chk",
+		Ignore: true,
 		// Not a series or tag so skipping this.
 	},
-	MetricMetaName{
-		Name: "last_agt",
+	MetricMetaHAProxy{
+		Name:   "last_agt",
+		Ignore: true,
 		// Not a series or tag so skipping this.
 	},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "qtime",
 		MetricMeta: MetricMeta{RateType: metadata.Gauge,
 			Unit: metadata.MilliSecond,
 			Desc: "The average queue time in ms over the 1024 last requests.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "ctime",
 		MetricMeta: MetricMeta{RateType: metadata.Gauge,
 			Unit: metadata.MilliSecond,
 			Desc: "The average connect time in ms over the 1024 last requests.",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "rtime",
 		MetricMeta: MetricMeta{RateType: metadata.Gauge,
 			Unit: metadata.MilliSecond,
 			Desc: "The average response time in ms over the 1024 last requests (0 for TCP).",
 		}},
-	MetricMetaName{
+	MetricMetaHAProxy{
 		Name: "ttime",
 		MetricMeta: MetricMeta{RateType: metadata.Gauge,
 			Unit: metadata.MilliSecond,

--- a/cmd/scollector/main.go
+++ b/cmd/scollector/main.go
@@ -39,7 +39,6 @@ var (
 	flagBatchSize       = flag.Int("b", 0, "OpenTSDB batch size. Used for debugging bad data.")
 	flagSNMP            = flag.String("s", "", "SNMP host to poll of the format: \"community@host[,community@host...]\".")
 	flagICMP            = flag.String("i", "", "ICMP host to ping of the format: \"host[,host...]\".")
-	flagHAProxy         = flag.String("haproxy", "", `haproxy host to poll of the format: "user:password@host[,user:password@host...]".`)
 	flagVsphere         = flag.String("v", "", `vSphere host to poll of the format: "user:password@host[,user:password@host...]".`)
 	flagFake            = flag.Int("fake", 0, "Generates X fake data points on the test.fake metric per second.")
 	flagDebug           = flag.Bool("d", false, "Enables debug output.")
@@ -109,7 +108,21 @@ func readConf() {
 		case "icmp":
 			f(flagICMP)
 		case "haproxy":
-			f(flagHAProxy)
+			if v != "" {
+				for _, s := range strings.Split(v, ",") {
+					sp := strings.SplitN(s, ":", 2)
+					if len(sp) != 2 {
+						slog.Fatal("invalid haproxy string:", v)
+					}
+					user := sp[0]
+					pwd := sp[1]
+					collectors.HAProxy(user, pwd)
+				}
+			}
+		case "haproxy_instance":
+			if err := collectors.AddHAProxyInstance(v); err != nil {
+				slog.Fatal(err)
+			}
 		case "tags":
 			f(flagTags)
 		case "aws":
@@ -200,25 +213,6 @@ func main() {
 				slog.Fatal("invalid AWS string:", *flagAWS)
 			}
 			collectors.AWS(accessKey, secretKey, region)
-		}
-	}
-	if *flagHAProxy != "" {
-		for _, s := range strings.Split(*flagHAProxy, ",") {
-			sp := strings.SplitN(s, ":", 2)
-			if len(sp) != 2 {
-				slog.Fatal("invalid haproxy string:", *flagHAProxy)
-			}
-			user := sp[0]
-			idx := strings.LastIndex(sp[1], "@")
-			if idx == -1 {
-				slog.Fatal("invalid haproxy string:", *flagHAProxy)
-			}
-			pwd := sp[1][:idx]
-			url := sp[1][idx+1:]
-			if len(url) == 0 {
-				slog.Fatal("invalid haproxy string:", *flagHAProxy)
-			}
-			collectors.HAProxy(user, pwd, url)
 		}
 	}
 	if *flagVsphere != "" {

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -37,11 +37,13 @@ const (
 	None           Unit = ""
 	A                   = "A" // Amps
 	Alert               = "alerts"
+	Abort               = "aborts"
 	Bool                = "bool"
 	BitsPerSecond       = "bits per second"
 	Bytes               = "bytes"
 	BytesPerSecond      = "bytes per second"
 	C                   = "C" // Celsius
+	Check               = "checks"
 	CHz                 = "CentiHertz"
 	Connection          = "connections"
 	Context             = "contexts"
@@ -74,20 +76,28 @@ const (
 	Process             = "processes"
 	Priority            = "priority"
 	Query               = "queries"
+	Redispatch          = "redispatches"
 	Refresh             = "refreshes"
 	Replica             = "replicas"
+	Retry               = "retries"
+	Response            = "responses"
+	Request             = "requests"
 	RPM                 = "RPM" // Rotations per minute.
 	Second              = "seconds"
 	Segment             = "segments"
+	Server              = "servers"
+	Session             = "sessions"
 	Shard               = "shards"
 	Socket              = "sockets"
 	Suggest             = "suggests"
 	StatusCode          = "status code"
 	Syscall             = "system calls"
 	Thread              = "threads"
+	Transition          = "transitions"
 	V                   = "V" // Volts
 	V10                 = "tenth-Volts"
 	Watt                = "Watts"
+	Weight              = "weight"
 	Yield               = "yields"
 )
 


### PR DESCRIPTION
Much of this code is from @kylebrandt, however I have done despicable things to it under the guise of "finishing" it.

I've modeled much of the multiple-fetch off of processes_linux. The config file will look something like the following:

```
haproxy = username:password
haproxy_instance = 1:http://lb01:7001/haproxy;csv
haproxy_instance = 2:http://lb01:7002/haproxy;csv
```

Splitting the instances up is primarily to improve readability and prevent very long lines.

This original code made some assumptions regarding haproxy layout, and I've furthered piled on more assumptions leading to a very assumptive tower of pancakes. The assumptions are as follows:

1. haproxy stats will always be secured with user/pass HTTP auth.
1. Multiple haproxy instances on one server are tagged as 'tiers', a bit of a misnomer in almost all cases (but existing terminology in ours).
1. A single set of credentials is used for all haproxy instances running. This is designed this way primarily to prevent repeating the credentials over and over, and also to make most of the config file viewable after it has been blackboxed.
1. If you have an 'haproxy' config line, you'll also have at least one 'haproxy_instance' config line.


As a side note, another reason I discarded @kylebrandt's config line method is that we cannot guarantee what characters may exist in the password, and as such a credential line can be a bit scary to parse (unless you use a connection-string like format).

So, there you have it. Let the code evisceration commence.

:eyeglasses: @kylebrandt  @mjibson 