### PR TITLE
Adding dash to the metric-name regex

### DIFF
--- a/opentsdb/tsdb.go
+++ b/opentsdb/tsdb.go
@@ -376,7 +376,7 @@ func ParseRequest(req string) (*Request, error) {
 	return &r, nil
 }
 
-var qRE = regexp.MustCompile(`^(\w+):(?:(\w+-\w+):)?(?:(rate.*):)?([\w./]+)(?:\{([\w./,=*-|]+)\})?$`)
+var qRE = regexp.MustCompile(`^(\w+):(?:(\w+-\w+):)?(?:(rate.*):)?([\w./-]+)(?:\{([\w./,=*-|]+)\})?$`)
 
 // ParseQuery parses OpenTSDB queries of the form: avg:rate:cpu{k=v}. Validation
 // errors will be returned along with a valid Query.


### PR DESCRIPTION
Fixes #876