### PR TITLE
Improve/extend support for graphite resultsets without format spec

### DIFF
--- a/cmd/bosun/expr/funcs.go
+++ b/cmd/bosun/expr/funcs.go
@@ -354,15 +354,19 @@ func parseGraphiteResponse(req *graphite.Request, s *graphite.Response, formatTa
 	results := make([]*Result, 0)
 	for _, res := range *s {
 		// build tag set
-		nodes := strings.Split(res.Target, ".")
-		if len(nodes) < len(formatTags) {
-			msg := fmt.Sprintf("returned target '%s' does not match format '%s'", res.Target, strings.Join(formatTags, ","))
-			return nil, fmt.Errorf(parseErrFmt, req.URL, msg)
-		}
 		tags := make(opentsdb.TagSet)
-		for i, key := range formatTags {
-			if len(key) > 0 {
-				tags[key] = nodes[i]
+		if len(formatTags) == 1 && formatTags[0] == "" {
+			tags["key"] = res.Target
+		} else {
+			nodes := strings.Split(res.Target, ".")
+			if len(nodes) < len(formatTags) {
+				msg := fmt.Sprintf("returned target '%s' does not match format '%s'", res.Target, strings.Join(formatTags, ","))
+				return nil, fmt.Errorf(parseErrFmt, req.URL, msg)
+			}
+			for i, key := range formatTags {
+				if len(key) > 0 {
+					tags[key] = nodes[i]
+				}
 			}
 		}
 		if ts := tags.String(); !seen[ts] {


### PR DESCRIPTION
Graphite is a tag-less system by design.
We can parse out tags ad hocs via the current method of passing in a
parse format at query time, but sometimes this is just too cumbersome.
Sometimes we just want to query graphite and have each series identified
by its key, without worrying about constructing a parse format, which
may not always make sense anyway (not all words cleanly correspond to
tags), especially in automated systems (such as Grafana alerting)
where we just want to query for graphite
metric id's and don't have connotation of tags to begin with.

Currently you can pass "" as format and:
* it works if 1 series was returned (it just creates an empty tag group),
* multiple series however result in the
`More than 1 series identified by tagset '{}'` error.

This patch improves and extends the concept for multiple series:

* improves because now we get a tagset with 1 tag: key=<full-graphite-key>
* extends because series are now uniquely identified and won't clash