### PR TITLE
collect: Add os tag to scollector.collect.* metrics

### DIFF
--- a/cmd/scollector/main.go
+++ b/cmd/scollector/main.go
@@ -266,6 +266,7 @@ func main() {
 	}
 	collectors.DefaultFreq = time.Second * time.Duration(freq)
 	collect.Freq = time.Second * time.Duration(freq)
+	collect.Tags = opentsdb.TagSet{"os": runtime.GOOS}
 	if *flagPrint {
 		collect.Print = true
 	}

--- a/collect/queue.go
+++ b/collect/queue.go
@@ -91,15 +91,15 @@ func sendBatch(batch []json.RawMessage) {
 	if err == nil {
 		defer resp.Body.Close()
 	}
-	Add("collect.post.total_duration", nil, d)
-	Add("collect.post.count", nil, 1)
+	Add("collect.post.total_duration", Tags, d)
+	Add("collect.post.count", Tags, 1)
 	// Some problem with connecting to the server; retry later.
 	if err != nil || resp.StatusCode != http.StatusNoContent {
 		if err != nil {
-			Add("collect.post.error", nil, 1)
+			Add("collect.post.error", Tags, 1)
 			slog.Error(err)
 		} else if resp.StatusCode != http.StatusNoContent {
-			Add("collect.post.bad_status", nil, 1)
+			Add("collect.post.bad_status", Tags, 1)
 			slog.Errorln(resp.Status)
 			body, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
@@ -120,7 +120,7 @@ func sendBatch(batch []json.RawMessage) {
 			tchan <- &dp
 		}
 		d := time.Second * 5
-		Add("collect.post.restore", nil, int64(restored))
+		Add("collect.post.restore", Tags, int64(restored))
 		slog.Infof("restored %d, sleeping %s", restored, d)
 		time.Sleep(d)
 		return


### PR DESCRIPTION
I'd also like to add metadata to these metrics but not sure exactly where to do that. I assume they can just use a goroutine to send the metric metadata every hour, or whatever our current design is.