### PR TITLE
cmd/bosun: move more state mutation into RunHistory

### DIFF
--- a/cmd/bosun/sched/sched_test.go
+++ b/cmd/bosun/sched/sched_test.go
@@ -251,7 +251,7 @@ func TestError_To_Unknown(t *testing.T) {
 			ak: state,
 		},
 	})
-	st := s.Status(expr.AlertKey(ak))
+	st := s.GetStatus(expr.AlertKey(ak))
 	if st.Status() != StError {
 		t.Errorf("Expected status to be %s but was %s", StError, st.Status())
 	}

--- a/cmd/bosun/web/expr.go
+++ b/cmd/bosun/web/expr.go
@@ -131,14 +131,14 @@ func procRule(t miniprofiler.Timer, c *conf.Conf, a *conf.Alert, now time.Time, 
 			}
 			for _, ak := range keys {
 				if ak.Group().Subset(ts) {
-					instance = s.Status(ak)
+					instance = s.GetOrCreateStatus(ak)
 					instance.History = []sched.Event{*rh.Events[ak]}
 					break
 				}
 			}
 		}
 		if instance == nil {
-			instance = s.Status(keys[0])
+			instance = s.GetOrCreateStatus(keys[0])
 			instance.History = []sched.Event{*rh.Events[keys[0]]}
 			if template_group != "" {
 				warning = append(warning, fmt.Sprintf("template group %s was not a subset of any result", template_group))

--- a/cmd/bosun/web/web.go
+++ b/cmd/bosun/web/web.go
@@ -336,7 +336,7 @@ func Status(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (inter
 		if err != nil {
 			return nil, err
 		}
-		st := ExtStatus{State: schedule.Status(ak)}
+		st := ExtStatus{State: schedule.GetStatus(ak)}
 		if st.State == nil {
 			return nil, fmt.Errorf("unknown alert key: %v", k)
 		}


### PR DESCRIPTION
Currently GetOrCreateStatus (only used in the web package) is the only
known place outside of RunHistory where state is mutated. This change moves
things like Touched and Result mutation into RunHistory.

This should prevent the recent panics because now the web package won't
create alert keys that shouldn't exist.