### PR TITLE
prevent "use of closed network connection" in graphite GET's

### DIFF
--- a/graphite/graphite.go
+++ b/graphite/graphite.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -100,6 +101,15 @@ func readTraceback(resp *http.Response) (*[]string, error) {
 // DefaultClient is the default HTTP client for requests.
 var DefaultClient = &http.Client{
 	Timeout: time.Minute,
+	Transport: &http.Transport{
+		MaxIdleConnsPerHost: 0,
+		Proxy:               http.ProxyFromEnvironment,
+		Dial: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout: 10 * time.Second,
+	},
 }
 
 // Context is the interface for querying a Graphite server.


### PR DESCRIPTION
I would sometimes see errors like:
graphiteBand: graphite RequestError (http://....): Get failed: Get
http://... : read tcp 10.90.128.100:80: use of closed network connection

This kind of error is not something that should bubble up to the caller
of a http client library, but it does.
see also:
https://github.com/golang/go/issues/8946
https://github.com/golang/go/issues/9424

there's a bunch more issues about the broken state of error handling in
net/http.
So anyway the http client tries to reuse an existing connection which
has broken.  Somehow this is the caller's problem, so we address it by
not keeping any idle connection and opening a new connection each time.
This should get rid of these errors without adding much overhead.

Note that the used http transport is, other than the
MaxIdleConnsPerHost setting, the same as the default transport.