### PR TITLE
Providing endpoint to backup state file.

### DIFF
--- a/cmd/bosun/sched/bolt.go
+++ b/cmd/bosun/sched/bolt.go
@@ -285,3 +285,15 @@ func (s *Schedule) LoadTempConfig(hash string) (text string, err error) {
 	go s.SaveTempConfig(config.Text) //refresh timestamp.
 	return config.Text, nil
 }
+
+func (s *Schedule) GetStateFileBackup() ([]byte, error) {
+	buf := bytes.Buffer{}
+	err := s.db.View(func(tx *bolt.Tx) error {
+		_, err := tx.WriteTo(&buf)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/cmd/bosun/web/web.go
+++ b/cmd/bosun/web/web.go
@@ -79,6 +79,7 @@ func Listen(listenAddr string, devMode bool, tsdbHost string) error {
 	router.HandleFunc("/api/", APIRedirect)
 	router.Handle("/api/action", JSON(Action))
 	router.Handle("/api/alerts", JSON(Alerts))
+	router.Handle("/api/backup", JSON(Backup))
 	router.Handle("/api/config", miniprofiler.NewHandler(Config))
 	router.Handle("/api/config_test", miniprofiler.NewHandler(ConfigTest))
 	router.Handle("/api/egraph/{bs}.svg", JSON(ExprGraph))
@@ -349,6 +350,15 @@ func MetadataMetrics(t miniprofiler.Timer, w http.ResponseWriter, r *http.Reques
 
 func Alerts(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	return schedule.MarshalGroups(t, r.FormValue("filter"))
+}
+
+func Backup(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (interface{}, error) {
+	data, err := schedule.GetStateFileBackup()
+	if err != nil {
+		return nil, err
+	}
+	_, err = w.Write(data)
+	return nil, err
 }
 
 func IncidentEvents(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (interface{}, error) {


### PR DESCRIPTION
Because bosun maintains a file lock on the state file, a simple solution for backups is for bosun itself to be able to backup its own state file.

A GET request to /api/backup will stream the state file over the web request.

`curl bosunserver/api/backup > mybackup-timestamp.state` is all that is needed.