### PR TITLE
Use TCP to insert data into OpenTSDB along with HTTP

### DIFF
--- a/cmd/scollector/main.go
+++ b/cmd/scollector/main.go
@@ -150,7 +150,7 @@ func readConf() {
 
 func main() {
 	flag.Parse()
-	if *flagPrint || *flagDebug  {
+	if *flagPrint || *flagDebug {
 		slog.Set(&slog.StdLog{Log: log.New(os.Stdout, "", log.LstdFlags)})
 	}
 	if *flagVersion {

--- a/cmd/scollector/main.go
+++ b/cmd/scollector/main.go
@@ -34,7 +34,7 @@ var (
 	flagFilter          = flag.String("f", "", "Filters collectors matching this term, multiple terms separated by comma. Works with all other arguments.")
 	flagList            = flag.Bool("l", false, "List available collectors.")
 	flagPrint           = flag.Bool("p", false, "Print to screen instead of sending to a host")
-	flagTCP             = flag.Bool("tcp", false, "Use TCP instead of HTTP")
+	flagTelnet          = flag.Bool("telnet", false, "Use telnet instead of HTTP")
 	flagHost            = flag.String("h", "", `Bosun or OpenTSDB host. Ex: "http://bosun.example.com:8070".`)
 	flagColDir          = flag.String("c", "", `External collectors directory.`)
 	flagBatchSize       = flag.Int("b", 0, "OpenTSDB batch size. Used for debugging bad data.")
@@ -271,9 +271,8 @@ func main() {
 	if *flagPrint {
 		collect.Print = true
 	}
-
-	if *flagTCP {
-		collect.TCP = true
+	if *flagTelnet {
+		collect.Telnet = true
 	}
 	if !*flagDisableMetadata {
 		if err := metadata.Init(u, *flagDebug); err != nil {

--- a/cmd/scollector/main.go
+++ b/cmd/scollector/main.go
@@ -49,7 +49,7 @@ var (
 	flagVersion         = flag.Bool("version", false, "Prints the version and exits.")
 	flagDisableDefault  = flag.Bool("n", false, "Disable sending of scollector self metrics.")
 	flagHostname        = flag.String("hostname", "", "If set, use as value of host tag instead of system hostname.")
-	flagFreq            = flag.String("freq", "15", "Set the default frequency in seconds for most collectors.")
+	flagFreq            = flag.String("freq", "", "Set the default frequency in seconds for most collectors.")
 	flagConf            = flag.String("conf", "", "Location of configuration file. Defaults to scollector.conf in directory of the scollector executable.")
 	flagAWS             = flag.String("aws", "", `AWS keys and region, format: "access_key:secret_key@region".`)
 
@@ -150,7 +150,7 @@ func readConf() {
 
 func main() {
 	flag.Parse()
-	if *flagPrint || *flagDebug {
+	if *flagPrint || *flagDebug || *flagHTTP {
 		slog.Set(&slog.StdLog{Log: log.New(os.Stdout, "", log.LstdFlags)})
 	}
 	if *flagVersion {
@@ -271,9 +271,10 @@ func main() {
 	if *flagPrint {
 		collect.Print = true
 	}
+
 	if *flagTCP {
 		collect.TCP = true
-	}
+
 	if !*flagDisableMetadata {
 		if err := metadata.Init(u, *flagDebug); err != nil {
 			slog.Fatal(err)

--- a/cmd/scollector/main.go
+++ b/cmd/scollector/main.go
@@ -34,6 +34,7 @@ var (
 	flagFilter          = flag.String("f", "", "Filters collectors matching this term, multiple terms separated by comma. Works with all other arguments.")
 	flagList            = flag.Bool("l", false, "List available collectors.")
 	flagPrint           = flag.Bool("p", false, "Print to screen instead of sending to a host")
+	flagHTTP            = flag.Bool("http", false, "Use HTTP instead of TCP")
 	flagHost            = flag.String("h", "", `Bosun or OpenTSDB host. Ex: "http://bosun.example.com:8070".`)
 	flagColDir          = flag.String("c", "", `External collectors directory.`)
 	flagBatchSize       = flag.Int("b", 0, "OpenTSDB batch size. Used for debugging bad data.")
@@ -48,7 +49,7 @@ var (
 	flagVersion         = flag.Bool("version", false, "Prints the version and exits.")
 	flagDisableDefault  = flag.Bool("n", false, "Disable sending of scollector self metrics.")
 	flagHostname        = flag.String("hostname", "", "If set, use as value of host tag instead of system hostname.")
-	flagFreq            = flag.String("freq", "15", "Set the default frequency in seconds for most collectors.")
+	flagFreq            = flag.String("freq", "", "Set the default frequency in seconds for most collectors.")
 	flagConf            = flag.String("conf", "", "Location of configuration file. Defaults to scollector.conf in directory of the scollector executable.")
 	flagAWS             = flag.String("aws", "", `AWS keys and region, format: "access_key:secret_key@region".`)
 
@@ -149,7 +150,7 @@ func readConf() {
 
 func main() {
 	flag.Parse()
-	if *flagPrint || *flagDebug {
+	if *flagPrint || *flagDebug || *flagHTTP {
 		slog.Set(&slog.StdLog{Log: log.New(os.Stdout, "", log.LstdFlags)})
 	}
 	if *flagVersion {
@@ -269,6 +270,9 @@ func main() {
 	collect.Tags = opentsdb.TagSet{"os": runtime.GOOS}
 	if *flagPrint {
 		collect.Print = true
+	}
+	if *flagHTTP {
+		collect.HTTP = true
 	}
 	if !*flagDisableMetadata {
 		if err := metadata.Init(u, *flagDebug); err != nil {

--- a/cmd/scollector/main.go
+++ b/cmd/scollector/main.go
@@ -34,7 +34,7 @@ var (
 	flagFilter          = flag.String("f", "", "Filters collectors matching this term, multiple terms separated by comma. Works with all other arguments.")
 	flagList            = flag.Bool("l", false, "List available collectors.")
 	flagPrint           = flag.Bool("p", false, "Print to screen instead of sending to a host")
-	flagHTTP            = flag.Bool("http", false, "Use HTTP instead of TCP")
+	flagTCP             = flag.Bool("tcp", false, "Use TCP instead of HTTP")
 	flagHost            = flag.String("h", "", `Bosun or OpenTSDB host. Ex: "http://bosun.example.com:8070".`)
 	flagColDir          = flag.String("c", "", `External collectors directory.`)
 	flagBatchSize       = flag.Int("b", 0, "OpenTSDB batch size. Used for debugging bad data.")
@@ -49,7 +49,7 @@ var (
 	flagVersion         = flag.Bool("version", false, "Prints the version and exits.")
 	flagDisableDefault  = flag.Bool("n", false, "Disable sending of scollector self metrics.")
 	flagHostname        = flag.String("hostname", "", "If set, use as value of host tag instead of system hostname.")
-	flagFreq            = flag.String("freq", "", "Set the default frequency in seconds for most collectors.")
+	flagFreq            = flag.String("freq", "15", "Set the default frequency in seconds for most collectors.")
 	flagConf            = flag.String("conf", "", "Location of configuration file. Defaults to scollector.conf in directory of the scollector executable.")
 	flagAWS             = flag.String("aws", "", `AWS keys and region, format: "access_key:secret_key@region".`)
 
@@ -150,7 +150,7 @@ func readConf() {
 
 func main() {
 	flag.Parse()
-	if *flagPrint || *flagDebug || *flagHTTP {
+	if *flagPrint || *flagDebug  {
 		slog.Set(&slog.StdLog{Log: log.New(os.Stdout, "", log.LstdFlags)})
 	}
 	if *flagVersion {
@@ -271,8 +271,8 @@ func main() {
 	if *flagPrint {
 		collect.Print = true
 	}
-	if *flagHTTP {
-		collect.HTTP = true
+	if *flagTCP {
+		collect.TCP = true
 	}
 	if !*flagDisableMetadata {
 		if err := metadata.Init(u, *flagDebug); err != nil {

--- a/cmd/scollector/main.go
+++ b/cmd/scollector/main.go
@@ -49,7 +49,7 @@ var (
 	flagVersion         = flag.Bool("version", false, "Prints the version and exits.")
 	flagDisableDefault  = flag.Bool("n", false, "Disable sending of scollector self metrics.")
 	flagHostname        = flag.String("hostname", "", "If set, use as value of host tag instead of system hostname.")
-	flagFreq            = flag.String("freq", "", "Set the default frequency in seconds for most collectors.")
+	flagFreq            = flag.String("freq", "15", "Set the default frequency in seconds for most collectors.")
 	flagConf            = flag.String("conf", "", "Location of configuration file. Defaults to scollector.conf in directory of the scollector executable.")
 	flagAWS             = flag.String("aws", "", `AWS keys and region, format: "access_key:secret_key@region".`)
 
@@ -150,7 +150,7 @@ func readConf() {
 
 func main() {
 	flag.Parse()
-	if *flagPrint || *flagDebug || *flagHTTP {
+	if *flagPrint || *flagDebug  {
 		slog.Set(&slog.StdLog{Log: log.New(os.Stdout, "", log.LstdFlags)})
 	}
 	if *flagVersion {
@@ -274,7 +274,7 @@ func main() {
 
 	if *flagTCP {
 		collect.TCP = true
-
+	}
 	if !*flagDisableMetadata {
 		if err := metadata.Init(u, *flagDebug); err != nil {
 			slog.Fatal(err)

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -36,8 +36,8 @@ var (
 	// Print prints all datapoints to stdout instead of sending them.
 	Print = false
 
-	// Use TCP instead of HTTP.
-	TCP = false
+	// Use Telnet instead of HTTP.
+	Telnet = false
 
 	// DisableDefaultCollectors prevents the scollector self metrics from being
 	// generated.
@@ -61,7 +61,7 @@ var (
 	counters            = make(map[string]*addMetric)
 	sets                = make(map[string]*setMetric)
 	puts                = make(map[string]*putMetric)
-	tsdbTCP             string
+	tsdbTelnet             string
 	client              = &http.Client{
 		Transport: &timeoutTransport{Transport: new(http.Transport)},
 		Timeout:   time.Minute,
@@ -111,7 +111,7 @@ func InitChan(tsdbhost *url.URL, root string, ch chan *opentsdb.DataPoint) error
 		u.Host = "localhost" + u.Host
 	}
 	tsdbURL = u.String()
-	tsdbTCP = u.Host
+	tsdbTelnet = u.Host
 	metricRoot = root + "."
 	tchan = ch
 	go queuer()

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -61,7 +61,7 @@ var (
 	counters            = make(map[string]*addMetric)
 	sets                = make(map[string]*setMetric)
 	puts                = make(map[string]*putMetric)
-	tsdbTelnet             string
+	tsdbTelnet          string
 	client              = &http.Client{
 		Transport: &timeoutTransport{Transport: new(http.Transport)},
 		Timeout:   time.Minute,

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -36,6 +36,9 @@ var (
 	// Print prints all datapoints to stdout instead of sending them.
 	Print = false
 
+	// Use HTTP instead of HTTP.
+	HTTP = false
+
 	// DisableDefaultCollectors prevents the scollector self metrics from being
 	// generated.
 	DisableDefaultCollectors = false
@@ -58,6 +61,7 @@ var (
 	counters            = make(map[string]*addMetric)
 	sets                = make(map[string]*setMetric)
 	puts                = make(map[string]*putMetric)
+	tsdbTCP             string
 	client              = &http.Client{
 		Transport: &timeoutTransport{Transport: new(http.Transport)},
 		Timeout:   time.Minute,
@@ -107,6 +111,7 @@ func InitChan(tsdbhost *url.URL, root string, ch chan *opentsdb.DataPoint) error
 		u.Host = "localhost" + u.Host
 	}
 	tsdbURL = u.String()
+	tsdbTCP = u.Host
 	metricRoot = root + "."
 	tchan = ch
 	go queuer()

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -36,8 +36,8 @@ var (
 	// Print prints all datapoints to stdout instead of sending them.
 	Print = false
 
-	// Use HTTP instead of HTTP.
-	HTTP = false
+	// Use TCP instead of HTTP.
+	TCP = false
 
 	// DisableDefaultCollectors prevents the scollector self metrics from being
 	// generated.

--- a/collect/queue.go
+++ b/collect/queue.go
@@ -75,7 +75,7 @@ func sendBatch(batch []json.RawMessage) {
 		conn, err := net.Dial("tcp", tsdbTelnet)
 		if err != nil {
 			slog.Error(err)
-		}else{
+		} else {
 			for _, d := range batch {
 				var dp opentsdb.DataPoint
 				json.Unmarshal(d, &dp)
@@ -106,12 +106,13 @@ func sendBatch(batch []json.RawMessage) {
 				buffer.WriteString(b.String())
 				buffer.WriteString("\n")
 				fmt.Fprintf(conn, buffer.String())
-			}	
+			}
 			d := time.Since(now).Nanoseconds() / 1e6
 			Add("collect.post.total_duration", nil, d)
 			Add("collect.post.count", nil, 1)
 			conn.Close()
 		}
+
 	} else {
 		var buf bytes.Buffer
 		g := gzip.NewWriter(&buf)

--- a/collect/queue.go
+++ b/collect/queue.go
@@ -1,15 +1,17 @@
 package collect
 
 import (
+	"bosun.org/opentsdb"
+	"bosun.org/slog"
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
+	"strconv"
 	"time"
-
-	"bosun.org/opentsdb"
-	"bosun.org/slog"
 )
 
 func queuer() {
@@ -61,6 +63,7 @@ func send() {
 }
 
 func sendBatch(batch []json.RawMessage) {
+	now := time.Now()
 	if Print {
 		for _, d := range batch {
 			slog.Info(string(d))
@@ -68,66 +71,110 @@ func sendBatch(batch []json.RawMessage) {
 		recordSent(len(batch))
 		return
 	}
-	var buf bytes.Buffer
-	g := gzip.NewWriter(&buf)
-	if err := json.NewEncoder(g).Encode(batch); err != nil {
-		slog.Error(err)
-		return
-	}
-	if err := g.Close(); err != nil {
-		slog.Error(err)
-		return
-	}
-	req, err := http.NewRequest("POST", tsdbURL, &buf)
-	if err != nil {
-		slog.Error(err)
-		return
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Content-Encoding", "gzip")
-	now := time.Now()
-	resp, err := client.Do(req)
-	d := time.Since(now).Nanoseconds() / 1e6
-	if err == nil {
-		defer resp.Body.Close()
-	}
-	Add("collect.post.total_duration", Tags, d)
-	Add("collect.post.count", Tags, 1)
-	// Some problem with connecting to the server; retry later.
-	if err != nil || resp.StatusCode != http.StatusNoContent {
+	if Telnet {
+		conn, err := net.Dial("tcp", tsdbTelnet)
 		if err != nil {
-			Add("collect.post.error", Tags, 1)
 			slog.Error(err)
-		} else if resp.StatusCode != http.StatusNoContent {
-			Add("collect.post.bad_status", Tags, 1)
-			slog.Errorln(resp.Status)
-			body, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				slog.Error(err)
-			}
-			if len(body) > 0 {
-				slog.Error(string(body))
-			}
-		}
-		restored := 0
-		for _, msg := range batch {
-			var dp opentsdb.DataPoint
-			if err := json.Unmarshal(msg, &dp); err != nil {
-				slog.Error(err)
-				continue
-			}
-			restored++
-			tchan <- &dp
-		}
-		d := time.Second * 5
-		Add("collect.post.restore", Tags, int64(restored))
-		slog.Infof("restored %d, sleeping %s", restored, d)
-		time.Sleep(d)
-		return
-	}
-	recordSent(len(batch))
-}
+		}else{
+			for _, d := range batch {
+				var dp opentsdb.DataPoint
+				json.Unmarshal(d, &dp)
+				var buffer bytes.Buffer
+				buffer.WriteString("put ")
+				buffer.WriteString(dp.Metric)
+				buffer.WriteString(" ")
+				buffer.WriteString(strconv.FormatInt(dp.Timestamp, 10))
+				buffer.WriteString(" ")
+				str, ok := dp.Value.(float64)
+				if ok {
+					//slog.Debug("Valid Value")
+				}
+				var keys []string
+				for k := range dp.Tags {
+					keys = append(keys, k)
+				}
 
+				b := &bytes.Buffer{}
+				for i, k := range keys {
+					if i > 0 {
+						fmt.Fprint(b, " ")
+					}
+					fmt.Fprintf(b, "%s=%s", k, dp.Tags[k])
+				}
+				buffer.WriteString(strconv.FormatFloat(float64(str), 'f', 2, 32))
+				buffer.WriteString(" ")
+				buffer.WriteString(b.String())
+				buffer.WriteString("\n")
+				fmt.Fprintf(conn, buffer.String())
+			}	
+			d := time.Since(now).Nanoseconds() / 1e6
+			Add("collect.post.total_duration", nil, d)
+			Add("collect.post.count", nil, 1)
+			conn.Close()
+		}
+		
+	} else {
+		var buf bytes.Buffer
+		g := gzip.NewWriter(&buf)
+		if err := json.NewEncoder(g).Encode(batch); err != nil {
+			slog.Error(err)
+			return
+		}
+		if err := g.Close(); err != nil {
+			slog.Error(err)
+			return
+		}
+		req, err := http.NewRequest("POST", tsdbURL, &buf)
+		if err != nil {
+			slog.Error(err)
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Content-Encoding", "gzip")
+		now := time.Now()
+		resp, err := client.Do(req)
+		d := time.Since(now).Nanoseconds() / 1e6
+		if err == nil {
+			defer resp.Body.Close()
+		}
+		Add("collect.post.total_duration", nil, d)
+		Add("collect.post.count", nil, 1)
+		// Some problem with connecting to the server; retry later.
+		if err != nil || resp.StatusCode != http.StatusNoContent {
+			if err != nil {
+				Add("collect.post.error", nil, 1)
+				slog.Error(err)
+			} else if resp.StatusCode != http.StatusNoContent {
+				Add("collect.post.bad_status", nil, 1)
+				slog.Errorln(resp.Status)
+				body, err := ioutil.ReadAll(resp.Body)
+				if err != nil {
+					slog.Error(err)
+				}
+				if len(body) > 0 {
+					slog.Error(string(body))
+				}
+			}
+			restored := 0
+			for _, msg := range batch {
+				var dp opentsdb.DataPoint
+				if err := json.Unmarshal(msg, &dp); err != nil {
+					slog.Error(err)
+					continue
+				}
+				restored++
+				tchan <- &dp
+			}
+			d := time.Second * 5
+			Add("collect.post.restore", nil, int64(restored))
+			slog.Infof("restored %d, sleeping %s", restored, d)
+			time.Sleep(d)
+			return
+		}
+
+		recordSent(len(batch))
+	}
+}
 func recordSent(num int) {
 	if Debug {
 		slog.Infoln("sent", num)

--- a/collect/queue.go
+++ b/collect/queue.go
@@ -112,7 +112,11 @@ func sendBatch(batch []json.RawMessage) {
 			Add("collect.post.count", nil, 1)
 			conn.Close()
 		}
-		
+
+		d := time.Since(now).Nanoseconds() / 1e6
+		Add("collect.post.total_duration", nil, d)
+		Add("collect.post.count", nil, 1)
+		conn.Close()
 	} else {
 		var buf bytes.Buffer
 		g := gzip.NewWriter(&buf)

--- a/collect/queue.go
+++ b/collect/queue.go
@@ -112,11 +112,6 @@ func sendBatch(batch []json.RawMessage) {
 			Add("collect.post.count", nil, 1)
 			conn.Close()
 		}
-
-		d := time.Since(now).Nanoseconds() / 1e6
-		Add("collect.post.total_duration", nil, d)
-		Add("collect.post.count", nil, 1)
-		conn.Close()
 	} else {
 		var buf bytes.Buffer
 		g := gzip.NewWriter(&buf)


### PR DESCRIPTION
Hi Guys

We use OpenTSDB 2.0.1 for our needs and we could not use scollector's HTTP data GZIPed and chunked insertion. So we decided to tweek it to send stats over TCP by default. Also we have modified the code to fetch configurations related to frequency from `scollector.conf`

Please let me know if there are any issues.


