### PR TITLE
more useful graphite errors

### DIFF
--- a/cmd/bosun/web/static/partials/rule.html
+++ b/cmd/bosun/web/static/partials/rule.html
@@ -95,7 +95,7 @@
 </div>
 <div class="row" ng-show="error">
 	<div class="col-lg-12">
-		<div class="alert alert-danger" ng-bind="error"></div>
+		<pre class="alert alert-danger" ng-bind="error" style="white-space: pre-wrap;"></pre>
 	</div>
 </div>
 <div class="row" ng-show="warning.length > 0">


### PR DESCRIPTION
* make errors clearer in the web ui (shows request url and more information about what went wrong)
* print more details to log. in particular, the response body with graphite stacktrace:

```
2015/04/08 18:10:12 bosun web listening on: :8070
2015/04/08 18:10:12 tsdb host: 
2015/04/08 18:10:18 error: funcs.go:351: graphite: Get(http://graphite/render/?format=json&from=1428271818&target=divideSeries%28stats.gauges.stats_buffer_space_mb.%2A._data_s3%2A%29&until=1428531018) failed: got statuscode 500 INTERNAL SERVER ERROR
===================================================
<body style="background-color: #666666; color: black;">
<center>
<h2 style='font-family: "Arial"'>
<p>Graphite encountered an unexpected error while handling your request.</p>
<p>Please contact your site administrator if the problem persists.</p>
</h2>
<br/>
<div style="width: 50%; text-align: center; font-family: monospace; background-color: black; font-weight: bold; color: #ff4422;">

</div>

<div style="width: 70%; text-align: left; background-color: black; color: #44ff22; border: thin solid gray;">
<pre>
Traceback (most recent call last):
  File &quot;/usr/lib/python2.6/site-packages/django/core/handlers/base.py&quot;, line 109, in get_response
    response = callback(request, *callback_args, **callback_kwargs)
  File &quot;/usr/lib/python2.6/site-packages/graphite/render/views.py&quot;, line 107, in renderView
    seriesList = evaluateTarget(requestContext, target)
  File &quot;/usr/lib/python2.6/site-packages/graphite/render/evaluator.py&quot;, line 10, in evaluateTarget
    result = evaluateTokens(requestContext, tokens)
  File &quot;/usr/lib/python2.6/site-packages/graphite/render/evaluator.py&quot;, line 21, in evaluateTokens
    return evaluateTokens(requestContext, tokens.expression)
  File &quot;/usr/lib/python2.6/site-packages/graphite/render/evaluator.py&quot;, line 29, in evaluateTokens
    return func(requestContext, *args)
TypeError: divideSeries() takes exactly 3 arguments (2 given)

</pre>
</div>

</center>

===================================================
2015/04/08 18:10:18 graphite: Get(http://graphite/render/?format=json&from=1428271818&target=divideSeries%28stats.gauges.stats_buffer_space_mb.%2A._data_s3%2A%29&until=1428531018) failed: got statuscode 500 INTERNAL SERVER ERROR
2015/04/08 18:10:22 wrote metrictags: 86.00B
2015/04/08 18:10:22 wrote notifications: 48.00B
```
note:
* the error actually gets logged twice. we should probably fix this, not sure what's the best approach
* it seems overkill to use graphite.Error for those errors where there's no body to show. i'm planning to make those regular errors again.
* couldn't find an elegant way to strip html tags out. (see http://grokbase.com/t/gg/golang-nuts/13ckt90wpg/go-nuts-export-striptags-in-html-template). I could maybe try https://godoc.org/golang.org/x/net/html but that looks quite complicated too