### PR TITLE
cmd/bosun: Ensure web instances have their result set

### DIFF
--- a/cmd/bosun/web/expr.go
+++ b/cmd/bosun/web/expr.go
@@ -144,6 +144,13 @@ func procRule(t miniprofiler.Timer, c *conf.Conf, a *conf.Alert, now time.Time, 
 				warning = append(warning, fmt.Sprintf("template group %s was not a subset of any result", template_group))
 			}
 		}
+		if e := instance.History[0]; e.Error != nil {
+			instance.Result = e.Error
+		} else if e.Crit != nil {
+			instance.Result = e.Crit
+		} else if e.Warn != nil {
+			instance.Result = e.Warn
+		}
 		var b_err, s_err error
 		func() {
 			defer func() {

--- a/cmd/bosun/web/web_test.go
+++ b/cmd/bosun/web/web_test.go
@@ -1,0 +1,27 @@
+package web
+
+import (
+	"testing"
+	"time"
+
+	"bosun.org/cmd/bosun/conf"
+)
+
+func TestErrorTemplate(t *testing.T) {
+	c, err := conf.New("", `
+		template t {
+			body = {{.Eval "invalid"}}
+		}
+		alert a {
+			template = t
+			crit = 1
+		}
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = procRule(nil, c, c.Alerts["a"], time.Time{}, false, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Fixes a recent panic. Correct fix would be to refactor the web package to
use RunHistory, which already handled this correctly.