### PR TITLE
go get -u for esc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,5 @@ install:
   - export GOPATH=$HOME/gopath #Fix gopath. Original has trailing :
   - chmod +x $GOPATH/src/bosun.org/build/validate.sh
   - go get golang.org/x/tools/cmd/vet
-  - go get github.com/mjibson/esc
 
 script: $GOPATH/src/bosun.org/build/validate.sh

--- a/build/validate.sh
+++ b/build/validate.sh
@@ -15,6 +15,9 @@ echo -e "\nRunning go vet bosun.org/..."
 go vet bosun.org/...
 GOVETRESULT=$?
 
+echo -e "\nGetting esc"
+go get -u -v github.com/mjibson/esc
+
 echo -e "\nRunning go generate bosun.org/..."
 go generate bosun.org/...
 GOGENERATERESULT=$?

--- a/cmd/bosun/web/static.go
+++ b/cmd/bosun/web/static.go
@@ -126,7 +126,6 @@ func FS(useLocal bool) http.FileSystem {
 	return _esc_static
 }
 
-
 // FSByte returns the named file from the embedded assets. If useLocal is
 // true, the filesystem's contents are instead used.
 func FSByte(useLocal bool, name string) ([]byte, error) {


### PR DESCRIPTION
This should help alleviate the problem where a local version of esc is older than current. Travis always uses latest.

With this running validate.sh locally should update esc and make sure the output matches.