### PR TITLE
cmd/bosun: Inline css in emails

### DIFF
--- a/_third_party/github.com/PuerkitoBio/goquery/LICENSE
+++ b/_third_party/github.com/PuerkitoBio/goquery/LICENSE
@@ -1,0 +1,12 @@
+Copyright (c) 2012-2014, Martin Angers & Contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+* Neither the name of the author nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/_third_party/github.com/PuerkitoBio/goquery/README.md
+++ b/_third_party/github.com/PuerkitoBio/goquery/README.md
@@ -1,0 +1,113 @@
+# goquery - a little like that j-thing, only in Go
+
+[![build status](https://secure.travis-ci.org/PuerkitoBio/goquery.png)](http://travis-ci.org/PuerkitoBio/goquery)
+
+[![GoDoc](https://godoc.org/github.com/PuerkitoBio/goquery?status.png)](http://godoc.org/github.com/PuerkitoBio/goquery)
+
+goquery brings a syntax and a set of features similar to [jQuery][] to the [Go language][go]. It is based on Go's [net/html package][html] and the CSS Selector library [cascadia][]. Since the net/html parser returns nodes, and not a full-featured DOM tree, jQuery's stateful manipulation functions (like height(), css(), detach()) have been left off.
+
+Also, because the net/html parser requires UTF-8 encoding, so does goquery: it is the caller's responsibility to ensure that the source document provides UTF-8 encoded HTML. See the [wiki][] for various options to do this.
+
+Syntax-wise, it is as close as possible to jQuery, with the same function names when possible, and that warm and fuzzy chainable interface. jQuery being the ultra-popular library that it is, I felt that writing a similar HTML-manipulating library was better to follow its API than to start anew (in the same spirit as Go's `fmt` package), even though some of its methods are less than intuitive (looking at you, [index()][index]...).
+
+## Installation
+
+Please note that because of the net/html dependency, goquery requires Go1.1+.
+
+    $ go get github.com/PuerkitoBio/goquery
+
+(optional) To run unit tests:
+    
+    $ cd $GOPATH/src/github.com/PuerkitoBio/goquery
+    $ go test
+
+(optional) To run benchmarks (warning: it runs for a few minutes):
+
+    $ cd $GOPATH/src/github.com/PuerkitoBio/goquery
+    $ go test -bench=".*"
+
+## Changelog
+
+**Note that goquery's API is now stable, and will not break.**
+
+*    **2015-04-20** : Add `AttrOr` helper method to return the attribute's value or a default value if absent. Thanks to [piotrkowalczuk][piotr].
+*    **2015-02-04** : Add more manipulation functions - Prepend* - thanks again to [Andrew Stone][thatguystone].
+*    **2014-11-28** : Add more manipulation functions - ReplaceWith*, Wrap* and Unwrap - thanks again to [Andrew Stone][thatguystone].
+*    **2014-11-07** : Add manipulation functions (thanks to [Andrew Stone][thatguystone]) and `*Matcher` functions, that receive compiled cascadia selectors instead of selector strings, thus avoiding potential panics thrown by goquery via `cascadia.MustCompile` calls. This results in better performance (selectors can be compiled once and reused) and more idiomatic error handling (you can handle cascadia's compilation errors, instead of recovering from panics, which had been bugging me for a long time). Note that the actual type expected is a `Matcher` interface, that `cascadia.Selector` implements. Other matcher implementations could be used.
+*    **2014-11-06** : Change import paths of net/html to golang.org/x/net/html (see https://groups.google.com/forum/#!topic/golang-nuts/eD8dh3T9yyA). Make sure to update your code to use the new import path too when you call goquery with `html.Node`s.
+*    **v0.3.2** : Add `NewDocumentFromReader()` (thanks jweir) which allows creating a goquery document from an io.Reader.
+*    **v0.3.1** : Add `NewDocumentFromResponse()` (thanks assassingj) which allows creating a goquery document from an http response.
+*    **v0.3.0** : Add `EachWithBreak()` which allows to break out of an `Each()` loop by returning false. This function was added instead of changing the existing `Each()` to avoid breaking compatibility.
+*    **v0.2.1** : Make go-getable, now that [go.net/html is Go1.0-compatible][gonet] (thanks to @matrixik for pointing this out).
+*    **v0.2.0** : Add support for negative indices in Slice(). **BREAKING CHANGE** `Document.Root` is removed, `Document` is now a `Selection` itself (a selection of one, the root element, just like `Document.Root` was before). Add jQuery's Closest() method.
+*    **v0.1.1** : Add benchmarks to use as baseline for refactorings, refactor Next...() and Prev...() methods to use the new html package's linked list features (Next/PrevSibling, FirstChild). Good performance boost (40+% in some cases).
+*    **v0.1.0** : Initial release.
+
+## API
+
+goquery exposes two structs, `Document` and `Selection`, and the `Matcher` interface. Unlike jQuery, which is loaded as part of a DOM document, and thus acts on its containing document, goquery doesn't know which HTML document to act upon. So it needs to be told, and that's what the `Document` type is for. It holds the root document node as the initial Selection value to manipulate.
+
+jQuery often has many variants for the same function (no argument, a selector string argument, a jQuery object argument, a DOM element argument, ...). Instead of exposing the same features in goquery as a single method with variadic empty interface arguments, statically-typed signatures are used following this naming convention:
+
+*    When the jQuery equivalent can be called with no argument, it has the same name as jQuery for the no argument signature (e.g.: `Prev()`), and the version with a selector string argument is called `XxxFiltered()` (e.g.: `PrevFiltered()`)
+*    When the jQuery equivalent **requires** one argument, the same name as jQuery is used for the selector string version (e.g.: `Is()`)
+*    The signatures accepting a jQuery object as argument are defined in goquery as `XxxSelection()` and take a `*Selection` object as argument (e.g.: `FilterSelection()`)
+*    The signatures accepting a DOM element as argument in jQuery are defined in goquery as `XxxNodes()` and take a variadic argument of type `*html.Node` (e.g.: `FilterNodes()`)
+*    The signatures accepting a function as argument in jQuery are defined in goquery as `XxxFunction()` and take a function as argument (e.g.: `FilterFunction()`)
+*    The goquery methods that can be called with a selector string have a corresponding version that take a `Matcher` interface and are defined as `XxxMatcher()` (e.g.: `IsMatcher()`)
+
+The complete [godoc reference documentation can be found here][doc].
+
+Please note that Cascadia's selectors do not necessarily match all supported selectors of jQuery (Sizzle). See the [cascadia project][cascadia] for details.
+
+## Examples
+
+See some tips and tricks in the [wiki][].
+
+Taken (and adapted as if executed from outside the goquery package) from example_test.go:
+
+```Go
+package main
+
+import (
+  "fmt"
+  "log"
+
+  "github.com/PuerkitoBio/goquery"
+)
+
+func ExampleScrape() {
+  doc, err := goquery.NewDocument("http://metalsucks.net") 
+  if err != nil {
+    log.Fatal(err)
+  }
+
+  doc.Find(".reviews-wrap article .review-rhs").Each(func(i int, s *goquery.Selection) {
+    band := s.Find("h3").Text()
+    title := s.Find("i").Text()
+    fmt.Printf("Review %d: %s - %s\n", i, band, title)
+  })
+}
+
+func main() {
+  ExampleScrape()
+}
+```
+
+## License
+
+The [BSD 3-Clause license][bsd], the same as the [Go language][golic]. Cascadia's license is [here][caslic].
+
+[jquery]: http://jquery.com/
+[go]: http://golang.org/
+[cascadia]: https://github.com/andybalholm/cascadia
+[bsd]: http://opensource.org/licenses/BSD-3-Clause
+[golic]: http://golang.org/LICENSE
+[caslic]: https://github.com/andybalholm/cascadia/blob/master/LICENSE
+[doc]: http://godoc.org/github.com/PuerkitoBio/goquery
+[index]: http://api.jquery.com/index/
+[gonet]: https://github.com/golang/net/
+[html]: http://godoc.org/golang.org/x/net/html
+[wiki]: https://github.com/PuerkitoBio/goquery/wiki/Tips-and-tricks
+[thatguystone]: https://github.com/thatguystone
+[piotr]: https://github.com/piotrkowalczuk

--- a/_third_party/github.com/PuerkitoBio/goquery/array.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/array.go
@@ -1,0 +1,103 @@
+package goquery
+
+import (
+	"bosun.org/_third_party/golang.org/x/net/html"
+)
+
+// First reduces the set of matched elements to the first in the set.
+// It returns a new Selection object, and an empty Selection object if the
+// the selection is empty.
+func (s *Selection) First() *Selection {
+	return s.Eq(0)
+}
+
+// Last reduces the set of matched elements to the last in the set.
+// It returns a new Selection object, and an empty Selection object if
+// the selection is empty.
+func (s *Selection) Last() *Selection {
+	return s.Eq(-1)
+}
+
+// Eq reduces the set of matched elements to the one at the specified index.
+// If a negative index is given, it counts backwards starting at the end of the
+// set. It returns a new Selection object, and an empty Selection object if the
+// index is invalid.
+func (s *Selection) Eq(index int) *Selection {
+	if index < 0 {
+		index += len(s.Nodes)
+	}
+
+	if index >= len(s.Nodes) || index < 0 {
+		return newEmptySelection(s.document)
+	}
+
+	return s.Slice(index, index+1)
+}
+
+// Slice reduces the set of matched elements to a subset specified by a range
+// of indices.
+func (s *Selection) Slice(start, end int) *Selection {
+	if start < 0 {
+		start += len(s.Nodes)
+	}
+	if end < 0 {
+		end += len(s.Nodes)
+	}
+	return pushStack(s, s.Nodes[start:end])
+}
+
+// Get retrieves the underlying node at the specified index.
+// Get without parameter is not implemented, since the node array is available
+// on the Selection object.
+func (s *Selection) Get(index int) *html.Node {
+	if index < 0 {
+		index += len(s.Nodes) // Negative index gets from the end
+	}
+	return s.Nodes[index]
+}
+
+// Index returns the position of the first element within the Selection object
+// relative to its sibling elements.
+func (s *Selection) Index() int {
+	if len(s.Nodes) > 0 {
+		return newSingleSelection(s.Nodes[0], s.document).PrevAll().Length()
+	}
+	return -1
+}
+
+// IndexSelector returns the position of the first element within the
+// Selection object relative to the elements matched by the selector, or -1 if
+// not found.
+func (s *Selection) IndexSelector(selector string) int {
+	if len(s.Nodes) > 0 {
+		sel := s.document.Find(selector)
+		return indexInSlice(sel.Nodes, s.Nodes[0])
+	}
+	return -1
+}
+
+// IndexMatcher returns the position of the first element within the
+// Selection object relative to the elements matched by the matcher, or -1 if
+// not found.
+func (s *Selection) IndexMatcher(m Matcher) int {
+	if len(s.Nodes) > 0 {
+		sel := s.document.FindMatcher(m)
+		return indexInSlice(sel.Nodes, s.Nodes[0])
+	}
+	return -1
+}
+
+// IndexOfNode returns the position of the specified node within the Selection
+// object, or -1 if not found.
+func (s *Selection) IndexOfNode(node *html.Node) int {
+	return indexInSlice(s.Nodes, node)
+}
+
+// IndexOfSelection returns the position of the first node in the specified
+// Selection object within this Selection object, or -1 if not found.
+func (s *Selection) IndexOfSelection(sel *Selection) int {
+	if sel != nil && len(sel.Nodes) > 0 {
+		return indexInSlice(s.Nodes, sel.Nodes[0])
+	}
+	return -1
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/array_test.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/array_test.go
@@ -1,0 +1,180 @@
+package goquery
+
+import (
+	"testing"
+)
+
+func TestFirst(t *testing.T) {
+	sel := Doc().Find(".pvk-content").First()
+	assertLength(t, sel.Nodes, 1)
+}
+
+func TestFirstEmpty(t *testing.T) {
+	sel := Doc().Find(".pvk-zzcontentzz").First()
+	assertLength(t, sel.Nodes, 0)
+}
+
+func TestFirstRollback(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	sel2 := sel.First().End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestLast(t *testing.T) {
+	sel := Doc().Find(".pvk-content").Last()
+	assertLength(t, sel.Nodes, 1)
+
+	// Should contain Footer
+	foot := Doc().Find(".footer")
+	if !sel.Contains(foot.Nodes[0]) {
+		t.Error("Last .pvk-content should contain .footer.")
+	}
+}
+
+func TestLastEmpty(t *testing.T) {
+	sel := Doc().Find(".pvk-zzcontentzz").Last()
+	assertLength(t, sel.Nodes, 0)
+}
+
+func TestLastRollback(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	sel2 := sel.Last().End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestEq(t *testing.T) {
+	sel := Doc().Find(".pvk-content").Eq(1)
+	assertLength(t, sel.Nodes, 1)
+}
+
+func TestEqNegative(t *testing.T) {
+	sel := Doc().Find(".pvk-content").Eq(-1)
+	assertLength(t, sel.Nodes, 1)
+
+	// Should contain Footer
+	foot := Doc().Find(".footer")
+	if !sel.Contains(foot.Nodes[0]) {
+		t.Error("Index -1 of .pvk-content should contain .footer.")
+	}
+}
+
+func TestEqEmpty(t *testing.T) {
+	sel := Doc().Find("something_random_that_does_not_exists").Eq(0)
+	assertLength(t, sel.Nodes, 0)
+}
+
+func TestEqInvalidPositive(t *testing.T) {
+	sel := Doc().Find(".pvk-content").Eq(3)
+	assertLength(t, sel.Nodes, 0)
+}
+
+func TestEqInvalidNegative(t *testing.T) {
+	sel := Doc().Find(".pvk-content").Eq(-4)
+	assertLength(t, sel.Nodes, 0)
+}
+
+func TestEqRollback(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	sel2 := sel.Eq(1).End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestSlice(t *testing.T) {
+	sel := Doc().Find(".pvk-content").Slice(0, 2)
+
+	assertLength(t, sel.Nodes, 2)
+}
+
+func TestSliceOutOfBounds(t *testing.T) {
+	defer assertPanic(t)
+	Doc().Find(".pvk-content").Slice(2, 12)
+}
+
+func TestNegativeSliceStart(t *testing.T) {
+	sel := Doc().Find(".container-fluid").Slice(-2, 3)
+	assertLength(t, sel.Nodes, 1)
+	assertSelectionIs(t, sel.Eq(0), "#cf3")
+}
+
+func TestNegativeSliceEnd(t *testing.T) {
+	sel := Doc().Find(".container-fluid").Slice(1, -1)
+	assertLength(t, sel.Nodes, 2)
+	assertSelectionIs(t, sel.Eq(0), "#cf2")
+	assertSelectionIs(t, sel.Eq(1), "#cf3")
+}
+
+func TestNegativeSliceBoth(t *testing.T) {
+	sel := Doc().Find(".container-fluid").Slice(-3, -1)
+	assertLength(t, sel.Nodes, 2)
+	assertSelectionIs(t, sel.Eq(0), "#cf2")
+	assertSelectionIs(t, sel.Eq(1), "#cf3")
+}
+
+func TestNegativeSliceOutOfBounds(t *testing.T) {
+	defer assertPanic(t)
+	Doc().Find(".container-fluid").Slice(-12, -7)
+}
+
+func TestSliceRollback(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	sel2 := sel.Slice(0, 2).End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestGet(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	node := sel.Get(1)
+	if sel.Nodes[1] != node {
+		t.Errorf("Expected node %v to be %v.", node, sel.Nodes[1])
+	}
+}
+
+func TestGetNegative(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	node := sel.Get(-3)
+	if sel.Nodes[0] != node {
+		t.Errorf("Expected node %v to be %v.", node, sel.Nodes[0])
+	}
+}
+
+func TestGetInvalid(t *testing.T) {
+	defer assertPanic(t)
+	sel := Doc().Find(".pvk-content")
+	sel.Get(129)
+}
+
+func TestIndex(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	if i := sel.Index(); i != 1 {
+		t.Errorf("Expected index of 1, got %v.", i)
+	}
+}
+
+func TestIndexSelector(t *testing.T) {
+	sel := Doc().Find(".hero-unit")
+	if i := sel.IndexSelector("div"); i != 4 {
+		t.Errorf("Expected index of 4, got %v.", i)
+	}
+}
+
+func TestIndexOfNode(t *testing.T) {
+	sel := Doc().Find("div.pvk-gutter")
+	if i := sel.IndexOfNode(sel.Nodes[1]); i != 1 {
+		t.Errorf("Expected index of 1, got %v.", i)
+	}
+}
+
+func TestIndexOfNilNode(t *testing.T) {
+	sel := Doc().Find("div.pvk-gutter")
+	if i := sel.IndexOfNode(nil); i != -1 {
+		t.Errorf("Expected index of -1, got %v.", i)
+	}
+}
+
+func TestIndexOfSelection(t *testing.T) {
+	sel := Doc().Find("div")
+	sel2 := Doc().Find(".hero-unit")
+	if i := sel.IndexOfSelection(sel2); i != 4 {
+		t.Errorf("Expected index of 4, got %v.", i)
+	}
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/bench_array_test.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/bench_array_test.go
@@ -1,0 +1,112 @@
+package goquery
+
+import (
+	"testing"
+)
+
+func BenchmarkFirst(b *testing.B) {
+	b.StopTimer()
+	sel := DocB().Find("dd")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		sel.First()
+	}
+}
+
+func BenchmarkLast(b *testing.B) {
+	b.StopTimer()
+	sel := DocB().Find("dd")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		sel.Last()
+	}
+}
+
+func BenchmarkEq(b *testing.B) {
+	b.StopTimer()
+	sel := DocB().Find("dd")
+	j := 0
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		sel.Eq(j)
+		if j++; j >= sel.Length() {
+			j = 0
+		}
+	}
+}
+
+func BenchmarkSlice(b *testing.B) {
+	b.StopTimer()
+	sel := DocB().Find("dd")
+	j := 0
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		sel.Slice(j, j+4)
+		if j++; j >= (sel.Length() - 4) {
+			j = 0
+		}
+	}
+}
+
+func BenchmarkGet(b *testing.B) {
+	b.StopTimer()
+	sel := DocB().Find("dd")
+	j := 0
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		sel.Get(j)
+		if j++; j >= sel.Length() {
+			j = 0
+		}
+	}
+}
+
+func BenchmarkIndex(b *testing.B) {
+	var j int
+
+	b.StopTimer()
+	sel := DocB().Find("#Main")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		j = sel.Index()
+	}
+	b.Logf("Index=%d", j)
+}
+
+func BenchmarkIndexSelector(b *testing.B) {
+	var j int
+
+	b.StopTimer()
+	sel := DocB().Find("#manual-nav dl dd:nth-child(1)")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		j = sel.IndexSelector("dd")
+	}
+	b.Logf("IndexSelector=%d", j)
+}
+
+func BenchmarkIndexOfNode(b *testing.B) {
+	var j int
+
+	b.StopTimer()
+	sel := DocB().Find("span a")
+	sel2 := DocB().Find("span a:nth-child(3)")
+	n := sel2.Get(0)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		j = sel.IndexOfNode(n)
+	}
+	b.Logf("IndexOfNode=%d", j)
+}
+
+func BenchmarkIndexOfSelection(b *testing.B) {
+	var j int
+	b.StopTimer()
+	sel := DocB().Find("span a")
+	sel2 := DocB().Find("span a:nth-child(3)")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		j = sel.IndexOfSelection(sel2)
+	}
+	b.Logf("IndexOfSelection=%d", j)
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/bench_example_test.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/bench_example_test.go
@@ -1,0 +1,42 @@
+package goquery
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"testing"
+)
+
+func BenchmarkMetalReviewExample(b *testing.B) {
+	var n int
+	var buf bytes.Buffer
+
+	b.StopTimer()
+	doc := loadDoc("metalreview.html")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		doc.Find(".slider-row:nth-child(1) .slider-item").Each(func(i int, s *Selection) {
+			var band, title string
+			var score float64
+			var e error
+
+			n++
+			// For each item found, get the band, title and score, and print it
+			band = s.Find("strong").Text()
+			title = s.Find("em").Text()
+			if score, e = strconv.ParseFloat(s.Find(".score").Text(), 64); e != nil {
+				// Not a valid float, ignore score
+				if n <= 4 {
+					buf.WriteString(fmt.Sprintf("Review %d: %s - %s.\n", i, band, title))
+				}
+			} else {
+				// Print all, including score
+				if n <= 4 {
+					buf.WriteString(fmt.Sprintf("Review %d: %s - %s (%2.1f).\n", i, band, title, score))
+				}
+			}
+		})
+	}
+	b.Log(buf.String())
+	b.Logf("MetalReviewExample=%d", n)
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/bench_expand_test.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/bench_expand_test.go
@@ -1,0 +1,72 @@
+package goquery
+
+import (
+	"testing"
+)
+
+func BenchmarkAdd(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocB().Find("dd")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.Add("h2[title]").Length()
+		} else {
+			sel.Add("h2[title]")
+		}
+	}
+	b.Logf("Add=%d", n)
+}
+
+func BenchmarkAddSelection(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocB().Find("dd")
+	sel2 := DocB().Find("h2[title]")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.AddSelection(sel2).Length()
+		} else {
+			sel.AddSelection(sel2)
+		}
+	}
+	b.Logf("AddSelection=%d", n)
+}
+
+func BenchmarkAddNodes(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocB().Find("dd")
+	sel2 := DocB().Find("h2[title]")
+	nodes := sel2.Nodes
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.AddNodes(nodes...).Length()
+		} else {
+			sel.AddNodes(nodes...)
+		}
+	}
+	b.Logf("AddNodes=%d", n)
+}
+
+func BenchmarkAndSelf(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocB().Find("dd").Parent()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.AndSelf().Length()
+		} else {
+			sel.AndSelf()
+		}
+	}
+	b.Logf("AndSelf=%d", n)
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/bench_filter_test.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/bench_filter_test.go
@@ -1,0 +1,212 @@
+package goquery
+
+import (
+	"testing"
+)
+
+func BenchmarkFilter(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("li")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.Filter(".toclevel-1").Length()
+		} else {
+			sel.Filter(".toclevel-1")
+		}
+	}
+	b.Logf("Filter=%d", n)
+}
+
+func BenchmarkNot(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("li")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.Not(".toclevel-2").Length()
+		} else {
+			sel.Filter(".toclevel-2")
+		}
+	}
+	b.Logf("Not=%d", n)
+}
+
+func BenchmarkFilterFunction(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("li")
+	f := func(i int, s *Selection) bool {
+		return len(s.Get(0).Attr) > 0
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.FilterFunction(f).Length()
+		} else {
+			sel.FilterFunction(f)
+		}
+	}
+	b.Logf("FilterFunction=%d", n)
+}
+
+func BenchmarkNotFunction(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("li")
+	f := func(i int, s *Selection) bool {
+		return len(s.Get(0).Attr) > 0
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.NotFunction(f).Length()
+		} else {
+			sel.NotFunction(f)
+		}
+	}
+	b.Logf("NotFunction=%d", n)
+}
+
+func BenchmarkFilterNodes(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("li")
+	sel2 := DocW().Find(".toclevel-2")
+	nodes := sel2.Nodes
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.FilterNodes(nodes...).Length()
+		} else {
+			sel.FilterNodes(nodes...)
+		}
+	}
+	b.Logf("FilterNodes=%d", n)
+}
+
+func BenchmarkNotNodes(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("li")
+	sel2 := DocW().Find(".toclevel-1")
+	nodes := sel2.Nodes
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.NotNodes(nodes...).Length()
+		} else {
+			sel.NotNodes(nodes...)
+		}
+	}
+	b.Logf("NotNodes=%d", n)
+}
+
+func BenchmarkFilterSelection(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("li")
+	sel2 := DocW().Find(".toclevel-2")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.FilterSelection(sel2).Length()
+		} else {
+			sel.FilterSelection(sel2)
+		}
+	}
+	b.Logf("FilterSelection=%d", n)
+}
+
+func BenchmarkNotSelection(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("li")
+	sel2 := DocW().Find(".toclevel-1")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.NotSelection(sel2).Length()
+		} else {
+			sel.NotSelection(sel2)
+		}
+	}
+	b.Logf("NotSelection=%d", n)
+}
+
+func BenchmarkHas(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("h2")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.Has(".editsection").Length()
+		} else {
+			sel.Has(".editsection")
+		}
+	}
+	b.Logf("Has=%d", n)
+}
+
+func BenchmarkHasNodes(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("li")
+	sel2 := DocW().Find(".tocnumber")
+	nodes := sel2.Nodes
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.HasNodes(nodes...).Length()
+		} else {
+			sel.HasNodes(nodes...)
+		}
+	}
+	b.Logf("HasNodes=%d", n)
+}
+
+func BenchmarkHasSelection(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("li")
+	sel2 := DocW().Find(".tocnumber")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.HasSelection(sel2).Length()
+		} else {
+			sel.HasSelection(sel2)
+		}
+	}
+	b.Logf("HasSelection=%d", n)
+}
+
+func BenchmarkEnd(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("li").Has(".tocnumber")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.End().Length()
+		} else {
+			sel.End()
+		}
+	}
+	b.Logf("End=%d", n)
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/bench_iteration_test.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/bench_iteration_test.go
@@ -1,0 +1,62 @@
+package goquery
+
+import (
+	"testing"
+)
+
+func BenchmarkEach(b *testing.B) {
+	var tmp, n int
+
+	b.StopTimer()
+	sel := DocW().Find("td")
+	f := func(i int, s *Selection) {
+		tmp++
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		sel.Each(f)
+		if n == 0 {
+			n = tmp
+		}
+	}
+	b.Logf("Each=%d", n)
+}
+
+func BenchmarkMap(b *testing.B) {
+	var tmp, n int
+
+	b.StopTimer()
+	sel := DocW().Find("td")
+	f := func(i int, s *Selection) string {
+		tmp++
+		return string(tmp)
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		sel.Map(f)
+		if n == 0 {
+			n = tmp
+		}
+	}
+	b.Logf("Map=%d", n)
+}
+
+func BenchmarkEachWithBreak(b *testing.B) {
+	var tmp, n int
+
+	b.StopTimer()
+	sel := DocW().Find("td")
+	f := func(i int, s *Selection) bool {
+		tmp++
+		return tmp < 10
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		tmp = 0
+		sel.EachWithBreak(f)
+		if n == 0 {
+			n = tmp
+		}
+	}
+	b.Logf("Each=%d", n)
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/bench_property_test.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/bench_property_test.go
@@ -1,0 +1,47 @@
+package goquery
+
+import (
+	"testing"
+)
+
+func BenchmarkAttr(b *testing.B) {
+	var s string
+
+	b.StopTimer()
+	sel := DocW().Find("h1")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		s, _ = sel.Attr("id")
+	}
+	b.Logf("Attr=%s", s)
+}
+
+func BenchmarkText(b *testing.B) {
+	b.StopTimer()
+	sel := DocW().Find("h2")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		sel.Text()
+	}
+}
+
+func BenchmarkLength(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("h2")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		n = sel.Length()
+	}
+	b.Logf("Length=%d", n)
+}
+
+func BenchmarkHtml(b *testing.B) {
+	b.StopTimer()
+	sel := DocW().Find("h2")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		sel.Html()
+	}
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/bench_query_test.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/bench_query_test.go
@@ -1,0 +1,97 @@
+package goquery
+
+import (
+	"testing"
+)
+
+func BenchmarkIs(b *testing.B) {
+	var y bool
+
+	b.StopTimer()
+	sel := DocW().Find("li")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		y = sel.Is(".toclevel-2")
+	}
+	b.Logf("Is=%v", y)
+}
+
+func BenchmarkIsPositional(b *testing.B) {
+	var y bool
+
+	b.StopTimer()
+	sel := DocW().Find("li")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		y = sel.Is("li:nth-child(2)")
+	}
+	b.Logf("IsPositional=%v", y)
+}
+
+func BenchmarkIsFunction(b *testing.B) {
+	var y bool
+
+	b.StopTimer()
+	sel := DocW().Find(".toclevel-1")
+	f := func(i int, s *Selection) bool {
+		return i == 8
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		y = sel.IsFunction(f)
+	}
+	b.Logf("IsFunction=%v", y)
+}
+
+func BenchmarkIsSelection(b *testing.B) {
+	var y bool
+
+	b.StopTimer()
+	sel := DocW().Find("li")
+	sel2 := DocW().Find(".toclevel-2")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		y = sel.IsSelection(sel2)
+	}
+	b.Logf("IsSelection=%v", y)
+}
+
+func BenchmarkIsNodes(b *testing.B) {
+	var y bool
+
+	b.StopTimer()
+	sel := DocW().Find("li")
+	sel2 := DocW().Find(".toclevel-2")
+	nodes := sel2.Nodes
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		y = sel.IsNodes(nodes...)
+	}
+	b.Logf("IsNodes=%v", y)
+}
+
+func BenchmarkHasClass(b *testing.B) {
+	var y bool
+
+	b.StopTimer()
+	sel := DocW().Find("span")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		y = sel.HasClass("official")
+	}
+	b.Logf("HasClass=%v", y)
+}
+
+func BenchmarkContains(b *testing.B) {
+	var y bool
+
+	b.StopTimer()
+	sel := DocW().Find("span.url")
+	sel2 := DocW().Find("a[rel=\"nofollow\"]")
+	node := sel2.Nodes[0]
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		y = sel.Contains(node)
+	}
+	b.Logf("Contains=%v", y)
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/bench_traversal_test.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/bench_traversal_test.go
@@ -1,0 +1,716 @@
+package goquery
+
+import (
+	"testing"
+)
+
+func BenchmarkFind(b *testing.B) {
+	var n int
+
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = DocB().Find("dd").Length()
+
+		} else {
+			DocB().Find("dd")
+		}
+	}
+	b.Logf("Find=%d", n)
+}
+
+func BenchmarkFindWithinSelection(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("ul")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.Find("a[class]").Length()
+		} else {
+			sel.Find("a[class]")
+		}
+	}
+	b.Logf("FindWithinSelection=%d", n)
+}
+
+func BenchmarkFindSelection(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("ul")
+	sel2 := DocW().Find("span")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.FindSelection(sel2).Length()
+		} else {
+			sel.FindSelection(sel2)
+		}
+	}
+	b.Logf("FindSelection=%d", n)
+}
+
+func BenchmarkFindNodes(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("ul")
+	sel2 := DocW().Find("span")
+	nodes := sel2.Nodes
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.FindNodes(nodes...).Length()
+		} else {
+			sel.FindNodes(nodes...)
+		}
+	}
+	b.Logf("FindNodes=%d", n)
+}
+
+func BenchmarkContents(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find(".toclevel-1")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.Contents().Length()
+		} else {
+			sel.Contents()
+		}
+	}
+	b.Logf("Contents=%d", n)
+}
+
+func BenchmarkContentsFiltered(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find(".toclevel-1")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.ContentsFiltered("a[href=\"#Examples\"]").Length()
+		} else {
+			sel.ContentsFiltered("a[href=\"#Examples\"]")
+		}
+	}
+	b.Logf("ContentsFiltered=%d", n)
+}
+
+func BenchmarkChildren(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find(".toclevel-2")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.Children().Length()
+		} else {
+			sel.Children()
+		}
+	}
+	b.Logf("Children=%d", n)
+}
+
+func BenchmarkChildrenFiltered(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("h3")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.ChildrenFiltered(".editsection").Length()
+		} else {
+			sel.ChildrenFiltered(".editsection")
+		}
+	}
+	b.Logf("ChildrenFiltered=%d", n)
+}
+
+func BenchmarkParent(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("li")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.Parent().Length()
+		} else {
+			sel.Parent()
+		}
+	}
+	b.Logf("Parent=%d", n)
+}
+
+func BenchmarkParentFiltered(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("li")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.ParentFiltered("ul[id]").Length()
+		} else {
+			sel.ParentFiltered("ul[id]")
+		}
+	}
+	b.Logf("ParentFiltered=%d", n)
+}
+
+func BenchmarkParents(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("th a")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.Parents().Length()
+		} else {
+			sel.Parents()
+		}
+	}
+	b.Logf("Parents=%d", n)
+}
+
+func BenchmarkParentsFiltered(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("th a")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.ParentsFiltered("tr").Length()
+		} else {
+			sel.ParentsFiltered("tr")
+		}
+	}
+	b.Logf("ParentsFiltered=%d", n)
+}
+
+func BenchmarkParentsUntil(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("th a")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.ParentsUntil("table").Length()
+		} else {
+			sel.ParentsUntil("table")
+		}
+	}
+	b.Logf("ParentsUntil=%d", n)
+}
+
+func BenchmarkParentsUntilSelection(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("th a")
+	sel2 := DocW().Find("#content")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.ParentsUntilSelection(sel2).Length()
+		} else {
+			sel.ParentsUntilSelection(sel2)
+		}
+	}
+	b.Logf("ParentsUntilSelection=%d", n)
+}
+
+func BenchmarkParentsUntilNodes(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("th a")
+	sel2 := DocW().Find("#content")
+	nodes := sel2.Nodes
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.ParentsUntilNodes(nodes...).Length()
+		} else {
+			sel.ParentsUntilNodes(nodes...)
+		}
+	}
+	b.Logf("ParentsUntilNodes=%d", n)
+}
+
+func BenchmarkParentsFilteredUntil(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find(".toclevel-1 a")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.ParentsFilteredUntil(":nth-child(1)", "ul").Length()
+		} else {
+			sel.ParentsFilteredUntil(":nth-child(1)", "ul")
+		}
+	}
+	b.Logf("ParentsFilteredUntil=%d", n)
+}
+
+func BenchmarkParentsFilteredUntilSelection(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find(".toclevel-1 a")
+	sel2 := DocW().Find("ul")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.ParentsFilteredUntilSelection(":nth-child(1)", sel2).Length()
+		} else {
+			sel.ParentsFilteredUntilSelection(":nth-child(1)", sel2)
+		}
+	}
+	b.Logf("ParentsFilteredUntilSelection=%d", n)
+}
+
+func BenchmarkParentsFilteredUntilNodes(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find(".toclevel-1 a")
+	sel2 := DocW().Find("ul")
+	nodes := sel2.Nodes
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.ParentsFilteredUntilNodes(":nth-child(1)", nodes...).Length()
+		} else {
+			sel.ParentsFilteredUntilNodes(":nth-child(1)", nodes...)
+		}
+	}
+	b.Logf("ParentsFilteredUntilNodes=%d", n)
+}
+
+func BenchmarkSiblings(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("ul li:nth-child(1)")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.Siblings().Length()
+		} else {
+			sel.Siblings()
+		}
+	}
+	b.Logf("Siblings=%d", n)
+}
+
+func BenchmarkSiblingsFiltered(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("ul li:nth-child(1)")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.SiblingsFiltered("[class]").Length()
+		} else {
+			sel.SiblingsFiltered("[class]")
+		}
+	}
+	b.Logf("SiblingsFiltered=%d", n)
+}
+
+func BenchmarkNext(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("li:nth-child(1)")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.Next().Length()
+		} else {
+			sel.Next()
+		}
+	}
+	b.Logf("Next=%d", n)
+}
+
+func BenchmarkNextFiltered(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("li:nth-child(1)")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.NextFiltered("[class]").Length()
+		} else {
+			sel.NextFiltered("[class]")
+		}
+	}
+	b.Logf("NextFiltered=%d", n)
+}
+
+func BenchmarkNextAll(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("li:nth-child(3)")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.NextAll().Length()
+		} else {
+			sel.NextAll()
+		}
+	}
+	b.Logf("NextAll=%d", n)
+}
+
+func BenchmarkNextAllFiltered(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("li:nth-child(3)")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.NextAllFiltered("[class]").Length()
+		} else {
+			sel.NextAllFiltered("[class]")
+		}
+	}
+	b.Logf("NextAllFiltered=%d", n)
+}
+
+func BenchmarkPrev(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("li:last-child")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.Prev().Length()
+		} else {
+			sel.Prev()
+		}
+	}
+	b.Logf("Prev=%d", n)
+}
+
+func BenchmarkPrevFiltered(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("li:last-child")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.PrevFiltered("[class]").Length()
+		} else {
+			sel.PrevFiltered("[class]")
+		}
+	}
+	// There is one more Prev li with a class, compared to Next li with a class
+	// (confirmed by looking at the HTML, this is ok)
+	b.Logf("PrevFiltered=%d", n)
+}
+
+func BenchmarkPrevAll(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("li:nth-child(4)")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.PrevAll().Length()
+		} else {
+			sel.PrevAll()
+		}
+	}
+	b.Logf("PrevAll=%d", n)
+}
+
+func BenchmarkPrevAllFiltered(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("li:nth-child(4)")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.PrevAllFiltered("[class]").Length()
+		} else {
+			sel.PrevAllFiltered("[class]")
+		}
+	}
+	b.Logf("PrevAllFiltered=%d", n)
+}
+
+func BenchmarkNextUntil(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("li:first-child")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.NextUntil(":nth-child(4)").Length()
+		} else {
+			sel.NextUntil(":nth-child(4)")
+		}
+	}
+	b.Logf("NextUntil=%d", n)
+}
+
+func BenchmarkNextUntilSelection(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("h2")
+	sel2 := DocW().Find("ul")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.NextUntilSelection(sel2).Length()
+		} else {
+			sel.NextUntilSelection(sel2)
+		}
+	}
+	b.Logf("NextUntilSelection=%d", n)
+}
+
+func BenchmarkNextUntilNodes(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("h2")
+	sel2 := DocW().Find("p")
+	nodes := sel2.Nodes
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.NextUntilNodes(nodes...).Length()
+		} else {
+			sel.NextUntilNodes(nodes...)
+		}
+	}
+	b.Logf("NextUntilNodes=%d", n)
+}
+
+func BenchmarkPrevUntil(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("li:last-child")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.PrevUntil(":nth-child(4)").Length()
+		} else {
+			sel.PrevUntil(":nth-child(4)")
+		}
+	}
+	b.Logf("PrevUntil=%d", n)
+}
+
+func BenchmarkPrevUntilSelection(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("h2")
+	sel2 := DocW().Find("ul")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.PrevUntilSelection(sel2).Length()
+		} else {
+			sel.PrevUntilSelection(sel2)
+		}
+	}
+	b.Logf("PrevUntilSelection=%d", n)
+}
+
+func BenchmarkPrevUntilNodes(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("h2")
+	sel2 := DocW().Find("p")
+	nodes := sel2.Nodes
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.PrevUntilNodes(nodes...).Length()
+		} else {
+			sel.PrevUntilNodes(nodes...)
+		}
+	}
+	b.Logf("PrevUntilNodes=%d", n)
+}
+
+func BenchmarkNextFilteredUntil(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("h2")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.NextFilteredUntil("p", "div").Length()
+		} else {
+			sel.NextFilteredUntil("p", "div")
+		}
+	}
+	b.Logf("NextFilteredUntil=%d", n)
+}
+
+func BenchmarkNextFilteredUntilSelection(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("h2")
+	sel2 := DocW().Find("div")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.NextFilteredUntilSelection("p", sel2).Length()
+		} else {
+			sel.NextFilteredUntilSelection("p", sel2)
+		}
+	}
+	b.Logf("NextFilteredUntilSelection=%d", n)
+}
+
+func BenchmarkNextFilteredUntilNodes(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("h2")
+	sel2 := DocW().Find("div")
+	nodes := sel2.Nodes
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.NextFilteredUntilNodes("p", nodes...).Length()
+		} else {
+			sel.NextFilteredUntilNodes("p", nodes...)
+		}
+	}
+	b.Logf("NextFilteredUntilNodes=%d", n)
+}
+
+func BenchmarkPrevFilteredUntil(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("h2")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.PrevFilteredUntil("p", "div").Length()
+		} else {
+			sel.PrevFilteredUntil("p", "div")
+		}
+	}
+	b.Logf("PrevFilteredUntil=%d", n)
+}
+
+func BenchmarkPrevFilteredUntilSelection(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("h2")
+	sel2 := DocW().Find("div")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.PrevFilteredUntilSelection("p", sel2).Length()
+		} else {
+			sel.PrevFilteredUntilSelection("p", sel2)
+		}
+	}
+	b.Logf("PrevFilteredUntilSelection=%d", n)
+}
+
+func BenchmarkPrevFilteredUntilNodes(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := DocW().Find("h2")
+	sel2 := DocW().Find("div")
+	nodes := sel2.Nodes
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.PrevFilteredUntilNodes("p", nodes...).Length()
+		} else {
+			sel.PrevFilteredUntilNodes("p", nodes...)
+		}
+	}
+	b.Logf("PrevFilteredUntilNodes=%d", n)
+}
+
+func BenchmarkClosest(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := Doc().Find(".container-fluid")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.Closest(".pvk-content").Length()
+		} else {
+			sel.Closest(".pvk-content")
+		}
+	}
+	b.Logf("Closest=%d", n)
+}
+
+func BenchmarkClosestSelection(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := Doc().Find(".container-fluid")
+	sel2 := Doc().Find(".pvk-content")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.ClosestSelection(sel2).Length()
+		} else {
+			sel.ClosestSelection(sel2)
+		}
+	}
+	b.Logf("ClosestSelection=%d", n)
+}
+
+func BenchmarkClosestNodes(b *testing.B) {
+	var n int
+
+	b.StopTimer()
+	sel := Doc().Find(".container-fluid")
+	nodes := Doc().Find(".pvk-content").Nodes
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if n == 0 {
+			n = sel.ClosestNodes(nodes...).Length()
+		} else {
+			sel.ClosestNodes(nodes...)
+		}
+	}
+	b.Logf("ClosestNodes=%d", n)
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/doc.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/doc.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2012-2014, Martin Angers & Contributors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+// * Neither the name of the author nor the names of its contributors may be used to
+// endorse or promote products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+// OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+// WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/*
+Package goquery implements features similar to jQuery, including the chainable
+syntax, to manipulate and query an HTML document.
+
+It brings a syntax and a set of features similar to jQuery to the Go language.
+It is based on Go's net/html package and the CSS Selector library cascadia.
+Since the net/html parser returns nodes, and not a full-featured DOM
+tree, jQuery's stateful manipulation functions (like height(), css(), detach())
+have been left off.
+
+Also, because the net/html parser requires UTF-8 encoding, so does goquery: it is
+the caller's responsibility to ensure that the source document provides UTF-8 encoded HTML.
+See the repository's wiki for various options on how to do this.
+
+Syntax-wise, it is as close as possible to jQuery, with the same function names when
+possible, and that warm and fuzzy chainable interface. jQuery being the
+ultra-popular library that it is, writing a similar HTML-manipulating
+library was better to follow its API than to start anew (in the same spirit as
+Go's fmt package), even though some of its methods are less than intuitive (looking
+at you, index()...).
+
+It is hosted on GitHub, along with additional documentation in the README.md
+file: https://github.com/puerkitobio/goquery
+
+Please note that because of the net/html dependency, goquery requires Go1.1+.
+
+The various methods are split into files based on the category of behavior.
+The three dots (...) indicate that various "overloads" are available.
+
+* array.go : array-like positional manipulation of the selection.
+    - Eq()
+    - First()
+    - Get()
+    - Index...()
+    - Last()
+    - Slice()
+
+* expand.go : methods that expand or augment the selection's set.
+    - Add...()
+    - AndSelf()
+    - Union(), which is an alias for AddSelection()
+
+* filter.go : filtering methods, that reduce the selection's set.
+    - End()
+    - Filter...()
+    - Has...()
+    - Intersection(), which is an alias of FilterSelection()
+    - Not...()
+
+* iteration.go : methods to loop over the selection's nodes.
+    - Each()
+    - EachWithBreak()
+    - Map()
+
+* manipulation.go : methods for modifying the document
+    - After...()
+    - Append...()
+    - Before...()
+    - Clone()
+    - Empty()
+    - Prepend...()
+    - Remove...()
+    - ReplaceWith...()
+    - Unwrap()
+    - Wrap...()
+    - WrapAll...()
+    - WrapInner...()
+
+* property.go : methods that inspect and get the node's properties values.
+    - Attr*(), RemoveAttr(), SetAttr()
+    - AddClass(), HasClass(), RemoveClass(), ToggleClass()
+    - Html()
+    - Length()
+    - Size(), which is an alias for Length()
+    - Text()
+
+* query.go : methods that query, or reflect, a node's identity.
+    - Contains()
+    - Is...()
+
+* traversal.go : methods to traverse the HTML document tree.
+    - Children...()
+    - Contents()
+    - Find...()
+    - Next...()
+    - Parent[s]...()
+    - Prev...()
+    - Siblings...()
+
+* type.go : definition of the types exposed by goquery.
+    - Document
+    - Selection
+    - Matcher
+*/
+package goquery

--- a/_third_party/github.com/PuerkitoBio/goquery/example_test.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/example_test.go
@@ -1,0 +1,32 @@
+package goquery
+
+import (
+	"fmt"
+	"log"
+
+	// In real use, this import would be required (not in this example, since it
+	// is part of the goquery package)
+	//"github.com/PuerkitoBio/goquery"
+)
+
+// This example scrapes the reviews shown on the home page of metalsucks.net.
+func ExampleScrape_MetalSucks() {
+	// Load the HTML document (in real use, the type would be *goquery.Document)
+	doc, err := NewDocument("http://metalsucks.net")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Find the review items (the type of the Selection would be *goquery.Selection)
+	doc.Find(".reviews-wrap article .review-rhs").Each(func(i int, s *Selection) {
+		// For each item found, get the band and title
+		band := s.Find("h3").Text()
+		title := s.Find("i").Text()
+		fmt.Printf("Review %d: %s - %s\n", i, band, title)
+	})
+	// To see the output of the Example while running the test suite (go test), simply
+	// remove the leading "x" before Output on the next line. This will cause the
+	// example to fail (all the "real" tests should pass).
+
+	// xOutput: voluntarily fail the Example output.
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/expand.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/expand.go
@@ -1,0 +1,49 @@
+package goquery
+
+import (
+	"bosun.org/_third_party/github.com/andybalholm/cascadia"
+	"bosun.org/_third_party/golang.org/x/net/html"
+)
+
+// Add adds the selector string's matching nodes to those in the current
+// selection and returns a new Selection object.
+// The selector string is run in the context of the document of the current
+// Selection object.
+func (s *Selection) Add(selector string) *Selection {
+	return s.AddNodes(findWithMatcher([]*html.Node{s.document.rootNode}, cascadia.MustCompile(selector))...)
+}
+
+// AddMatcher adds the matcher's matching nodes to those in the current
+// selection and returns a new Selection object.
+// The matcher is run in the context of the document of the current
+// Selection object.
+func (s *Selection) AddMatcher(m Matcher) *Selection {
+	return s.AddNodes(findWithMatcher([]*html.Node{s.document.rootNode}, m)...)
+}
+
+// AddSelection adds the specified Selection object's nodes to those in the
+// current selection and returns a new Selection object.
+func (s *Selection) AddSelection(sel *Selection) *Selection {
+	if sel == nil {
+		return s.AddNodes()
+	}
+	return s.AddNodes(sel.Nodes...)
+}
+
+// Union is an alias for AddSelection.
+func (s *Selection) Union(sel *Selection) *Selection {
+	return s.AddSelection(sel)
+}
+
+// AddNodes adds the specified nodes to those in the
+// current selection and returns a new Selection object.
+func (s *Selection) AddNodes(nodes ...*html.Node) *Selection {
+	return pushStack(s, appendWithoutDuplicates(s.Nodes, nodes))
+}
+
+// AndSelf adds the previous set of elements on the stack to the current set.
+// It returns a new Selection object containing the current Selection combined
+// with the previous one.
+func (s *Selection) AndSelf() *Selection {
+	return s.AddSelection(s.prevSel)
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/expand_test.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/expand_test.go
@@ -1,0 +1,68 @@
+package goquery
+
+import (
+	"testing"
+)
+
+func TestAdd(t *testing.T) {
+	sel := Doc().Find("div.row-fluid").Add("a")
+	assertLength(t, sel.Nodes, 19)
+}
+
+func TestAddRollback(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	sel2 := sel.Add("a").End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestAddSelection(t *testing.T) {
+	sel := Doc().Find("div.row-fluid")
+	sel2 := Doc().Find("a")
+	sel = sel.AddSelection(sel2)
+	assertLength(t, sel.Nodes, 19)
+}
+
+func TestAddSelectionNil(t *testing.T) {
+	sel := Doc().Find("div.row-fluid")
+	assertLength(t, sel.Nodes, 9)
+
+	sel = sel.AddSelection(nil)
+	assertLength(t, sel.Nodes, 9)
+}
+
+func TestAddSelectionRollback(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	sel2 := sel.Find("a")
+	sel2 = sel.AddSelection(sel2).End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestAddNodes(t *testing.T) {
+	sel := Doc().Find("div.pvk-gutter")
+	sel2 := Doc().Find(".pvk-content")
+	sel = sel.AddNodes(sel2.Nodes...)
+	assertLength(t, sel.Nodes, 9)
+}
+
+func TestAddNodesNone(t *testing.T) {
+	sel := Doc().Find("div.pvk-gutter").AddNodes()
+	assertLength(t, sel.Nodes, 6)
+}
+
+func TestAddNodesRollback(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	sel2 := sel.Find("a")
+	sel2 = sel.AddNodes(sel2.Nodes...).End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestAndSelf(t *testing.T) {
+	sel := Doc().Find(".span12").Last().AndSelf()
+	assertLength(t, sel.Nodes, 2)
+}
+
+func TestAndSelfRollback(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	sel2 := sel.Find("a").AndSelf().End().End()
+	assertEqual(t, sel, sel2)
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/filter.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/filter.go
@@ -1,0 +1,156 @@
+package goquery
+
+import (
+	"bosun.org/_third_party/github.com/andybalholm/cascadia"
+	"bosun.org/_third_party/golang.org/x/net/html"
+)
+
+// Filter reduces the set of matched elements to those that match the selector string.
+// It returns a new Selection object for this subset of matching elements.
+func (s *Selection) Filter(selector string) *Selection {
+	return s.FilterMatcher(cascadia.MustCompile(selector))
+}
+
+// FilterMatcher reduces the set of matched elements to those that match
+// the given matcher.
+// It returns a new Selection object for this subset of matching elements.
+func (s *Selection) FilterMatcher(m Matcher) *Selection {
+	return pushStack(s, winnow(s, m, true))
+}
+
+// Not removes elements from the Selection that match the selector string.
+// It returns a new Selection object with the matching elements removed.
+func (s *Selection) Not(selector string) *Selection {
+	return s.NotMatcher(cascadia.MustCompile(selector))
+}
+
+// NotMatcher removes elements from the Selection that match the given matcher.
+// It returns a new Selection object with the matching elements removed.
+func (s *Selection) NotMatcher(m Matcher) *Selection {
+	return pushStack(s, winnow(s, m, false))
+}
+
+// FilterFunction reduces the set of matched elements to those that pass the function's test.
+// It returns a new Selection object for this subset of elements.
+func (s *Selection) FilterFunction(f func(int, *Selection) bool) *Selection {
+	return pushStack(s, winnowFunction(s, f, true))
+}
+
+// NotFunction removes elements from the Selection that pass the function's test.
+// It returns a new Selection object with the matching elements removed.
+func (s *Selection) NotFunction(f func(int, *Selection) bool) *Selection {
+	return pushStack(s, winnowFunction(s, f, false))
+}
+
+// FilterNodes reduces the set of matched elements to those that match the specified nodes.
+// It returns a new Selection object for this subset of elements.
+func (s *Selection) FilterNodes(nodes ...*html.Node) *Selection {
+	return pushStack(s, winnowNodes(s, nodes, true))
+}
+
+// NotNodes removes elements from the Selection that match the specified nodes.
+// It returns a new Selection object with the matching elements removed.
+func (s *Selection) NotNodes(nodes ...*html.Node) *Selection {
+	return pushStack(s, winnowNodes(s, nodes, false))
+}
+
+// FilterSelection reduces the set of matched elements to those that match a
+// node in the specified Selection object.
+// It returns a new Selection object for this subset of elements.
+func (s *Selection) FilterSelection(sel *Selection) *Selection {
+	if sel == nil {
+		return pushStack(s, winnowNodes(s, nil, true))
+	}
+	return pushStack(s, winnowNodes(s, sel.Nodes, true))
+}
+
+// NotSelection removes elements from the Selection that match a node in the specified
+// Selection object. It returns a new Selection object with the matching elements removed.
+func (s *Selection) NotSelection(sel *Selection) *Selection {
+	if sel == nil {
+		return pushStack(s, winnowNodes(s, nil, false))
+	}
+	return pushStack(s, winnowNodes(s, sel.Nodes, false))
+}
+
+// Intersection is an alias for FilterSelection.
+func (s *Selection) Intersection(sel *Selection) *Selection {
+	return s.FilterSelection(sel)
+}
+
+// Has reduces the set of matched elements to those that have a descendant
+// that matches the selector.
+// It returns a new Selection object with the matching elements.
+func (s *Selection) Has(selector string) *Selection {
+	return s.HasSelection(s.document.Find(selector))
+}
+
+// HasMatcher reduces the set of matched elements to those that have a descendant
+// that matches the matcher.
+// It returns a new Selection object with the matching elements.
+func (s *Selection) HasMatcher(m Matcher) *Selection {
+	return s.HasSelection(s.document.FindMatcher(m))
+}
+
+// HasNodes reduces the set of matched elements to those that have a
+// descendant that matches one of the nodes.
+// It returns a new Selection object with the matching elements.
+func (s *Selection) HasNodes(nodes ...*html.Node) *Selection {
+	return s.FilterFunction(func(_ int, sel *Selection) bool {
+		// Add all nodes that contain one of the specified nodes
+		for _, n := range nodes {
+			if sel.Contains(n) {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// HasSelection reduces the set of matched elements to those that have a
+// descendant that matches one of the nodes of the specified Selection object.
+// It returns a new Selection object with the matching elements.
+func (s *Selection) HasSelection(sel *Selection) *Selection {
+	if sel == nil {
+		return s.HasNodes()
+	}
+	return s.HasNodes(sel.Nodes...)
+}
+
+// End ends the most recent filtering operation in the current chain and
+// returns the set of matched elements to its previous state.
+func (s *Selection) End() *Selection {
+	if s.prevSel != nil {
+		return s.prevSel
+	}
+	return newEmptySelection(s.document)
+}
+
+// Filter based on the matcher, and the indicator to keep (Filter) or
+// to get rid of (Not) the matching elements.
+func winnow(sel *Selection, m Matcher, keep bool) []*html.Node {
+	// Optimize if keep is requested
+	if keep {
+		return m.Filter(sel.Nodes)
+	}
+	// Use grep
+	return grep(sel, func(i int, s *Selection) bool {
+		return !m.Match(s.Get(0))
+	})
+}
+
+// Filter based on an array of nodes, and the indicator to keep (Filter) or
+// to get rid of (Not) the matching elements.
+func winnowNodes(sel *Selection, nodes []*html.Node, keep bool) []*html.Node {
+	return grep(sel, func(i int, s *Selection) bool {
+		return isInSlice(nodes, s.Get(0)) == keep
+	})
+}
+
+// Filter based on a function test, and the indicator to keep (Filter) or
+// to get rid of (Not) the matching elements.
+func winnowFunction(sel *Selection, f func(int, *Selection) bool, keep bool) []*html.Node {
+	return grep(sel, func(i int, s *Selection) bool {
+		return f(i, s) == keep
+	})
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/filter_test.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/filter_test.go
@@ -1,0 +1,191 @@
+package goquery
+
+import (
+	"testing"
+)
+
+func TestFilter(t *testing.T) {
+	sel := Doc().Find(".span12").Filter(".alert")
+	assertLength(t, sel.Nodes, 1)
+}
+
+func TestFilterNone(t *testing.T) {
+	sel := Doc().Find(".span12").Filter(".zzalert")
+	assertLength(t, sel.Nodes, 0)
+}
+
+func TestFilterRollback(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	sel2 := sel.Filter(".alert").End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestFilterFunction(t *testing.T) {
+	sel := Doc().Find(".pvk-content").FilterFunction(func(i int, s *Selection) bool {
+		return i > 0
+	})
+	assertLength(t, sel.Nodes, 2)
+}
+
+func TestFilterFunctionRollback(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	sel2 := sel.FilterFunction(func(i int, s *Selection) bool {
+		return i > 0
+	}).End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestFilterNode(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	sel2 := sel.FilterNodes(sel.Nodes[2])
+	assertLength(t, sel2.Nodes, 1)
+}
+
+func TestFilterNodeRollback(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	sel2 := sel.FilterNodes(sel.Nodes[2]).End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestFilterSelection(t *testing.T) {
+	sel := Doc().Find(".link")
+	sel2 := Doc().Find("a[ng-click]")
+	sel3 := sel.FilterSelection(sel2)
+	assertLength(t, sel3.Nodes, 1)
+}
+
+func TestFilterSelectionRollback(t *testing.T) {
+	sel := Doc().Find(".link")
+	sel2 := Doc().Find("a[ng-click]")
+	sel2 = sel.FilterSelection(sel2).End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestFilterSelectionNil(t *testing.T) {
+	var sel2 *Selection
+
+	sel := Doc().Find(".link")
+	sel3 := sel.FilterSelection(sel2)
+	assertLength(t, sel3.Nodes, 0)
+}
+
+func TestNot(t *testing.T) {
+	sel := Doc().Find(".span12").Not(".alert")
+	assertLength(t, sel.Nodes, 1)
+}
+
+func TestNotRollback(t *testing.T) {
+	sel := Doc().Find(".span12")
+	sel2 := sel.Not(".alert").End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestNotNone(t *testing.T) {
+	sel := Doc().Find(".span12").Not(".zzalert")
+	assertLength(t, sel.Nodes, 2)
+}
+
+func TestNotFunction(t *testing.T) {
+	sel := Doc().Find(".pvk-content").NotFunction(func(i int, s *Selection) bool {
+		return i > 0
+	})
+	assertLength(t, sel.Nodes, 1)
+}
+
+func TestNotFunctionRollback(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	sel2 := sel.NotFunction(func(i int, s *Selection) bool {
+		return i > 0
+	}).End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestNotNode(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	sel2 := sel.NotNodes(sel.Nodes[2])
+	assertLength(t, sel2.Nodes, 2)
+}
+
+func TestNotNodeRollback(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	sel2 := sel.NotNodes(sel.Nodes[2]).End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestNotSelection(t *testing.T) {
+	sel := Doc().Find(".link")
+	sel2 := Doc().Find("a[ng-click]")
+	sel3 := sel.NotSelection(sel2)
+	assertLength(t, sel3.Nodes, 6)
+}
+
+func TestNotSelectionRollback(t *testing.T) {
+	sel := Doc().Find(".link")
+	sel2 := Doc().Find("a[ng-click]")
+	sel2 = sel.NotSelection(sel2).End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestIntersection(t *testing.T) {
+	sel := Doc().Find(".pvk-gutter")
+	sel2 := Doc().Find("div").Intersection(sel)
+	assertLength(t, sel2.Nodes, 6)
+}
+
+func TestIntersectionRollback(t *testing.T) {
+	sel := Doc().Find(".pvk-gutter")
+	sel2 := Doc().Find("div")
+	sel2 = sel.Intersection(sel2).End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestHas(t *testing.T) {
+	sel := Doc().Find(".container-fluid").Has(".center-content")
+	assertLength(t, sel.Nodes, 2)
+	// Has() returns the high-level .container-fluid div, and the one that is the immediate parent of center-content
+}
+
+func TestHasRollback(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := sel.Has(".center-content").End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestHasNodes(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := Doc().Find(".center-content")
+	sel = sel.HasNodes(sel2.Nodes...)
+	assertLength(t, sel.Nodes, 2)
+	// Has() returns the high-level .container-fluid div, and the one that is the immediate parent of center-content
+}
+
+func TestHasNodesRollback(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := Doc().Find(".center-content")
+	sel2 = sel.HasNodes(sel2.Nodes...).End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestHasSelection(t *testing.T) {
+	sel := Doc().Find("p")
+	sel2 := Doc().Find("small")
+	sel = sel.HasSelection(sel2)
+	assertLength(t, sel.Nodes, 1)
+}
+
+func TestHasSelectionRollback(t *testing.T) {
+	sel := Doc().Find("p")
+	sel2 := Doc().Find("small")
+	sel2 = sel.HasSelection(sel2).End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestEnd(t *testing.T) {
+	sel := Doc().Find("p").Has("small").End()
+	assertLength(t, sel.Nodes, 4)
+}
+
+func TestEndToTop(t *testing.T) {
+	sel := Doc().Find("p").Has("small").End().End().End()
+	assertLength(t, sel.Nodes, 0)
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/iteration.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/iteration.go
@@ -1,0 +1,33 @@
+package goquery
+
+// Each iterates over a Selection object, executing a function for each
+// matched element. It returns the current Selection object.
+func (s *Selection) Each(f func(int, *Selection)) *Selection {
+	for i, n := range s.Nodes {
+		f(i, newSingleSelection(n, s.document))
+	}
+	return s
+}
+
+// EachWithBreak iterates over a Selection object, executing a function for each
+// matched element. It is identical to Each except that it is possible to break
+// out of the loop by returning false in the callback function. It returns the
+// current Selection object.
+func (s *Selection) EachWithBreak(f func(int, *Selection) bool) *Selection {
+	for i, n := range s.Nodes {
+		if !f(i, newSingleSelection(n, s.document)) {
+			return s
+		}
+	}
+	return s
+}
+
+// Map passes each element in the current matched set through a function,
+// producing a slice of string holding the returned values.
+func (s *Selection) Map(f func(int, *Selection) string) (result []string) {
+	for i, n := range s.Nodes {
+		result = append(result, f(i, newSingleSelection(n, s.document)))
+	}
+
+	return result
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/iteration_test.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/iteration_test.go
@@ -1,0 +1,88 @@
+package goquery
+
+import (
+	"testing"
+
+	"bosun.org/_third_party/golang.org/x/net/html"
+)
+
+func TestEach(t *testing.T) {
+	var cnt int
+
+	sel := Doc().Find(".hero-unit .row-fluid").Each(func(i int, n *Selection) {
+		cnt++
+		t.Logf("At index %v, node %v", i, n.Nodes[0].Data)
+	}).Find("a")
+
+	if cnt != 4 {
+		t.Errorf("Expected Each() to call function 4 times, got %v times.", cnt)
+	}
+	assertLength(t, sel.Nodes, 6)
+}
+
+func TestEachWithBreak(t *testing.T) {
+	var cnt int
+
+	sel := Doc().Find(".hero-unit .row-fluid").EachWithBreak(func(i int, n *Selection) bool {
+		cnt++
+		t.Logf("At index %v, node %v", i, n.Nodes[0].Data)
+		return false
+	}).Find("a")
+
+	if cnt != 1 {
+		t.Errorf("Expected Each() to call function 1 time, got %v times.", cnt)
+	}
+	assertLength(t, sel.Nodes, 6)
+}
+
+func TestEachEmptySelection(t *testing.T) {
+	var cnt int
+
+	sel := Doc().Find("zzzz")
+	sel.Each(func(i int, n *Selection) {
+		cnt++
+	})
+	if cnt > 0 {
+		t.Error("Expected Each() to not be called on empty Selection.")
+	}
+	sel2 := sel.Find("div")
+	assertLength(t, sel2.Nodes, 0)
+}
+
+func TestMap(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	vals := sel.Map(func(i int, s *Selection) string {
+		n := s.Get(0)
+		if n.Type == html.ElementNode {
+			return n.Data
+		}
+		return ""
+	})
+	for _, v := range vals {
+		if v != "div" {
+			t.Error("Expected Map array result to be all 'div's.")
+		}
+	}
+	if len(vals) != 3 {
+		t.Errorf("Expected Map array result to have a length of 3, found %v.", len(vals))
+	}
+}
+
+func TestForRange(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	initLen := sel.Length()
+	for i := range sel.Nodes {
+		single := sel.Eq(i)
+		//h, err := single.Html()
+		//if err != nil {
+		//	t.Fatal(err)
+		//}
+		//fmt.Println(i, h)
+		if single.Length() != 1 {
+			t.Errorf("%d: expected length of 1, got %d", i, single.Length())
+		}
+	}
+	if sel.Length() != initLen {
+		t.Errorf("expected initial selection to still have length %d, got %d", initLen, sel.Length())
+	}
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/manipulation.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/manipulation.go
@@ -1,0 +1,551 @@
+package goquery
+
+import (
+	"strings"
+
+	"bosun.org/_third_party/github.com/andybalholm/cascadia"
+	"bosun.org/_third_party/golang.org/x/net/html"
+)
+
+// After applies the selector from the root document and inserts the matched elements
+// after the elements in the set of matched elements.
+//
+// If one of the matched elements in the selection is not currently in the
+// document, it's impossible to insert nodes after it, so it will be ignored.
+//
+// This follows the same rules as Selection.Append.
+func (s *Selection) After(selector string) *Selection {
+	return s.AfterMatcher(cascadia.MustCompile(selector))
+}
+
+// AfterMatcher applies the matcher from the root document and inserts the matched elements
+// after the elements in the set of matched elements.
+//
+// If one of the matched elements in the selection is not currently in the
+// document, it's impossible to insert nodes after it, so it will be ignored.
+//
+// This follows the same rules as Selection.Append.
+func (s *Selection) AfterMatcher(m Matcher) *Selection {
+	return s.AfterNodes(m.MatchAll(s.document.rootNode)...)
+}
+
+// AfterSelection inserts the elements in the selection after each element in the set of matched
+// elements.
+//
+// This follows the same rules as Selection.Append.
+func (s *Selection) AfterSelection(sel *Selection) *Selection {
+	return s.AfterNodes(sel.Nodes...)
+}
+
+// AfterHtml parses the html and inserts it after the set of matched elements.
+//
+// This follows the same rules as Selection.Append.
+func (s *Selection) AfterHtml(html string) *Selection {
+	return s.AfterNodes(parseHtml(html)...)
+}
+
+// AfterNodes inserts the nodes after each element in the set of matched elements.
+//
+// This follows the same rules as Selection.Append.
+func (s *Selection) AfterNodes(ns ...*html.Node) *Selection {
+	return s.manipulateNodes(ns, true, func(sn *html.Node, n *html.Node) {
+		if sn.Parent != nil {
+			sn.Parent.InsertBefore(n, sn.NextSibling)
+		}
+	})
+}
+
+// Append appends the elements specified by the selector to the end of each element
+// in the set of matched elements, following those rules:
+//
+// 1) The selector is applied to the root document.
+//
+// 2) Elements that are part of the document will be moved to the new location.
+//
+// 3) If there are multiple locations to append to, cloned nodes will be
+// appended to all target locations except the last one, which will be moved
+// as noted in (2).
+func (s *Selection) Append(selector string) *Selection {
+	return s.AppendMatcher(cascadia.MustCompile(selector))
+}
+
+// AppendMatcher appends the elements specified by the matcher to the end of each element
+// in the set of matched elements.
+//
+// This follows the same rules as Selection.Append.
+func (s *Selection) AppendMatcher(m Matcher) *Selection {
+	return s.AppendNodes(m.MatchAll(s.document.rootNode)...)
+}
+
+// AppendSelection appends the elements in the selection to the end of each element
+// in the set of matched elements.
+//
+// This follows the same rules as Selection.Append.
+func (s *Selection) AppendSelection(sel *Selection) *Selection {
+	return s.AppendNodes(sel.Nodes...)
+}
+
+// AppendHtml parses the html and appends it to the set of matched elements.
+func (s *Selection) AppendHtml(html string) *Selection {
+	return s.AppendNodes(parseHtml(html)...)
+}
+
+// AppendNodes appends the specified nodes to each node in the set of matched elements.
+//
+// This follows the same rules as Selection.Append.
+func (s *Selection) AppendNodes(ns ...*html.Node) *Selection {
+	return s.manipulateNodes(ns, false, func(sn *html.Node, n *html.Node) {
+		sn.AppendChild(n)
+	})
+}
+
+// Before inserts the matched elements before each element in the set of matched elements.
+//
+// This follows the same rules as Selection.Append.
+func (s *Selection) Before(selector string) *Selection {
+	return s.BeforeMatcher(cascadia.MustCompile(selector))
+}
+
+// BeforeMatcher inserts the matched elements before each element in the set of matched elements.
+//
+// This follows the same rules as Selection.Append.
+func (s *Selection) BeforeMatcher(m Matcher) *Selection {
+	return s.BeforeNodes(m.MatchAll(s.document.rootNode)...)
+}
+
+// BeforeSelection inserts the elements in the selection before each element in the set of matched
+// elements.
+//
+// This follows the same rules as Selection.Append.
+func (s *Selection) BeforeSelection(sel *Selection) *Selection {
+	return s.BeforeNodes(sel.Nodes...)
+}
+
+// BeforeHtml parses the html and inserts it before the set of matched elements.
+//
+// This follows the same rules as Selection.Append.
+func (s *Selection) BeforeHtml(html string) *Selection {
+	return s.BeforeNodes(parseHtml(html)...)
+}
+
+// BeforeNodes inserts the nodes before each element in the set of matched elements.
+//
+// This follows the same rules as Selection.Append.
+func (s *Selection) BeforeNodes(ns ...*html.Node) *Selection {
+	return s.manipulateNodes(ns, false, func(sn *html.Node, n *html.Node) {
+		if sn.Parent != nil {
+			sn.Parent.InsertBefore(n, sn)
+		}
+	})
+}
+
+// Clone creates a deep copy of the set of matched nodes. The new nodes will not be
+// attached to the document.
+func (s *Selection) Clone() *Selection {
+	ns := newEmptySelection(s.document)
+	ns.Nodes = cloneNodes(s.Nodes)
+	return ns
+}
+
+// Empty removes all children nodes from the set of matched elements.
+// It returns the children nodes in a new Selection.
+func (s *Selection) Empty() *Selection {
+	var nodes []*html.Node
+
+	for _, n := range s.Nodes {
+		for c := n.FirstChild; c != nil; c = n.FirstChild {
+			n.RemoveChild(c)
+			nodes = append(nodes, c)
+		}
+	}
+
+	return pushStack(s, nodes)
+}
+
+// Prepend prepends the elements specified by the selector to each element in
+// the set of matched elements, following the same rules as Append.
+func (s *Selection) Prepend(selector string) *Selection {
+	return s.PrependMatcher(cascadia.MustCompile(selector))
+}
+
+// PrependMatcher prepends the elements specified by the matcher to each
+// element in the set of matched elements.
+//
+// This follows the same rules as Selection.Append.
+func (s *Selection) PrependMatcher(m Matcher) *Selection {
+	return s.PrependNodes(m.MatchAll(s.document.rootNode)...)
+}
+
+// PrependSelection prepends the elements in the selection to each element in
+// the set of matched elements.
+//
+// This follows the same rules as Selection.Append.
+func (s *Selection) PrependSelection(sel *Selection) *Selection {
+	return s.PrependNodes(sel.Nodes...)
+}
+
+// PrependHtml parses the html and prepends it to the set of matched elements.
+func (s *Selection) PrependHtml(html string) *Selection {
+	return s.PrependNodes(parseHtml(html)...)
+}
+
+// PrependNodes prepends the specified nodes to each node in the set of
+// matched elements.
+//
+// This follows the same rules as Selection.Append.
+func (s *Selection) PrependNodes(ns ...*html.Node) *Selection {
+	return s.manipulateNodes(ns, true, func(sn *html.Node, n *html.Node) {
+		// sn.FirstChild may be nil, in which case this functions like
+		// sn.AppendChild()
+		sn.InsertBefore(n, sn.FirstChild)
+	})
+}
+
+// Remove removes the set of matched elements from the document.
+// It returns the same selection, now consisting of nodes not in the document.
+func (s *Selection) Remove() *Selection {
+	for _, n := range s.Nodes {
+		if n.Parent != nil {
+			n.Parent.RemoveChild(n)
+		}
+	}
+
+	return s
+}
+
+// RemoveFiltered removes the set of matched elements by selector.
+// It returns the Selection of removed nodes.
+func (s *Selection) RemoveFiltered(selector string) *Selection {
+	return s.RemoveMatcher(cascadia.MustCompile(selector))
+}
+
+// RemoveMatcher removes the set of matched elements.
+// It returns the Selection of removed nodes.
+func (s *Selection) RemoveMatcher(m Matcher) *Selection {
+	return s.FilterMatcher(m).Remove()
+}
+
+// ReplaceWith replaces each element in the set of matched elements with the
+// nodes matched by the given selector.
+// It returns the removed elements.
+//
+// This follows the same rules as Selection.Append.
+func (s *Selection) ReplaceWith(selector string) *Selection {
+	return s.ReplaceWithMatcher(cascadia.MustCompile(selector))
+}
+
+// ReplaceWithMatcher replaces each element in the set of matched elements with
+// the nodes matched by the given Matcher.
+// It returns the removed elements.
+//
+// This follows the same rules as Selection.Append.
+func (s *Selection) ReplaceWithMatcher(m Matcher) *Selection {
+	return s.ReplaceWithNodes(m.MatchAll(s.document.rootNode)...)
+}
+
+// ReplaceWithSelection replaces each element in the set of matched elements with
+// the nodes from the given Selection.
+// It returns the removed elements.
+//
+// This follows the same rules as Selection.Append.
+func (s *Selection) ReplaceWithSelection(sel *Selection) *Selection {
+	return s.ReplaceWithNodes(sel.Nodes...)
+}
+
+// ReplaceWithHtml replaces each element in the set of matched elements with
+// the parsed HTML.
+// It returns the removed elements.
+//
+// This follows the same rules as Selection.Append.
+func (s *Selection) ReplaceWithHtml(html string) *Selection {
+	return s.ReplaceWithNodes(parseHtml(html)...)
+}
+
+// ReplaceWithNodes replaces each element in the set of matched elements with
+// the given nodes.
+// It returns the removed elements.
+//
+// This follows the same rules as Selection.Append.
+func (s *Selection) ReplaceWithNodes(ns ...*html.Node) *Selection {
+	s.AfterNodes(ns...)
+	return s.Remove()
+}
+
+// Unwrap removes the parents of the set of matched elements, leaving the matched
+// elements (and their siblings, if any) in their place.
+// It returns the original selection.
+func (s *Selection) Unwrap() *Selection {
+	s.Parent().Each(func(i int, ss *Selection) {
+		// For some reason, jquery allows unwrap to remove the <head> element, so
+		// allowing it here too. Same for <html>. Why it allows those elements to
+		// be unwrapped while not allowing body is a mystery to me.
+		if ss.Nodes[0].Data != "body" {
+			ss.ReplaceWithSelection(ss.Contents())
+		}
+	})
+
+	return s
+}
+
+// Wrap wraps each element in the set of matched elements inside the first
+// element matched by the given selector. The matched child is cloned before
+// being inserted into the document.
+//
+// It returns the original set of elements.
+func (s *Selection) Wrap(selector string) *Selection {
+	return s.WrapMatcher(cascadia.MustCompile(selector))
+}
+
+// WrapMatcher wraps each element in the set of matched elements inside the
+// first element matched by the given matcher. The matched child is cloned
+// before being inserted into the document.
+//
+// It returns the original set of elements.
+func (s *Selection) WrapMatcher(m Matcher) *Selection {
+	return s.wrapNodes(m.MatchAll(s.document.rootNode)...)
+}
+
+// WrapSelection wraps each element in the set of matched elements inside the
+// first element in the given Selection. The element is cloned before being
+// inserted into the document.
+//
+// It returns the original set of elements.
+func (s *Selection) WrapSelection(sel *Selection) *Selection {
+	return s.wrapNodes(sel.Nodes...)
+}
+
+// WrapHtml wraps each element in the set of matched elements inside the inner-
+// most child of the given HTML.
+//
+// It returns the original set of elements.
+func (s *Selection) WrapHtml(html string) *Selection {
+	return s.wrapNodes(parseHtml(html)...)
+}
+
+// WrapNode wraps each element in the set of matched elements inside the inner-
+// most child of the given node. The given node is copied before being inserted
+// into the document.
+//
+// It returns the original set of elements.
+func (s *Selection) WrapNode(n *html.Node) *Selection {
+	return s.wrapNodes(n)
+}
+
+func (s *Selection) wrapNodes(ns ...*html.Node) *Selection {
+	s.Each(func(i int, ss *Selection) {
+		ss.wrapAllNodes(ns...)
+	})
+
+	return s
+}
+
+// WrapAll wraps a single HTML structure, matched by the given selector, around
+// all elements in the set of matched elements. The matched child is cloned
+// before being inserted into the document.
+//
+// It returns the original set of elements.
+func (s *Selection) WrapAll(selector string) *Selection {
+	return s.WrapAllMatcher(cascadia.MustCompile(selector))
+}
+
+// WrapAllMatcher wraps a single HTML structure, matched by the given Matcher,
+// around all elements in the set of matched elements. The matched child is
+// cloned before being inserted into the document.
+//
+// It returns the original set of elements.
+func (s *Selection) WrapAllMatcher(m Matcher) *Selection {
+	return s.wrapAllNodes(m.MatchAll(s.document.rootNode)...)
+}
+
+// WrapAllSelection wraps a single HTML structure, the first node of the given
+// Selection, around all elements in the set of matched elements. The matched
+// child is cloned before being inserted into the document.
+//
+// It returns the original set of elements.
+func (s *Selection) WrapAllSelection(sel *Selection) *Selection {
+	return s.wrapAllNodes(sel.Nodes...)
+}
+
+// WrapAllHtml wraps the given HTML structure around all elements in the set of
+// matched elements. The matched child is cloned before being inserted into the
+// document.
+//
+// It returns the original set of elements.
+func (s *Selection) WrapAllHtml(html string) *Selection {
+	return s.wrapAllNodes(parseHtml(html)...)
+}
+
+func (s *Selection) wrapAllNodes(ns ...*html.Node) *Selection {
+	if len(ns) > 0 {
+		return s.WrapAllNode(ns[0])
+	}
+	return s
+}
+
+// WrapAllNode wraps the given node around the first element in the Selection,
+// making all other nodes in the Selection children of the given node. The node
+// is cloned before being inserted into the document.
+//
+// It returns the original set of elements.
+func (s *Selection) WrapAllNode(n *html.Node) *Selection {
+	if s.Size() == 0 {
+		return s
+	}
+
+	wrap := cloneNode(n)
+
+	first := s.Nodes[0]
+	if first.Parent != nil {
+		first.Parent.InsertBefore(wrap, first)
+		first.Parent.RemoveChild(first)
+	}
+
+	for c := getFirstChildEl(wrap); c != nil; c = getFirstChildEl(wrap) {
+		wrap = c
+	}
+
+	newSingleSelection(wrap, s.document).AppendSelection(s)
+
+	return s
+}
+
+// WrapInner wraps an HTML structure, matched by the given selector, around the
+// content of element in the set of matched elements. The matched child is
+// cloned before being inserted into the document.
+//
+// It returns the original set of elements.
+func (s *Selection) WrapInner(selector string) *Selection {
+	return s.WrapInnerMatcher(cascadia.MustCompile(selector))
+}
+
+// WrapInnerMatcher wraps an HTML structure, matched by the given selector,
+// around the content of element in the set of matched elements. The matched
+// child is cloned before being inserted into the document.
+//
+// It returns the original set of elements.
+func (s *Selection) WrapInnerMatcher(m Matcher) *Selection {
+	return s.wrapInnerNodes(m.MatchAll(s.document.rootNode)...)
+}
+
+// WrapInnerSelection wraps an HTML structure, matched by the given selector,
+// around the content of element in the set of matched elements. The matched
+// child is cloned before being inserted into the document.
+//
+// It returns the original set of elements.
+func (s *Selection) WrapInnerSelection(sel *Selection) *Selection {
+	return s.wrapInnerNodes(sel.Nodes...)
+}
+
+// WrapInnerHtml wraps an HTML structure, matched by the given selector, around
+// the content of element in the set of matched elements. The matched child is
+// cloned before being inserted into the document.
+//
+// It returns the original set of elements.
+func (s *Selection) WrapInnerHtml(html string) *Selection {
+	return s.wrapInnerNodes(parseHtml(html)...)
+}
+
+// WrapInnerNode wraps an HTML structure, matched by the given selector, around
+// the content of element in the set of matched elements. The matched child is
+// cloned before being inserted into the document.
+//
+// It returns the original set of elements.
+func (s *Selection) WrapInnerNode(n *html.Node) *Selection {
+	return s.wrapInnerNodes(n)
+}
+
+func (s *Selection) wrapInnerNodes(ns ...*html.Node) *Selection {
+	if len(ns) == 0 {
+		return s
+	}
+
+	s.Each(func(i int, s *Selection) {
+		contents := s.Contents()
+
+		if contents.Size() > 0 {
+			contents.wrapAllNodes(ns...)
+		} else {
+			s.AppendNodes(cloneNode(ns[0]))
+		}
+	})
+
+	return s
+}
+
+func parseHtml(h string) []*html.Node {
+	// Errors are only returned when the io.Reader returns any error besides
+	// EOF, but strings.Reader never will
+	nodes, err := html.ParseFragment(strings.NewReader(h), &html.Node{Type: html.ElementNode})
+	if err != nil {
+		panic("goquery: failed to parse HTML: " + err.Error())
+	}
+	return nodes
+}
+
+// Get the first child that is an ElementNode
+func getFirstChildEl(n *html.Node) *html.Node {
+	c := n.FirstChild
+	for c != nil && c.Type != html.ElementNode {
+		c = c.NextSibling
+	}
+	return c
+}
+
+// Deep copy a slice of nodes.
+func cloneNodes(ns []*html.Node) []*html.Node {
+	cns := make([]*html.Node, 0, len(ns))
+
+	for _, n := range ns {
+		cns = append(cns, cloneNode(n))
+	}
+
+	return cns
+}
+
+// Deep copy a node. The new node has clones of all the original node's
+// children but none of its parents or siblings.
+func cloneNode(n *html.Node) *html.Node {
+	nn := &html.Node{
+		Type:     n.Type,
+		DataAtom: n.DataAtom,
+		Data:     n.Data,
+		Attr:     make([]html.Attribute, len(n.Attr)),
+	}
+
+	copy(nn.Attr, n.Attr)
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		nn.AppendChild(cloneNode(c))
+	}
+
+	return nn
+}
+
+func (s *Selection) manipulateNodes(ns []*html.Node, reverse bool,
+	f func(sn *html.Node, n *html.Node)) *Selection {
+
+	lasti := s.Size() - 1
+
+	// net.Html doesn't provide document fragments for insertion, so to get
+	// things in the correct order with After() and Prepend(), the callback
+	// needs to be called on the reverse of the nodes.
+	if reverse {
+		for i, j := 0, len(ns)-1; i < j; i, j = i+1, j-1 {
+			ns[i], ns[j] = ns[j], ns[i]
+		}
+	}
+
+	for i, sn := range s.Nodes {
+		for _, n := range ns {
+			if i != lasti {
+				f(sn, cloneNode(n))
+			} else {
+				if n.Parent != nil {
+					n.Parent.RemoveChild(n)
+				}
+				f(sn, n)
+			}
+		}
+	}
+
+	return s
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/manipulation_test.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/manipulation_test.go
@@ -1,0 +1,453 @@
+package goquery
+
+import (
+	"testing"
+)
+
+const (
+	wrapHtml = "<div id=\"ins\">test string<div><p><em><b></b></em></p></div></div>"
+)
+
+func TestAfter(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("#main").After("#nf6")
+
+	assertLength(t, doc.Find("#main #nf6").Nodes, 0)
+	assertLength(t, doc.Find("#foot #nf6").Nodes, 0)
+	assertLength(t, doc.Find("#main + #nf6").Nodes, 1)
+	printSel(t, doc.Selection)
+}
+
+func TestAfterMany(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find(".one").After("#nf6")
+
+	assertLength(t, doc.Find("#foot #nf6").Nodes, 1)
+	assertLength(t, doc.Find("#main #nf6").Nodes, 1)
+	assertLength(t, doc.Find(".one + #nf6").Nodes, 2)
+	printSel(t, doc.Selection)
+}
+
+func TestAfterWithRemoved(t *testing.T) {
+	doc := Doc2Clone()
+	s := doc.Find("#main").Remove()
+	s.After("#nf6")
+
+	assertLength(t, s.Find("#nf6").Nodes, 0)
+	assertLength(t, doc.Find("#nf6").Nodes, 0)
+	printSel(t, doc.Selection)
+}
+
+func TestAfterSelection(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("#main").AfterSelection(doc.Find("#nf1, #nf2"))
+
+	assertLength(t, doc.Find("#main #nf1, #main #nf2").Nodes, 0)
+	assertLength(t, doc.Find("#foot #nf1, #foot #nf2").Nodes, 0)
+	assertLength(t, doc.Find("#main + #nf1, #nf1 + #nf2").Nodes, 2)
+	printSel(t, doc.Selection)
+}
+
+func TestAfterHtml(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("#main").AfterHtml("<strong>new node</strong>")
+
+	assertLength(t, doc.Find("#main + strong").Nodes, 1)
+	printSel(t, doc.Selection)
+}
+
+func TestAppend(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("#main").Append("#nf6")
+
+	assertLength(t, doc.Find("#foot #nf6").Nodes, 0)
+	assertLength(t, doc.Find("#main #nf6").Nodes, 1)
+	printSel(t, doc.Selection)
+}
+
+func TestAppendBody(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("body").Append("#nf6")
+
+	assertLength(t, doc.Find("#foot #nf6").Nodes, 0)
+	assertLength(t, doc.Find("#main #nf6").Nodes, 0)
+	assertLength(t, doc.Find("body > #nf6").Nodes, 1)
+	printSel(t, doc.Selection)
+}
+
+func TestAppendSelection(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("#main").AppendSelection(doc.Find("#nf1, #nf2"))
+
+	assertLength(t, doc.Find("#foot #nf1").Nodes, 0)
+	assertLength(t, doc.Find("#foot #nf2").Nodes, 0)
+	assertLength(t, doc.Find("#main #nf1").Nodes, 1)
+	assertLength(t, doc.Find("#main #nf2").Nodes, 1)
+	printSel(t, doc.Selection)
+}
+
+func TestAppendSelectionExisting(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("#main").AppendSelection(doc.Find("#n1, #n2"))
+
+	assertClass(t, doc.Find("#main :nth-child(1)"), "three")
+	assertClass(t, doc.Find("#main :nth-child(5)"), "one")
+	assertClass(t, doc.Find("#main :nth-child(6)"), "two")
+	printSel(t, doc.Selection)
+}
+
+func TestAppendClone(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("#n1").AppendSelection(doc.Find("#nf1").Clone())
+
+	assertLength(t, doc.Find("#foot #nf1").Nodes, 1)
+	assertLength(t, doc.Find("#main #nf1").Nodes, 1)
+	printSel(t, doc.Selection)
+}
+
+func TestAppendHtml(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("div").AppendHtml("<strong>new node</strong>")
+
+	assertLength(t, doc.Find("strong").Nodes, 14)
+	printSel(t, doc.Selection)
+}
+
+func TestBefore(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("#main").Before("#nf6")
+
+	assertLength(t, doc.Find("#main #nf6").Nodes, 0)
+	assertLength(t, doc.Find("#foot #nf6").Nodes, 0)
+	assertLength(t, doc.Find("body > #nf6:first-child").Nodes, 1)
+	printSel(t, doc.Selection)
+}
+
+func TestBeforeWithRemoved(t *testing.T) {
+	doc := Doc2Clone()
+	s := doc.Find("#main").Remove()
+	s.Before("#nf6")
+
+	assertLength(t, s.Find("#nf6").Nodes, 0)
+	assertLength(t, doc.Find("#nf6").Nodes, 0)
+	printSel(t, doc.Selection)
+}
+
+func TestBeforeSelection(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("#main").BeforeSelection(doc.Find("#nf1, #nf2"))
+
+	assertLength(t, doc.Find("#main #nf1, #main #nf2").Nodes, 0)
+	assertLength(t, doc.Find("#foot #nf1, #foot #nf2").Nodes, 0)
+	assertLength(t, doc.Find("body > #nf1:first-child, #nf1 + #nf2").Nodes, 2)
+	printSel(t, doc.Selection)
+}
+
+func TestBeforeHtml(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("#main").BeforeHtml("<strong>new node</strong>")
+
+	assertLength(t, doc.Find("body > strong:first-child").Nodes, 1)
+	printSel(t, doc.Selection)
+}
+
+func TestEmpty(t *testing.T) {
+	doc := Doc2Clone()
+	s := doc.Find("#main").Empty()
+
+	assertLength(t, doc.Find("#main").Children().Nodes, 0)
+	assertLength(t, s.Filter("div").Nodes, 6)
+	printSel(t, doc.Selection)
+}
+
+func TestPrepend(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("#main").Prepend("#nf6")
+
+	assertLength(t, doc.Find("#foot #nf6").Nodes, 0)
+	assertLength(t, doc.Find("#main #nf6:first-child").Nodes, 1)
+	printSel(t, doc.Selection)
+}
+
+func TestPrependBody(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("body").Prepend("#nf6")
+
+	assertLength(t, doc.Find("#foot #nf6").Nodes, 0)
+	assertLength(t, doc.Find("#main #nf6").Nodes, 0)
+	assertLength(t, doc.Find("body > #nf6:first-child").Nodes, 1)
+	printSel(t, doc.Selection)
+}
+
+func TestPrependSelection(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("#main").PrependSelection(doc.Find("#nf1, #nf2"))
+
+	assertLength(t, doc.Find("#foot #nf1").Nodes, 0)
+	assertLength(t, doc.Find("#foot #nf2").Nodes, 0)
+	assertLength(t, doc.Find("#main #nf1:first-child").Nodes, 1)
+	assertLength(t, doc.Find("#main #nf2:nth-child(2)").Nodes, 1)
+	printSel(t, doc.Selection)
+}
+
+func TestPrependSelectionExisting(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("#main").PrependSelection(doc.Find("#n5, #n6"))
+
+	assertClass(t, doc.Find("#main :nth-child(1)"), "five")
+	assertClass(t, doc.Find("#main :nth-child(2)"), "six")
+	assertClass(t, doc.Find("#main :nth-child(5)"), "three")
+	assertClass(t, doc.Find("#main :nth-child(6)"), "four")
+	printSel(t, doc.Selection)
+}
+
+func TestPrependClone(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("#n1").PrependSelection(doc.Find("#nf1").Clone())
+
+	assertLength(t, doc.Find("#foot #nf1:first-child").Nodes, 1)
+	assertLength(t, doc.Find("#main #nf1:first-child").Nodes, 1)
+	printSel(t, doc.Selection)
+}
+
+func TestPrependHtml(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("div").PrependHtml("<strong>new node</strong>")
+
+	assertLength(t, doc.Find("strong:first-child").Nodes, 14)
+	printSel(t, doc.Selection)
+}
+
+func TestRemove(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("#nf1").Remove()
+
+	assertLength(t, doc.Find("#foot #nf1").Nodes, 0)
+	printSel(t, doc.Selection)
+}
+
+func TestRemoveAll(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("*").Remove()
+
+	assertLength(t, doc.Find("*").Nodes, 0)
+	printSel(t, doc.Selection)
+}
+
+func TestRemoveRoot(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("html").Remove()
+
+	assertLength(t, doc.Find("html").Nodes, 0)
+	printSel(t, doc.Selection)
+}
+
+func TestRemoveFiltered(t *testing.T) {
+	doc := Doc2Clone()
+	nf6 := doc.Find("#nf6")
+	s := doc.Find("div").RemoveFiltered("#nf6")
+
+	assertLength(t, doc.Find("#nf6").Nodes, 0)
+	assertLength(t, s.Nodes, 1)
+	if nf6.Nodes[0] != s.Nodes[0] {
+		t.Error("Removed node does not match original")
+	}
+	printSel(t, doc.Selection)
+}
+
+func TestReplaceWith(t *testing.T) {
+	doc := Doc2Clone()
+
+	doc.Find("#nf6").ReplaceWith("#main")
+	assertLength(t, doc.Find("#foot #main:last-child").Nodes, 1)
+	printSel(t, doc.Selection)
+
+	doc.Find("#foot").ReplaceWith("#main")
+	assertLength(t, doc.Find("#foot").Nodes, 0)
+	assertLength(t, doc.Find("#main").Nodes, 1)
+
+	printSel(t, doc.Selection)
+}
+
+func TestReplaceWithHtml(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("#main, #foot").ReplaceWithHtml("<div id=\"replace\"></div>")
+
+	assertLength(t, doc.Find("#replace").Nodes, 2)
+
+	printSel(t, doc.Selection)
+}
+
+func TestReplaceWithSelection(t *testing.T) {
+	doc := Doc2Clone()
+	sel := doc.Find("#nf6").ReplaceWithSelection(doc.Find("#nf5"))
+
+	assertSelectionIs(t, sel, "#nf6")
+	assertLength(t, doc.Find("#nf6").Nodes, 0)
+	assertLength(t, doc.Find("#nf5").Nodes, 1)
+
+	printSel(t, doc.Selection)
+}
+
+func TestUnwrap(t *testing.T) {
+	doc := Doc2Clone()
+
+	doc.Find("#nf5").Unwrap()
+	assertLength(t, doc.Find("#foot").Nodes, 0)
+	assertLength(t, doc.Find("body > #nf1").Nodes, 1)
+	assertLength(t, doc.Find("body > #nf5").Nodes, 1)
+
+	printSel(t, doc.Selection)
+
+	doc = Doc2Clone()
+
+	doc.Find("#nf5, #n1").Unwrap()
+	assertLength(t, doc.Find("#foot").Nodes, 0)
+	assertLength(t, doc.Find("#main").Nodes, 0)
+	assertLength(t, doc.Find("body > #n1").Nodes, 1)
+	assertLength(t, doc.Find("body > #nf5").Nodes, 1)
+
+	printSel(t, doc.Selection)
+}
+
+func TestUnwrapBody(t *testing.T) {
+	doc := Doc2Clone()
+
+	doc.Find("#main").Unwrap()
+	assertLength(t, doc.Find("body").Nodes, 1)
+	assertLength(t, doc.Find("body > #main").Nodes, 1)
+
+	printSel(t, doc.Selection)
+}
+
+func TestUnwrapHead(t *testing.T) {
+	doc := Doc2Clone()
+
+	doc.Find("title").Unwrap()
+	assertLength(t, doc.Find("head").Nodes, 0)
+	assertLength(t, doc.Find("head > title").Nodes, 0)
+	assertLength(t, doc.Find("title").Nodes, 1)
+
+	printSel(t, doc.Selection)
+}
+
+func TestUnwrapHtml(t *testing.T) {
+	doc := Doc2Clone()
+
+	doc.Find("head").Unwrap()
+	assertLength(t, doc.Find("html").Nodes, 0)
+	assertLength(t, doc.Find("html head").Nodes, 0)
+	assertLength(t, doc.Find("head").Nodes, 1)
+
+	printSel(t, doc.Selection)
+}
+
+func TestWrap(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("#nf1").Wrap("#nf2")
+	nf1 := doc.Find("#foot #nf2 #nf1")
+	assertLength(t, nf1.Nodes, 1)
+
+	nf2 := doc.Find("#nf2")
+	assertLength(t, nf2.Nodes, 2)
+
+	printSel(t, doc.Selection)
+}
+
+func TestWrapEmpty(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("#nf1").Wrap("#doesnt-exist")
+
+	origHtml, _ := Doc2().Html()
+	newHtml, _ := doc.Html()
+
+	if origHtml != newHtml {
+		t.Error("Expected the two documents to be identical.")
+	}
+
+	printSel(t, doc.Selection)
+}
+
+func TestWrapHtml(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find(".odd").WrapHtml(wrapHtml)
+	nf2 := doc.Find("#ins #nf2")
+	assertLength(t, nf2.Nodes, 1)
+	printSel(t, doc.Selection)
+}
+
+func TestWrapSelection(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("#nf1").WrapSelection(doc.Find("#nf2"))
+	nf1 := doc.Find("#foot #nf2 #nf1")
+	assertLength(t, nf1.Nodes, 1)
+
+	nf2 := doc.Find("#nf2")
+	assertLength(t, nf2.Nodes, 2)
+
+	printSel(t, doc.Selection)
+}
+
+func TestWrapAll(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find(".odd").WrapAll("#nf1")
+	nf1 := doc.Find("#main #nf1")
+	assertLength(t, nf1.Nodes, 1)
+
+	sel := nf1.Find("#n2 ~ #n4 ~ #n6 ~ #nf2 ~ #nf4 ~ #nf6")
+	assertLength(t, sel.Nodes, 1)
+
+	printSel(t, doc.Selection)
+}
+
+func TestWrapAllHtml(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find(".odd").WrapAllHtml(wrapHtml)
+	nf1 := doc.Find("#main div#ins div p em b #n2 ~ #n4 ~ #n6 ~ #nf2 ~ #nf4 ~ #nf6")
+	assertLength(t, nf1.Nodes, 1)
+	printSel(t, doc.Selection)
+}
+
+func TestWrapInnerNoContent(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find(".one").WrapInner(".two")
+
+	twos := doc.Find(".two")
+	assertLength(t, twos.Nodes, 4)
+	assertLength(t, doc.Find(".one .two").Nodes, 2)
+
+	printSel(t, doc.Selection)
+}
+
+func TestWrapInnerWithContent(t *testing.T) {
+	doc := Doc3Clone()
+	doc.Find(".one").WrapInner(".two")
+
+	twos := doc.Find(".two")
+	assertLength(t, twos.Nodes, 4)
+	assertLength(t, doc.Find(".one .two").Nodes, 2)
+
+	printSel(t, doc.Selection)
+}
+
+func TestWrapInnerNoWrapper(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find(".one").WrapInner(".not-exist")
+
+	twos := doc.Find(".two")
+	assertLength(t, twos.Nodes, 2)
+	assertLength(t, doc.Find(".one").Nodes, 2)
+	assertLength(t, doc.Find(".one .two").Nodes, 0)
+
+	printSel(t, doc.Selection)
+}
+
+func TestWrapInnerHtml(t *testing.T) {
+	doc := Doc2Clone()
+	doc.Find("#foot").WrapInnerHtml(wrapHtml)
+
+	foot := doc.Find("#foot div#ins div p em b #nf1 ~ #nf2 ~ #nf3")
+	assertLength(t, foot.Nodes, 1)
+
+	printSel(t, doc.Selection)
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/property.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/property.go
@@ -1,0 +1,278 @@
+package goquery
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+
+	"bosun.org/_third_party/golang.org/x/net/html"
+)
+
+var rxClassTrim = regexp.MustCompile("[\t\r\n]")
+
+// Attr gets the specified attribute's value for the first element in the
+// Selection. To get the value for each element individually, use a looping
+// construct such as Each or Map method.
+func (s *Selection) Attr(attrName string) (val string, exists bool) {
+	if len(s.Nodes) == 0 {
+		return
+	}
+	return getAttributeValue(attrName, s.Nodes[0])
+}
+
+// AttrOr works like Attr but returns default value if attribute is not present.
+func (s *Selection) AttrOr(attrName, defaultValue string) string {
+	if len(s.Nodes) == 0 {
+		return ""
+	}
+
+	val, exists := getAttributeValue(attrName, s.Nodes[0])
+	if !exists {
+		return defaultValue
+	}
+
+	return val
+}
+
+// RemoveAttr removes the named attribute from each element in the set of matched elements.
+func (s *Selection) RemoveAttr(attrName string) *Selection {
+	for _, n := range s.Nodes {
+		removeAttr(n, attrName)
+	}
+
+	return s
+}
+
+// SetAttr sets the given attribute on each element in the set of matched elements.
+func (s *Selection) SetAttr(attrName, val string) *Selection {
+	for _, n := range s.Nodes {
+		attr := getAttributePtr(attrName, n)
+		if attr == nil {
+			n.Attr = append(n.Attr, html.Attribute{Key: attrName, Val: val})
+		} else {
+			attr.Val = val
+		}
+	}
+
+	return s
+}
+
+// Text gets the combined text contents of each element in the set of matched
+// elements, including their descendants.
+func (s *Selection) Text() string {
+	var buf bytes.Buffer
+
+	// Slightly optimized vs calling Each: no single selection object created
+	for _, n := range s.Nodes {
+		buf.WriteString(getNodeText(n))
+	}
+	return buf.String()
+}
+
+// Size is an alias for Length.
+func (s *Selection) Size() int {
+	return s.Length()
+}
+
+// Length returns the number of elements in the Selection object.
+func (s *Selection) Length() int {
+	return len(s.Nodes)
+}
+
+// Html gets the HTML contents of the first element in the set of matched
+// elements. It includes text and comment nodes.
+func (s *Selection) Html() (ret string, e error) {
+	// Since there is no .innerHtml, the HTML content must be re-created from
+	// the nodes using html.Render.
+	var buf bytes.Buffer
+
+	if len(s.Nodes) > 0 {
+		for c := s.Nodes[0].FirstChild; c != nil; c = c.NextSibling {
+			e = html.Render(&buf, c)
+			if e != nil {
+				return
+			}
+		}
+		ret = buf.String()
+	}
+
+	return
+}
+
+// AddClass adds the given class(es) to each element in the set of matched elements.
+// Multiple class names can be specified, separated by a space or via multiple arguments.
+func (s *Selection) AddClass(class ...string) *Selection {
+	classStr := strings.TrimSpace(strings.Join(class, " "))
+
+	if classStr == "" {
+		return s
+	}
+
+	tcls := getClassesSlice(classStr)
+	for _, n := range s.Nodes {
+		curClasses, attr := getClassesAndAttr(n, true)
+		for _, newClass := range tcls {
+			if strings.Index(curClasses, " "+newClass+" ") == -1 {
+				curClasses += newClass + " "
+			}
+		}
+
+		setClasses(n, attr, curClasses)
+	}
+
+	return s
+}
+
+// HasClass determines whether any of the matched elements are assigned the
+// given class.
+func (s *Selection) HasClass(class string) bool {
+	class = " " + class + " "
+	for _, n := range s.Nodes {
+		classes, _ := getClassesAndAttr(n, false)
+		if strings.Index(classes, class) > -1 {
+			return true
+		}
+	}
+	return false
+}
+
+// RemoveClass removes the given class(es) from each element in the set of matched elements.
+// Multiple class names can be specified, separated by a space or via multiple arguments.
+// If no class name is provided, all classes are removed.
+func (s *Selection) RemoveClass(class ...string) *Selection {
+	var rclasses []string
+
+	classStr := strings.TrimSpace(strings.Join(class, " "))
+	remove := classStr == ""
+
+	if !remove {
+		rclasses = getClassesSlice(classStr)
+	}
+
+	for _, n := range s.Nodes {
+		if remove {
+			removeAttr(n, "class")
+		} else {
+			classes, attr := getClassesAndAttr(n, true)
+			for _, rcl := range rclasses {
+				classes = strings.Replace(classes, " "+rcl+" ", " ", -1)
+			}
+
+			setClasses(n, attr, classes)
+		}
+	}
+
+	return s
+}
+
+// ToggleClass adds or removes the given class(es) for each element in the set of matched elements.
+// Multiple class names can be specified, separated by a space or via multiple arguments.
+func (s *Selection) ToggleClass(class ...string) *Selection {
+	classStr := strings.TrimSpace(strings.Join(class, " "))
+
+	if classStr == "" {
+		return s
+	}
+
+	tcls := getClassesSlice(classStr)
+
+	for _, n := range s.Nodes {
+		classes, attr := getClassesAndAttr(n, true)
+		for _, tcl := range tcls {
+			if strings.Index(classes, " "+tcl+" ") != -1 {
+				classes = strings.Replace(classes, " "+tcl+" ", " ", -1)
+			} else {
+				classes += tcl + " "
+			}
+		}
+
+		setClasses(n, attr, classes)
+	}
+
+	return s
+}
+
+// Get the specified node's text content.
+func getNodeText(node *html.Node) string {
+	if node.Type == html.TextNode {
+		// Keep newlines and spaces, like jQuery
+		return node.Data
+	} else if node.FirstChild != nil {
+		var buf bytes.Buffer
+		for c := node.FirstChild; c != nil; c = c.NextSibling {
+			buf.WriteString(getNodeText(c))
+		}
+		return buf.String()
+	}
+
+	return ""
+}
+
+func getAttributePtr(attrName string, n *html.Node) *html.Attribute {
+	if n == nil {
+		return nil
+	}
+
+	for i, a := range n.Attr {
+		if a.Key == attrName {
+			return &n.Attr[i]
+		}
+	}
+	return nil
+}
+
+// Private function to get the specified attribute's value from a node.
+func getAttributeValue(attrName string, n *html.Node) (val string, exists bool) {
+	if a := getAttributePtr(attrName, n); a != nil {
+		val = a.Val
+		exists = true
+	}
+	return
+}
+
+// Get and normalize the "class" attribute from the node.
+func getClassesAndAttr(n *html.Node, create bool) (classes string, attr *html.Attribute) {
+	// Applies only to element nodes
+	if n.Type == html.ElementNode {
+		attr = getAttributePtr("class", n)
+		if attr == nil && create {
+			n.Attr = append(n.Attr, html.Attribute{
+				Key: "class",
+				Val: "",
+			})
+			attr = &n.Attr[len(n.Attr)-1]
+		}
+	}
+
+	if attr == nil {
+		classes = " "
+	} else {
+		classes = rxClassTrim.ReplaceAllString(" "+attr.Val+" ", " ")
+	}
+
+	return
+}
+
+func getClassesSlice(classes string) []string {
+	return strings.Split(rxClassTrim.ReplaceAllString(" "+classes+" ", " "), " ")
+}
+
+func removeAttr(n *html.Node, attrName string) {
+	for i, a := range n.Attr {
+		if a.Key == attrName {
+			n.Attr[i], n.Attr[len(n.Attr)-1], n.Attr =
+				n.Attr[len(n.Attr)-1], html.Attribute{}, n.Attr[:len(n.Attr)-1]
+			return
+		}
+	}
+}
+
+func setClasses(n *html.Node, attr *html.Attribute, classes string) {
+	classes = strings.TrimSpace(classes)
+	if classes == "" {
+		removeAttr(n, "class")
+		return
+	}
+
+	attr.Val = classes
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/property_test.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/property_test.go
@@ -1,0 +1,247 @@
+package goquery
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestAttrExists(t *testing.T) {
+	if val, ok := Doc().Find("a").Attr("href"); !ok {
+		t.Error("Expected a value for the href attribute.")
+	} else {
+		t.Logf("Href of first anchor: %v.", val)
+	}
+}
+
+func TestAttrOr(t *testing.T) {
+	if val := Doc().Find("a").AttrOr("fake-attribute", "alternative"); val != "alternative" {
+		t.Error("Expected an alternative value for 'fake-attribute' attribute.")
+	} else {
+		t.Logf("Value returned for not existing attribute: %v.", val)
+	}
+}
+
+func TestAttrNotExist(t *testing.T) {
+	if val, ok := Doc().Find("div.row-fluid").Attr("href"); ok {
+		t.Errorf("Expected no value for the href attribute, got %v.", val)
+	}
+}
+
+func TestRemoveAttr(t *testing.T) {
+	sel := Doc2Clone().Find("div")
+
+	sel.RemoveAttr("id")
+
+	_, ok := sel.Attr("id")
+	if ok {
+		t.Error("Expected there to be no id attributes set")
+	}
+}
+
+func TestSetAttr(t *testing.T) {
+	sel := Doc2Clone().Find("#main")
+
+	sel.SetAttr("id", "not-main")
+
+	val, ok := sel.Attr("id")
+	if !ok {
+		t.Error("Expected an id attribute on main")
+	}
+
+	if val != "not-main" {
+		t.Errorf("Expected an attribute id to be not-main, got %s", val)
+	}
+}
+
+func TestSetAttr2(t *testing.T) {
+	sel := Doc2Clone().Find("#main")
+
+	sel.SetAttr("foo", "bar")
+
+	val, ok := sel.Attr("foo")
+	if !ok {
+		t.Error("Expected an 'foo' attribute on main")
+	}
+
+	if val != "bar" {
+		t.Errorf("Expected an attribute 'foo' to be 'bar', got '%s'", val)
+	}
+}
+
+func TestText(t *testing.T) {
+	txt := Doc().Find("h1").Text()
+	if strings.Trim(txt, " \n\r\t") != "Provok.in" {
+		t.Errorf("Expected text to be Provok.in, found %s.", txt)
+	}
+}
+
+func TestText2(t *testing.T) {
+	txt := Doc().Find(".hero-unit .container-fluid .row-fluid:nth-child(1)").Text()
+	if ok, e := regexp.MatchString(`^\s+Provok\.in\s+Prove your point.\s+$`, txt); !ok || e != nil {
+		t.Errorf("Expected text to be Provok.in Prove your point., found %s.", txt)
+		if e != nil {
+			t.Logf("Error: %s.", e.Error())
+		}
+	}
+}
+
+func TestText3(t *testing.T) {
+	txt := Doc().Find(".pvk-gutter").First().Text()
+	// There's an &nbsp; character in there...
+	if ok, e := regexp.MatchString(`^[\s\x{00A0}]+$`, txt); !ok || e != nil {
+		t.Errorf("Expected spaces, found <%v>.", txt)
+		if e != nil {
+			t.Logf("Error: %s.", e.Error())
+		}
+	}
+}
+
+func TestHtml(t *testing.T) {
+	txt, e := Doc().Find("h1").Html()
+	if e != nil {
+		t.Errorf("Error: %s.", e)
+	}
+
+	if ok, e := regexp.MatchString(`^\s*<a href="/">Provok<span class="green">\.</span><span class="red">i</span>n</a>\s*$`, txt); !ok || e != nil {
+		t.Errorf("Unexpected HTML content, found %s.", txt)
+		if e != nil {
+			t.Logf("Error: %s.", e.Error())
+		}
+	}
+}
+
+func TestNbsp(t *testing.T) {
+	src := `<p>Some&nbsp;text</p>`
+	d, err := NewDocumentFromReader(strings.NewReader(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	txt := d.Find("p").Text()
+	ix := strings.Index(txt, "\u00a0")
+	if ix != 4 {
+		t.Errorf("Text: expected a non-breaking space at index 4, got %d", ix)
+	}
+
+	h, err := d.Find("p").Html()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ix = strings.Index(h, "\u00a0")
+	if ix != 4 {
+		t.Errorf("Html: expected a non-breaking space at index 4, got %d", ix)
+	}
+}
+
+func TestAddClass(t *testing.T) {
+	sel := Doc2Clone().Find("#main")
+	sel.AddClass("main main main")
+
+	// Make sure that class was only added once
+	if a, ok := sel.Attr("class"); !ok || a != "main" {
+		t.Error("Expected #main to have class main")
+	}
+}
+
+func TestAddClassSimilar(t *testing.T) {
+	sel := Doc2Clone().Find("#nf5")
+	sel.AddClass("odd")
+
+	assertClass(t, sel, "odd")
+	assertClass(t, sel, "odder")
+	printSel(t, sel.Parent())
+}
+
+func TestAddEmptyClass(t *testing.T) {
+	sel := Doc2Clone().Find("#main")
+	sel.AddClass("")
+
+	// Make sure that class was only added once
+	if a, ok := sel.Attr("class"); ok {
+		t.Errorf("Expected #main to not to have a class, have: %s", a)
+	}
+}
+
+func TestAddClasses(t *testing.T) {
+	sel := Doc2Clone().Find("#main")
+	sel.AddClass("a b")
+
+	// Make sure that class was only added once
+	if !sel.HasClass("a") || !sel.HasClass("b") {
+		t.Errorf("#main does not have classes")
+	}
+}
+
+func TestHasClass(t *testing.T) {
+	sel := Doc().Find("div")
+	if !sel.HasClass("span12") {
+		t.Error("Expected at least one div to have class span12.")
+	}
+}
+
+func TestHasClassNone(t *testing.T) {
+	sel := Doc().Find("h2")
+	if sel.HasClass("toto") {
+		t.Error("Expected h1 to have no class.")
+	}
+}
+
+func TestHasClassNotFirst(t *testing.T) {
+	sel := Doc().Find(".alert")
+	if !sel.HasClass("alert-error") {
+		t.Error("Expected .alert to also have class .alert-error.")
+	}
+}
+
+func TestRemoveClass(t *testing.T) {
+	sel := Doc2Clone().Find("#nf1")
+	sel.RemoveClass("one row")
+
+	if !sel.HasClass("even") || sel.HasClass("one") || sel.HasClass("row") {
+		classes, _ := sel.Attr("class")
+		t.Error("Expected #nf1 to have class even, has ", classes)
+	}
+}
+
+func TestRemoveClassSimilar(t *testing.T) {
+	sel := Doc2Clone().Find("#nf5, #nf6")
+	assertLength(t, sel.Nodes, 2)
+
+	sel.RemoveClass("odd")
+	assertClass(t, sel.Eq(0), "odder")
+	printSel(t, sel)
+}
+
+func TestRemoveAllClasses(t *testing.T) {
+	sel := Doc2Clone().Find("#nf1")
+	sel.RemoveClass()
+
+	if a, ok := sel.Attr("class"); ok {
+		t.Error("All classes were not removed, has ", a)
+	}
+
+	sel = Doc2Clone().Find("#main")
+	sel.RemoveClass()
+	if a, ok := sel.Attr("class"); ok {
+		t.Error("All classes were not removed, has ", a)
+	}
+}
+
+func TestToggleClass(t *testing.T) {
+	sel := Doc2Clone().Find("#nf1")
+
+	sel.ToggleClass("one")
+	if sel.HasClass("one") {
+		t.Error("Expected #nf1 to not have class one")
+	}
+
+	sel.ToggleClass("one")
+	if !sel.HasClass("one") {
+		t.Error("Expected #nf1 to have class one")
+	}
+
+	sel.ToggleClass("one even row")
+	if a, ok := sel.Attr("class"); ok {
+		t.Errorf("Expected #nf1 to have no classes, have %q", a)
+	}
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/query.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/query.go
@@ -1,0 +1,56 @@
+package goquery
+
+import (
+	"bosun.org/_third_party/github.com/andybalholm/cascadia"
+	"bosun.org/_third_party/golang.org/x/net/html"
+)
+
+// Is checks the current matched set of elements against a selector and
+// returns true if at least one of these elements matches.
+func (s *Selection) Is(selector string) bool {
+	if len(s.Nodes) > 0 {
+		return s.IsMatcher(cascadia.MustCompile(selector))
+	}
+
+	return false
+}
+
+// IsMatcher checks the current matched set of elements against a matcher and
+// returns true if at least one of these elements matches.
+func (s *Selection) IsMatcher(m Matcher) bool {
+	if len(s.Nodes) > 0 {
+		if len(s.Nodes) == 1 {
+			return m.Match(s.Nodes[0])
+		}
+		return len(m.Filter(s.Nodes)) > 0
+	}
+
+	return false
+}
+
+// IsFunction checks the current matched set of elements against a predicate and
+// returns true if at least one of these elements matches.
+func (s *Selection) IsFunction(f func(int, *Selection) bool) bool {
+	return s.FilterFunction(f).Length() > 0
+}
+
+// IsSelection checks the current matched set of elements against a Selection object
+// and returns true if at least one of these elements matches.
+func (s *Selection) IsSelection(sel *Selection) bool {
+	return s.FilterSelection(sel).Length() > 0
+}
+
+// IsNodes checks the current matched set of elements against the specified nodes
+// and returns true if at least one of these elements matches.
+func (s *Selection) IsNodes(nodes ...*html.Node) bool {
+	return s.FilterNodes(nodes...).Length() > 0
+}
+
+// Contains returns true if the specified Node is within,
+// at any depth, one of the nodes in the Selection object.
+// It is NOT inclusive, to behave like jQuery's implementation, and
+// unlike Javascript's .contains, so if the contained
+// node is itself in the selection, it returns false.
+func (s *Selection) Contains(n *html.Node) bool {
+	return sliceContains(s.Nodes, n)
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/query_test.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/query_test.go
@@ -1,0 +1,96 @@
+package goquery
+
+import (
+	"testing"
+)
+
+func TestIs(t *testing.T) {
+	sel := Doc().Find(".footer p:nth-child(1)")
+	if !sel.Is("p") {
+		t.Error("Expected .footer p:nth-child(1) to be p.")
+	}
+}
+
+func TestIsPositional(t *testing.T) {
+	sel := Doc().Find(".footer p:nth-child(2)")
+	if !sel.Is("p:nth-child(2)") {
+		t.Error("Expected .footer p:nth-child(2) to be p:nth-child(2).")
+	}
+}
+
+func TestIsPositionalNot(t *testing.T) {
+	sel := Doc().Find(".footer p:nth-child(1)")
+	if sel.Is("p:nth-child(2)") {
+		t.Error("Expected .footer p:nth-child(1) NOT to be p:nth-child(2).")
+	}
+}
+
+func TestIsFunction(t *testing.T) {
+	ok := Doc().Find("div").IsFunction(func(i int, s *Selection) bool {
+		return s.HasClass("container-fluid")
+	})
+
+	if !ok {
+		t.Error("Expected some div to have a container-fluid class.")
+	}
+}
+
+func TestIsFunctionRollback(t *testing.T) {
+	ok := Doc().Find("div").IsFunction(func(i int, s *Selection) bool {
+		return s.HasClass("container-fluid")
+	})
+
+	if !ok {
+		t.Error("Expected some div to have a container-fluid class.")
+	}
+}
+
+func TestIsSelection(t *testing.T) {
+	sel := Doc().Find("div")
+	sel2 := Doc().Find(".pvk-gutter")
+
+	if !sel.IsSelection(sel2) {
+		t.Error("Expected some div to have a pvk-gutter class.")
+	}
+}
+
+func TestIsSelectionNot(t *testing.T) {
+	sel := Doc().Find("div")
+	sel2 := Doc().Find("a")
+
+	if sel.IsSelection(sel2) {
+		t.Error("Expected some div NOT to be an anchor.")
+	}
+}
+
+func TestIsNodes(t *testing.T) {
+	sel := Doc().Find("div")
+	sel2 := Doc().Find(".footer")
+
+	if !sel.IsNodes(sel2.Nodes[0]) {
+		t.Error("Expected some div to have a footer class.")
+	}
+}
+
+func TestDocContains(t *testing.T) {
+	sel := Doc().Find("h1")
+	if !Doc().Contains(sel.Nodes[0]) {
+		t.Error("Expected document to contain H1 tag.")
+	}
+}
+
+func TestSelContains(t *testing.T) {
+	sel := Doc().Find(".row-fluid")
+	sel2 := Doc().Find("a[ng-click]")
+	if !sel.Contains(sel2.Nodes[0]) {
+		t.Error("Expected .row-fluid to contain a[ng-click] tag.")
+	}
+}
+
+func TestSelNotContains(t *testing.T) {
+	sel := Doc().Find("a.link")
+	sel2 := Doc().Find("span")
+	if sel.Contains(sel2.Nodes[0]) {
+		t.Error("Expected a.link to NOT contain span tag.")
+	}
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/traversal.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/traversal.go
@@ -1,0 +1,696 @@
+package goquery
+
+import (
+	"bosun.org/_third_party/github.com/andybalholm/cascadia"
+	"bosun.org/_third_party/golang.org/x/net/html"
+)
+
+type siblingType int
+
+// Sibling type, used internally when iterating over children at the same
+// level (siblings) to specify which nodes are requested.
+const (
+	siblingPrevUntil siblingType = iota - 3
+	siblingPrevAll
+	siblingPrev
+	siblingAll
+	siblingNext
+	siblingNextAll
+	siblingNextUntil
+	siblingAllIncludingNonElements
+)
+
+// Find gets the descendants of each element in the current set of matched
+// elements, filtered by a selector. It returns a new Selection object
+// containing these matched elements.
+func (s *Selection) Find(selector string) *Selection {
+	return pushStack(s, findWithMatcher(s.Nodes, cascadia.MustCompile(selector)))
+}
+
+// FindMatcher gets the descendants of each element in the current set of matched
+// elements, filtered by the matcher. It returns a new Selection object
+// containing these matched elements.
+func (s *Selection) FindMatcher(m Matcher) *Selection {
+	return pushStack(s, findWithMatcher(s.Nodes, m))
+}
+
+// FindSelection gets the descendants of each element in the current
+// Selection, filtered by a Selection. It returns a new Selection object
+// containing these matched elements.
+func (s *Selection) FindSelection(sel *Selection) *Selection {
+	if sel == nil {
+		return pushStack(s, nil)
+	}
+	return s.FindNodes(sel.Nodes...)
+}
+
+// FindNodes gets the descendants of each element in the current
+// Selection, filtered by some nodes. It returns a new Selection object
+// containing these matched elements.
+func (s *Selection) FindNodes(nodes ...*html.Node) *Selection {
+	return pushStack(s, mapNodes(nodes, func(i int, n *html.Node) []*html.Node {
+		if sliceContains(s.Nodes, n) {
+			return []*html.Node{n}
+		}
+		return nil
+	}))
+}
+
+// Contents gets the children of each element in the Selection,
+// including text and comment nodes. It returns a new Selection object
+// containing these elements.
+func (s *Selection) Contents() *Selection {
+	return pushStack(s, getChildrenNodes(s.Nodes, siblingAllIncludingNonElements))
+}
+
+// ContentsFiltered gets the children of each element in the Selection,
+// filtered by the specified selector. It returns a new Selection
+// object containing these elements. Since selectors only act on Element nodes,
+// this function is an alias to ChildrenFiltered unless the selector is empty,
+// in which case it is an alias to Contents.
+func (s *Selection) ContentsFiltered(selector string) *Selection {
+	if selector != "" {
+		return s.ChildrenFiltered(selector)
+	}
+	return s.Contents()
+}
+
+// ContentsMatcher gets the children of each element in the Selection,
+// filtered by the specified matcher. It returns a new Selection
+// object containing these elements. Since matchers only act on Element nodes,
+// this function is an alias to ChildrenMatcher.
+func (s *Selection) ContentsMatcher(m Matcher) *Selection {
+	return s.ChildrenMatcher(m)
+}
+
+// Children gets the child elements of each element in the Selection.
+// It returns a new Selection object containing these elements.
+func (s *Selection) Children() *Selection {
+	return pushStack(s, getChildrenNodes(s.Nodes, siblingAll))
+}
+
+// ChildrenFiltered gets the child elements of each element in the Selection,
+// filtered by the specified selector. It returns a new
+// Selection object containing these elements.
+func (s *Selection) ChildrenFiltered(selector string) *Selection {
+	return filterAndPush(s, getChildrenNodes(s.Nodes, siblingAll), cascadia.MustCompile(selector))
+}
+
+// ChildrenMatcher gets the child elements of each element in the Selection,
+// filtered by the specified matcher. It returns a new
+// Selection object containing these elements.
+func (s *Selection) ChildrenMatcher(m Matcher) *Selection {
+	return filterAndPush(s, getChildrenNodes(s.Nodes, siblingAll), m)
+}
+
+// Parent gets the parent of each element in the Selection. It returns a
+// new Selection object containing the matched elements.
+func (s *Selection) Parent() *Selection {
+	return pushStack(s, getParentNodes(s.Nodes))
+}
+
+// ParentFiltered gets the parent of each element in the Selection filtered by a
+// selector. It returns a new Selection object containing the matched elements.
+func (s *Selection) ParentFiltered(selector string) *Selection {
+	return filterAndPush(s, getParentNodes(s.Nodes), cascadia.MustCompile(selector))
+}
+
+// ParentMatcher gets the parent of each element in the Selection filtered by a
+// matcher. It returns a new Selection object containing the matched elements.
+func (s *Selection) ParentMatcher(m Matcher) *Selection {
+	return filterAndPush(s, getParentNodes(s.Nodes), m)
+}
+
+// Closest gets the first element that matches the selector by testing the
+// element itself and traversing up through its ancestors in the DOM tree.
+func (s *Selection) Closest(selector string) *Selection {
+	cs := cascadia.MustCompile(selector)
+	return s.ClosestMatcher(cs)
+}
+
+// ClosestMatcher gets the first element that matches the matcher by testing the
+// element itself and traversing up through its ancestors in the DOM tree.
+func (s *Selection) ClosestMatcher(m Matcher) *Selection {
+	return pushStack(s, mapNodes(s.Nodes, func(i int, n *html.Node) []*html.Node {
+		// For each node in the selection, test the node itself, then each parent
+		// until a match is found.
+		for ; n != nil; n = n.Parent {
+			if m.Match(n) {
+				return []*html.Node{n}
+			}
+		}
+		return nil
+	}))
+}
+
+// ClosestNodes gets the first element that matches one of the nodes by testing the
+// element itself and traversing up through its ancestors in the DOM tree.
+func (s *Selection) ClosestNodes(nodes ...*html.Node) *Selection {
+	return pushStack(s, mapNodes(s.Nodes, func(i int, n *html.Node) []*html.Node {
+		// For each node in the selection, test the node itself, then each parent
+		// until a match is found.
+		for ; n != nil; n = n.Parent {
+			if isInSlice(nodes, n) {
+				return []*html.Node{n}
+			}
+		}
+		return nil
+	}))
+}
+
+// ClosestSelection gets the first element that matches one of the nodes in the
+// Selection by testing the element itself and traversing up through its ancestors
+// in the DOM tree.
+func (s *Selection) ClosestSelection(sel *Selection) *Selection {
+	if sel == nil {
+		return pushStack(s, nil)
+	}
+	return s.ClosestNodes(sel.Nodes...)
+}
+
+// Parents gets the ancestors of each element in the current Selection. It
+// returns a new Selection object with the matched elements.
+func (s *Selection) Parents() *Selection {
+	return pushStack(s, getParentsNodes(s.Nodes, nil, nil))
+}
+
+// ParentsFiltered gets the ancestors of each element in the current
+// Selection. It returns a new Selection object with the matched elements.
+func (s *Selection) ParentsFiltered(selector string) *Selection {
+	return filterAndPush(s, getParentsNodes(s.Nodes, nil, nil), cascadia.MustCompile(selector))
+}
+
+// ParentsMatcher gets the ancestors of each element in the current
+// Selection. It returns a new Selection object with the matched elements.
+func (s *Selection) ParentsMatcher(m Matcher) *Selection {
+	return filterAndPush(s, getParentsNodes(s.Nodes, nil, nil), m)
+}
+
+// ParentsUntil gets the ancestors of each element in the Selection, up to but
+// not including the element matched by the selector. It returns a new Selection
+// object containing the matched elements.
+func (s *Selection) ParentsUntil(selector string) *Selection {
+	return pushStack(s, getParentsNodes(s.Nodes, cascadia.MustCompile(selector), nil))
+}
+
+// ParentsUntilMatcher gets the ancestors of each element in the Selection, up to but
+// not including the element matched by the matcher. It returns a new Selection
+// object containing the matched elements.
+func (s *Selection) ParentsUntilMatcher(m Matcher) *Selection {
+	return pushStack(s, getParentsNodes(s.Nodes, m, nil))
+}
+
+// ParentsUntilSelection gets the ancestors of each element in the Selection,
+// up to but not including the elements in the specified Selection. It returns a
+// new Selection object containing the matched elements.
+func (s *Selection) ParentsUntilSelection(sel *Selection) *Selection {
+	if sel == nil {
+		return s.Parents()
+	}
+	return s.ParentsUntilNodes(sel.Nodes...)
+}
+
+// ParentsUntilNodes gets the ancestors of each element in the Selection,
+// up to but not including the specified nodes. It returns a
+// new Selection object containing the matched elements.
+func (s *Selection) ParentsUntilNodes(nodes ...*html.Node) *Selection {
+	return pushStack(s, getParentsNodes(s.Nodes, nil, nodes))
+}
+
+// ParentsFilteredUntil is like ParentsUntil, with the option to filter the
+// results based on a selector string. It returns a new Selection
+// object containing the matched elements.
+func (s *Selection) ParentsFilteredUntil(filterSelector, untilSelector string) *Selection {
+	return filterAndPush(s, getParentsNodes(s.Nodes, cascadia.MustCompile(untilSelector), nil), cascadia.MustCompile(filterSelector))
+}
+
+// ParentsFilteredUntilMatcher is like ParentsUntilMatcher, with the option to filter the
+// results based on a matcher. It returns a new Selection object containing the matched elements.
+func (s *Selection) ParentsFilteredUntilMatcher(filter, until Matcher) *Selection {
+	return filterAndPush(s, getParentsNodes(s.Nodes, until, nil), filter)
+}
+
+// ParentsFilteredUntilSelection is like ParentsUntilSelection, with the
+// option to filter the results based on a selector string. It returns a new
+// Selection object containing the matched elements.
+func (s *Selection) ParentsFilteredUntilSelection(filterSelector string, sel *Selection) *Selection {
+	return s.ParentsMatcherUntilSelection(cascadia.MustCompile(filterSelector), sel)
+}
+
+// ParentsMatcherUntilSelection is like ParentsUntilSelection, with the
+// option to filter the results based on a matcher. It returns a new
+// Selection object containing the matched elements.
+func (s *Selection) ParentsMatcherUntilSelection(filter Matcher, sel *Selection) *Selection {
+	if sel == nil {
+		return s.ParentsMatcher(filter)
+	}
+	return s.ParentsMatcherUntilNodes(filter, sel.Nodes...)
+}
+
+// ParentsFilteredUntilNodes is like ParentsUntilNodes, with the
+// option to filter the results based on a selector string. It returns a new
+// Selection object containing the matched elements.
+func (s *Selection) ParentsFilteredUntilNodes(filterSelector string, nodes ...*html.Node) *Selection {
+	return filterAndPush(s, getParentsNodes(s.Nodes, nil, nodes), cascadia.MustCompile(filterSelector))
+}
+
+// ParentsMatcherUntilNodes is like ParentsUntilNodes, with the
+// option to filter the results based on a matcher. It returns a new
+// Selection object containing the matched elements.
+func (s *Selection) ParentsMatcherUntilNodes(filter Matcher, nodes ...*html.Node) *Selection {
+	return filterAndPush(s, getParentsNodes(s.Nodes, nil, nodes), filter)
+}
+
+// Siblings gets the siblings of each element in the Selection. It returns
+// a new Selection object containing the matched elements.
+func (s *Selection) Siblings() *Selection {
+	return pushStack(s, getSiblingNodes(s.Nodes, siblingAll, nil, nil))
+}
+
+// SiblingsFiltered gets the siblings of each element in the Selection
+// filtered by a selector. It returns a new Selection object containing the
+// matched elements.
+func (s *Selection) SiblingsFiltered(selector string) *Selection {
+	return filterAndPush(s, getSiblingNodes(s.Nodes, siblingAll, nil, nil), cascadia.MustCompile(selector))
+}
+
+// SiblingsMatcher gets the siblings of each element in the Selection
+// filtered by a matcher. It returns a new Selection object containing the
+// matched elements.
+func (s *Selection) SiblingsMatcher(m Matcher) *Selection {
+	return filterAndPush(s, getSiblingNodes(s.Nodes, siblingAll, nil, nil), m)
+}
+
+// Next gets the immediately following sibling of each element in the
+// Selection. It returns a new Selection object containing the matched elements.
+func (s *Selection) Next() *Selection {
+	return pushStack(s, getSiblingNodes(s.Nodes, siblingNext, nil, nil))
+}
+
+// NextFiltered gets the immediately following sibling of each element in the
+// Selection filtered by a selector. It returns a new Selection object
+// containing the matched elements.
+func (s *Selection) NextFiltered(selector string) *Selection {
+	return filterAndPush(s, getSiblingNodes(s.Nodes, siblingNext, nil, nil), cascadia.MustCompile(selector))
+}
+
+// NextMatcher gets the immediately following sibling of each element in the
+// Selection filtered by a matcher. It returns a new Selection object
+// containing the matched elements.
+func (s *Selection) NextMatcher(m Matcher) *Selection {
+	return filterAndPush(s, getSiblingNodes(s.Nodes, siblingNext, nil, nil), m)
+}
+
+// NextAll gets all the following siblings of each element in the
+// Selection. It returns a new Selection object containing the matched elements.
+func (s *Selection) NextAll() *Selection {
+	return pushStack(s, getSiblingNodes(s.Nodes, siblingNextAll, nil, nil))
+}
+
+// NextAllFiltered gets all the following siblings of each element in the
+// Selection filtered by a selector. It returns a new Selection object
+// containing the matched elements.
+func (s *Selection) NextAllFiltered(selector string) *Selection {
+	return filterAndPush(s, getSiblingNodes(s.Nodes, siblingNextAll, nil, nil), cascadia.MustCompile(selector))
+}
+
+// NextAllMatcher gets all the following siblings of each element in the
+// Selection filtered by a matcher. It returns a new Selection object
+// containing the matched elements.
+func (s *Selection) NextAllMatcher(m Matcher) *Selection {
+	return filterAndPush(s, getSiblingNodes(s.Nodes, siblingNextAll, nil, nil), m)
+}
+
+// Prev gets the immediately preceding sibling of each element in the
+// Selection. It returns a new Selection object containing the matched elements.
+func (s *Selection) Prev() *Selection {
+	return pushStack(s, getSiblingNodes(s.Nodes, siblingPrev, nil, nil))
+}
+
+// PrevFiltered gets the immediately preceding sibling of each element in the
+// Selection filtered by a selector. It returns a new Selection object
+// containing the matched elements.
+func (s *Selection) PrevFiltered(selector string) *Selection {
+	return filterAndPush(s, getSiblingNodes(s.Nodes, siblingPrev, nil, nil), cascadia.MustCompile(selector))
+}
+
+// PrevMatcher gets the immediately preceding sibling of each element in the
+// Selection filtered by a matcher. It returns a new Selection object
+// containing the matched elements.
+func (s *Selection) PrevMatcher(m Matcher) *Selection {
+	return filterAndPush(s, getSiblingNodes(s.Nodes, siblingPrev, nil, nil), m)
+}
+
+// PrevAll gets all the preceding siblings of each element in the
+// Selection. It returns a new Selection object containing the matched elements.
+func (s *Selection) PrevAll() *Selection {
+	return pushStack(s, getSiblingNodes(s.Nodes, siblingPrevAll, nil, nil))
+}
+
+// PrevAllFiltered gets all the preceding siblings of each element in the
+// Selection filtered by a selector. It returns a new Selection object
+// containing the matched elements.
+func (s *Selection) PrevAllFiltered(selector string) *Selection {
+	return filterAndPush(s, getSiblingNodes(s.Nodes, siblingPrevAll, nil, nil), cascadia.MustCompile(selector))
+}
+
+// PrevAllMatcher gets all the preceding siblings of each element in the
+// Selection filtered by a matcher. It returns a new Selection object
+// containing the matched elements.
+func (s *Selection) PrevAllMatcher(m Matcher) *Selection {
+	return filterAndPush(s, getSiblingNodes(s.Nodes, siblingPrevAll, nil, nil), m)
+}
+
+// NextUntil gets all following siblings of each element up to but not
+// including the element matched by the selector. It returns a new Selection
+// object containing the matched elements.
+func (s *Selection) NextUntil(selector string) *Selection {
+	return pushStack(s, getSiblingNodes(s.Nodes, siblingNextUntil,
+		cascadia.MustCompile(selector), nil))
+}
+
+// NextUntilMatcher gets all following siblings of each element up to but not
+// including the element matched by the matcher. It returns a new Selection
+// object containing the matched elements.
+func (s *Selection) NextUntilMatcher(m Matcher) *Selection {
+	return pushStack(s, getSiblingNodes(s.Nodes, siblingNextUntil,
+		m, nil))
+}
+
+// NextUntilSelection gets all following siblings of each element up to but not
+// including the element matched by the Selection. It returns a new Selection
+// object containing the matched elements.
+func (s *Selection) NextUntilSelection(sel *Selection) *Selection {
+	if sel == nil {
+		return s.NextAll()
+	}
+	return s.NextUntilNodes(sel.Nodes...)
+}
+
+// NextUntilNodes gets all following siblings of each element up to but not
+// including the element matched by the nodes. It returns a new Selection
+// object containing the matched elements.
+func (s *Selection) NextUntilNodes(nodes ...*html.Node) *Selection {
+	return pushStack(s, getSiblingNodes(s.Nodes, siblingNextUntil,
+		nil, nodes))
+}
+
+// PrevUntil gets all preceding siblings of each element up to but not
+// including the element matched by the selector. It returns a new Selection
+// object containing the matched elements.
+func (s *Selection) PrevUntil(selector string) *Selection {
+	return pushStack(s, getSiblingNodes(s.Nodes, siblingPrevUntil,
+		cascadia.MustCompile(selector), nil))
+}
+
+// PrevUntilMatcher gets all preceding siblings of each element up to but not
+// including the element matched by the matcher. It returns a new Selection
+// object containing the matched elements.
+func (s *Selection) PrevUntilMatcher(m Matcher) *Selection {
+	return pushStack(s, getSiblingNodes(s.Nodes, siblingPrevUntil,
+		m, nil))
+}
+
+// PrevUntilSelection gets all preceding siblings of each element up to but not
+// including the element matched by the Selection. It returns a new Selection
+// object containing the matched elements.
+func (s *Selection) PrevUntilSelection(sel *Selection) *Selection {
+	if sel == nil {
+		return s.PrevAll()
+	}
+	return s.PrevUntilNodes(sel.Nodes...)
+}
+
+// PrevUntilNodes gets all preceding siblings of each element up to but not
+// including the element matched by the nodes. It returns a new Selection
+// object containing the matched elements.
+func (s *Selection) PrevUntilNodes(nodes ...*html.Node) *Selection {
+	return pushStack(s, getSiblingNodes(s.Nodes, siblingPrevUntil,
+		nil, nodes))
+}
+
+// NextFilteredUntil is like NextUntil, with the option to filter
+// the results based on a selector string.
+// It returns a new Selection object containing the matched elements.
+func (s *Selection) NextFilteredUntil(filterSelector, untilSelector string) *Selection {
+	return filterAndPush(s, getSiblingNodes(s.Nodes, siblingNextUntil,
+		cascadia.MustCompile(untilSelector), nil), cascadia.MustCompile(filterSelector))
+}
+
+// NextFilteredUntilMatcher is like NextUntilMatcher, with the option to filter
+// the results based on a matcher.
+// It returns a new Selection object containing the matched elements.
+func (s *Selection) NextFilteredUntilMatcher(filter, until Matcher) *Selection {
+	return filterAndPush(s, getSiblingNodes(s.Nodes, siblingNextUntil,
+		until, nil), filter)
+}
+
+// NextFilteredUntilSelection is like NextUntilSelection, with the
+// option to filter the results based on a selector string. It returns a new
+// Selection object containing the matched elements.
+func (s *Selection) NextFilteredUntilSelection(filterSelector string, sel *Selection) *Selection {
+	return s.NextMatcherUntilSelection(cascadia.MustCompile(filterSelector), sel)
+}
+
+// NextMatcherUntilSelection is like NextUntilSelection, with the
+// option to filter the results based on a matcher. It returns a new
+// Selection object containing the matched elements.
+func (s *Selection) NextMatcherUntilSelection(filter Matcher, sel *Selection) *Selection {
+	if sel == nil {
+		return s.NextMatcher(filter)
+	}
+	return s.NextMatcherUntilNodes(filter, sel.Nodes...)
+}
+
+// NextFilteredUntilNodes is like NextUntilNodes, with the
+// option to filter the results based on a selector string. It returns a new
+// Selection object containing the matched elements.
+func (s *Selection) NextFilteredUntilNodes(filterSelector string, nodes ...*html.Node) *Selection {
+	return filterAndPush(s, getSiblingNodes(s.Nodes, siblingNextUntil,
+		nil, nodes), cascadia.MustCompile(filterSelector))
+}
+
+// NextMatcherUntilNodes is like NextUntilNodes, with the
+// option to filter the results based on a matcher. It returns a new
+// Selection object containing the matched elements.
+func (s *Selection) NextMatcherUntilNodes(filter Matcher, nodes ...*html.Node) *Selection {
+	return filterAndPush(s, getSiblingNodes(s.Nodes, siblingNextUntil,
+		nil, nodes), filter)
+}
+
+// PrevFilteredUntil is like PrevUntil, with the option to filter
+// the results based on a selector string.
+// It returns a new Selection object containing the matched elements.
+func (s *Selection) PrevFilteredUntil(filterSelector, untilSelector string) *Selection {
+	return filterAndPush(s, getSiblingNodes(s.Nodes, siblingPrevUntil,
+		cascadia.MustCompile(untilSelector), nil), cascadia.MustCompile(filterSelector))
+}
+
+// PrevFilteredUntilMatcher is like PrevUntilMatcher, with the option to filter
+// the results based on a matcher.
+// It returns a new Selection object containing the matched elements.
+func (s *Selection) PrevFilteredUntilMatcher(filter, until Matcher) *Selection {
+	return filterAndPush(s, getSiblingNodes(s.Nodes, siblingPrevUntil,
+		until, nil), filter)
+}
+
+// PrevFilteredUntilSelection is like PrevUntilSelection, with the
+// option to filter the results based on a selector string. It returns a new
+// Selection object containing the matched elements.
+func (s *Selection) PrevFilteredUntilSelection(filterSelector string, sel *Selection) *Selection {
+	return s.PrevMatcherUntilSelection(cascadia.MustCompile(filterSelector), sel)
+}
+
+// PrevMatcherUntilSelection is like PrevUntilSelection, with the
+// option to filter the results based on a matcher. It returns a new
+// Selection object containing the matched elements.
+func (s *Selection) PrevMatcherUntilSelection(filter Matcher, sel *Selection) *Selection {
+	if sel == nil {
+		return s.PrevMatcher(filter)
+	}
+	return s.PrevMatcherUntilNodes(filter, sel.Nodes...)
+}
+
+// PrevFilteredUntilNodes is like PrevUntilNodes, with the
+// option to filter the results based on a selector string. It returns a new
+// Selection object containing the matched elements.
+func (s *Selection) PrevFilteredUntilNodes(filterSelector string, nodes ...*html.Node) *Selection {
+	return filterAndPush(s, getSiblingNodes(s.Nodes, siblingPrevUntil,
+		nil, nodes), cascadia.MustCompile(filterSelector))
+}
+
+// PrevMatcherUntilNodes is like PrevUntilNodes, with the
+// option to filter the results based on a matcher. It returns a new
+// Selection object containing the matched elements.
+func (s *Selection) PrevMatcherUntilNodes(filter Matcher, nodes ...*html.Node) *Selection {
+	return filterAndPush(s, getSiblingNodes(s.Nodes, siblingPrevUntil,
+		nil, nodes), filter)
+}
+
+// Filter and push filters the nodes based on a matcher, and pushes the results
+// on the stack, with the srcSel as previous selection.
+func filterAndPush(srcSel *Selection, nodes []*html.Node, m Matcher) *Selection {
+	// Create a temporary Selection with the specified nodes to filter using winnow
+	sel := &Selection{nodes, srcSel.document, nil}
+	// Filter based on matcher and push on stack
+	return pushStack(srcSel, winnow(sel, m, true))
+}
+
+// Internal implementation of Find that return raw nodes.
+func findWithMatcher(nodes []*html.Node, m Matcher) []*html.Node {
+	// Map nodes to find the matches within the children of each node
+	return mapNodes(nodes, func(i int, n *html.Node) (result []*html.Node) {
+		// Go down one level, becausejQuery's Find selects only within descendants
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			if c.Type == html.ElementNode {
+				result = append(result, m.MatchAll(c)...)
+			}
+		}
+		return
+	})
+}
+
+// Internal implementation to get all parent nodes, stopping at the specified
+// node (or nil if no stop).
+func getParentsNodes(nodes []*html.Node, stopm Matcher, stopNodes []*html.Node) []*html.Node {
+	return mapNodes(nodes, func(i int, n *html.Node) (result []*html.Node) {
+		for p := n.Parent; p != nil; p = p.Parent {
+			sel := newSingleSelection(p, nil)
+			if stopm != nil {
+				if sel.IsMatcher(stopm) {
+					break
+				}
+			} else if len(stopNodes) > 0 {
+				if sel.IsNodes(stopNodes...) {
+					break
+				}
+			}
+			if p.Type == html.ElementNode {
+				result = append(result, p)
+			}
+		}
+		return
+	})
+}
+
+// Internal implementation of sibling nodes that return a raw slice of matches.
+func getSiblingNodes(nodes []*html.Node, st siblingType, untilm Matcher, untilNodes []*html.Node) []*html.Node {
+	var f func(*html.Node) bool
+
+	// If the requested siblings are ...Until, create the test function to
+	// determine if the until condition is reached (returns true if it is)
+	if st == siblingNextUntil || st == siblingPrevUntil {
+		f = func(n *html.Node) bool {
+			if untilm != nil {
+				// Matcher-based condition
+				sel := newSingleSelection(n, nil)
+				return sel.IsMatcher(untilm)
+			} else if len(untilNodes) > 0 {
+				// Nodes-based condition
+				sel := newSingleSelection(n, nil)
+				return sel.IsNodes(untilNodes...)
+			}
+			return false
+		}
+	}
+
+	return mapNodes(nodes, func(i int, n *html.Node) []*html.Node {
+		return getChildrenWithSiblingType(n.Parent, st, n, f)
+	})
+}
+
+// Gets the children nodes of each node in the specified slice of nodes,
+// based on the sibling type request.
+func getChildrenNodes(nodes []*html.Node, st siblingType) []*html.Node {
+	return mapNodes(nodes, func(i int, n *html.Node) []*html.Node {
+		return getChildrenWithSiblingType(n, st, nil, nil)
+	})
+}
+
+// Gets the children of the specified parent, based on the requested sibling
+// type, skipping a specified node if required.
+func getChildrenWithSiblingType(parent *html.Node, st siblingType, skipNode *html.Node,
+	untilFunc func(*html.Node) bool) (result []*html.Node) {
+
+	// Create the iterator function
+	var iter = func(cur *html.Node) (ret *html.Node) {
+		// Based on the sibling type requested, iterate the right way
+		for {
+			switch st {
+			case siblingAll, siblingAllIncludingNonElements:
+				if cur == nil {
+					// First iteration, start with first child of parent
+					// Skip node if required
+					if ret = parent.FirstChild; ret == skipNode && skipNode != nil {
+						ret = skipNode.NextSibling
+					}
+				} else {
+					// Skip node if required
+					if ret = cur.NextSibling; ret == skipNode && skipNode != nil {
+						ret = skipNode.NextSibling
+					}
+				}
+			case siblingPrev, siblingPrevAll, siblingPrevUntil:
+				if cur == nil {
+					// Start with previous sibling of the skip node
+					ret = skipNode.PrevSibling
+				} else {
+					ret = cur.PrevSibling
+				}
+			case siblingNext, siblingNextAll, siblingNextUntil:
+				if cur == nil {
+					// Start with next sibling of the skip node
+					ret = skipNode.NextSibling
+				} else {
+					ret = cur.NextSibling
+				}
+			default:
+				panic("Invalid sibling type.")
+			}
+			if ret == nil || ret.Type == html.ElementNode || st == siblingAllIncludingNonElements {
+				return
+			}
+			// Not a valid node, try again from this one
+			cur = ret
+		}
+	}
+
+	for c := iter(nil); c != nil; c = iter(c) {
+		// If this is an ...Until case, test before append (returns true
+		// if the until condition is reached)
+		if st == siblingNextUntil || st == siblingPrevUntil {
+			if untilFunc(c) {
+				return
+			}
+		}
+		result = append(result, c)
+		if st == siblingNext || st == siblingPrev {
+			// Only one node was requested (immediate next or previous), so exit
+			return
+		}
+	}
+	return
+}
+
+// Internal implementation of parent nodes that return a raw slice of Nodes.
+func getParentNodes(nodes []*html.Node) []*html.Node {
+	return mapNodes(nodes, func(i int, n *html.Node) []*html.Node {
+		if n.Parent != nil && n.Parent.Type == html.ElementNode {
+			return []*html.Node{n.Parent}
+		}
+		return nil
+	})
+}
+
+// Internal map function used by many traversing methods. Takes the source nodes
+// to iterate on and the mapping function that returns an array of nodes.
+// Returns an array of nodes mapped by calling the callback function once for
+// each node in the source nodes.
+func mapNodes(nodes []*html.Node, f func(int, *html.Node) []*html.Node) (result []*html.Node) {
+	for i, n := range nodes {
+		if vals := f(i, n); len(vals) > 0 {
+			result = appendWithoutDuplicates(result, vals)
+		}
+	}
+	return
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/traversal_test.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/traversal_test.go
@@ -1,0 +1,697 @@
+package goquery
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFind(t *testing.T) {
+	sel := Doc().Find("div.row-fluid")
+	assertLength(t, sel.Nodes, 9)
+}
+
+func TestFindRollback(t *testing.T) {
+	sel := Doc().Find("div.row-fluid")
+	sel2 := sel.Find("a").End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestFindNotSelf(t *testing.T) {
+	sel := Doc().Find("h1").Find("h1")
+	assertLength(t, sel.Nodes, 0)
+}
+
+func TestFindInvalidSelector(t *testing.T) {
+	defer assertPanic(t)
+	Doc().Find(":+ ^")
+}
+
+func TestChainedFind(t *testing.T) {
+	sel := Doc().Find("div.hero-unit").Find(".row-fluid")
+	assertLength(t, sel.Nodes, 4)
+}
+
+func TestChildren(t *testing.T) {
+	sel := Doc().Find(".pvk-content").Children()
+	assertLength(t, sel.Nodes, 5)
+}
+
+func TestChildrenRollback(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	sel2 := sel.Children().End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestContents(t *testing.T) {
+	sel := Doc().Find(".pvk-content").Contents()
+	assertLength(t, sel.Nodes, 13)
+}
+
+func TestContentsRollback(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	sel2 := sel.Contents().End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestChildrenFiltered(t *testing.T) {
+	sel := Doc().Find(".pvk-content").ChildrenFiltered(".hero-unit")
+	assertLength(t, sel.Nodes, 1)
+}
+
+func TestChildrenFilteredRollback(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	sel2 := sel.ChildrenFiltered(".hero-unit").End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestContentsFiltered(t *testing.T) {
+	sel := Doc().Find(".pvk-content").ContentsFiltered(".hero-unit")
+	assertLength(t, sel.Nodes, 1)
+}
+
+func TestContentsFilteredRollback(t *testing.T) {
+	sel := Doc().Find(".pvk-content")
+	sel2 := sel.ContentsFiltered(".hero-unit").End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestChildrenFilteredNone(t *testing.T) {
+	sel := Doc().Find(".pvk-content").ChildrenFiltered("a.btn")
+	assertLength(t, sel.Nodes, 0)
+}
+
+func TestParent(t *testing.T) {
+	sel := Doc().Find(".container-fluid").Parent()
+	assertLength(t, sel.Nodes, 3)
+}
+
+func TestParentRollback(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := sel.Parent().End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestParentBody(t *testing.T) {
+	sel := Doc().Find("body").Parent()
+	assertLength(t, sel.Nodes, 1)
+}
+
+func TestParentFiltered(t *testing.T) {
+	sel := Doc().Find(".container-fluid").ParentFiltered(".hero-unit")
+	assertLength(t, sel.Nodes, 1)
+	assertClass(t, sel, "hero-unit")
+}
+
+func TestParentFilteredRollback(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := sel.ParentFiltered(".hero-unit").End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestParents(t *testing.T) {
+	sel := Doc().Find(".container-fluid").Parents()
+	assertLength(t, sel.Nodes, 8)
+}
+
+func TestParentsOrder(t *testing.T) {
+	sel := Doc().Find("#cf2").Parents()
+	assertLength(t, sel.Nodes, 6)
+	assertSelectionIs(t, sel, ".hero-unit", ".pvk-content", "div.row-fluid", "#cf1", "body", "html")
+}
+
+func TestParentsRollback(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := sel.Parents().End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestParentsFiltered(t *testing.T) {
+	sel := Doc().Find(".container-fluid").ParentsFiltered("body")
+	assertLength(t, sel.Nodes, 1)
+}
+
+func TestParentsFilteredRollback(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := sel.ParentsFiltered("body").End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestParentsUntil(t *testing.T) {
+	sel := Doc().Find(".container-fluid").ParentsUntil("body")
+	assertLength(t, sel.Nodes, 6)
+}
+
+func TestParentsUntilRollback(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := sel.ParentsUntil("body").End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestParentsUntilSelection(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := Doc().Find(".pvk-content")
+	sel = sel.ParentsUntilSelection(sel2)
+	assertLength(t, sel.Nodes, 3)
+}
+
+func TestParentsUntilSelectionRollback(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := Doc().Find(".pvk-content")
+	sel2 = sel.ParentsUntilSelection(sel2).End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestParentsUntilNodes(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := Doc().Find(".pvk-content, .hero-unit")
+	sel = sel.ParentsUntilNodes(sel2.Nodes...)
+	assertLength(t, sel.Nodes, 2)
+}
+
+func TestParentsUntilNodesRollback(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := Doc().Find(".pvk-content, .hero-unit")
+	sel2 = sel.ParentsUntilNodes(sel2.Nodes...).End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestParentsFilteredUntil(t *testing.T) {
+	sel := Doc().Find(".container-fluid").ParentsFilteredUntil(".pvk-content", "body")
+	assertLength(t, sel.Nodes, 2)
+}
+
+func TestParentsFilteredUntilRollback(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := sel.ParentsFilteredUntil(".pvk-content", "body").End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestParentsFilteredUntilSelection(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := Doc().Find(".row-fluid")
+	sel = sel.ParentsFilteredUntilSelection("div", sel2)
+	assertLength(t, sel.Nodes, 3)
+}
+
+func TestParentsFilteredUntilSelectionRollback(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := Doc().Find(".row-fluid")
+	sel2 = sel.ParentsFilteredUntilSelection("div", sel2).End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestParentsFilteredUntilNodes(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := Doc().Find(".row-fluid")
+	sel = sel.ParentsFilteredUntilNodes("body", sel2.Nodes...)
+	assertLength(t, sel.Nodes, 1)
+}
+
+func TestParentsFilteredUntilNodesRollback(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := Doc().Find(".row-fluid")
+	sel2 = sel.ParentsFilteredUntilNodes("body", sel2.Nodes...).End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestSiblings(t *testing.T) {
+	sel := Doc().Find("h1").Siblings()
+	assertLength(t, sel.Nodes, 1)
+}
+
+func TestSiblingsRollback(t *testing.T) {
+	sel := Doc().Find("h1")
+	sel2 := sel.Siblings().End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestSiblings2(t *testing.T) {
+	sel := Doc().Find(".pvk-gutter").Siblings()
+	assertLength(t, sel.Nodes, 9)
+}
+
+func TestSiblings3(t *testing.T) {
+	sel := Doc().Find("body>.container-fluid").Siblings()
+	assertLength(t, sel.Nodes, 0)
+}
+
+func TestSiblingsFiltered(t *testing.T) {
+	sel := Doc().Find(".pvk-gutter").SiblingsFiltered(".pvk-content")
+	assertLength(t, sel.Nodes, 3)
+}
+
+func TestSiblingsFilteredRollback(t *testing.T) {
+	sel := Doc().Find(".pvk-gutter")
+	sel2 := sel.SiblingsFiltered(".pvk-content").End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestNext(t *testing.T) {
+	sel := Doc().Find("h1").Next()
+	assertLength(t, sel.Nodes, 1)
+}
+
+func TestNextRollback(t *testing.T) {
+	sel := Doc().Find("h1")
+	sel2 := sel.Next().End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestNext2(t *testing.T) {
+	sel := Doc().Find(".close").Next()
+	assertLength(t, sel.Nodes, 1)
+}
+
+func TestNextNone(t *testing.T) {
+	sel := Doc().Find("small").Next()
+	assertLength(t, sel.Nodes, 0)
+}
+
+func TestNextFiltered(t *testing.T) {
+	sel := Doc().Find(".container-fluid").NextFiltered("div")
+	assertLength(t, sel.Nodes, 2)
+}
+
+func TestNextFilteredRollback(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := sel.NextFiltered("div").End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestNextFiltered2(t *testing.T) {
+	sel := Doc().Find(".container-fluid").NextFiltered("[ng-view]")
+	assertLength(t, sel.Nodes, 1)
+}
+
+func TestPrev(t *testing.T) {
+	sel := Doc().Find(".red").Prev()
+	assertLength(t, sel.Nodes, 1)
+	assertClass(t, sel, "green")
+}
+
+func TestPrevRollback(t *testing.T) {
+	sel := Doc().Find(".red")
+	sel2 := sel.Prev().End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestPrev2(t *testing.T) {
+	sel := Doc().Find(".row-fluid").Prev()
+	assertLength(t, sel.Nodes, 5)
+}
+
+func TestPrevNone(t *testing.T) {
+	sel := Doc().Find("h2").Prev()
+	assertLength(t, sel.Nodes, 0)
+}
+
+func TestPrevFiltered(t *testing.T) {
+	sel := Doc().Find(".row-fluid").PrevFiltered(".row-fluid")
+	assertLength(t, sel.Nodes, 5)
+}
+
+func TestPrevFilteredRollback(t *testing.T) {
+	sel := Doc().Find(".row-fluid")
+	sel2 := sel.PrevFiltered(".row-fluid").End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestNextAll(t *testing.T) {
+	sel := Doc().Find("#cf2 div:nth-child(1)").NextAll()
+	assertLength(t, sel.Nodes, 3)
+}
+
+func TestNextAllRollback(t *testing.T) {
+	sel := Doc().Find("#cf2 div:nth-child(1)")
+	sel2 := sel.NextAll().End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestNextAll2(t *testing.T) {
+	sel := Doc().Find("div[ng-cloak]").NextAll()
+	assertLength(t, sel.Nodes, 1)
+}
+
+func TestNextAllNone(t *testing.T) {
+	sel := Doc().Find(".footer").NextAll()
+	assertLength(t, sel.Nodes, 0)
+}
+
+func TestNextAllFiltered(t *testing.T) {
+	sel := Doc().Find("#cf2 .row-fluid").NextAllFiltered("[ng-cloak]")
+	assertLength(t, sel.Nodes, 2)
+}
+
+func TestNextAllFilteredRollback(t *testing.T) {
+	sel := Doc().Find("#cf2 .row-fluid")
+	sel2 := sel.NextAllFiltered("[ng-cloak]").End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestNextAllFiltered2(t *testing.T) {
+	sel := Doc().Find(".close").NextAllFiltered("h4")
+	assertLength(t, sel.Nodes, 1)
+}
+
+func TestPrevAll(t *testing.T) {
+	sel := Doc().Find("[ng-view]").PrevAll()
+	assertLength(t, sel.Nodes, 2)
+}
+
+func TestPrevAllOrder(t *testing.T) {
+	sel := Doc().Find("[ng-view]").PrevAll()
+	assertLength(t, sel.Nodes, 2)
+	assertSelectionIs(t, sel, "#cf4", "#cf3")
+}
+
+func TestPrevAllRollback(t *testing.T) {
+	sel := Doc().Find("[ng-view]")
+	sel2 := sel.PrevAll().End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestPrevAll2(t *testing.T) {
+	sel := Doc().Find(".pvk-gutter").PrevAll()
+	assertLength(t, sel.Nodes, 6)
+}
+
+func TestPrevAllFiltered(t *testing.T) {
+	sel := Doc().Find(".pvk-gutter").PrevAllFiltered(".pvk-content")
+	assertLength(t, sel.Nodes, 3)
+}
+
+func TestPrevAllFilteredRollback(t *testing.T) {
+	sel := Doc().Find(".pvk-gutter")
+	sel2 := sel.PrevAllFiltered(".pvk-content").End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestNextUntil(t *testing.T) {
+	sel := Doc().Find(".alert a").NextUntil("p")
+	assertLength(t, sel.Nodes, 1)
+	assertSelectionIs(t, sel, "h4")
+}
+
+func TestNextUntil2(t *testing.T) {
+	sel := Doc().Find("#cf2-1").NextUntil("[ng-cloak]")
+	assertLength(t, sel.Nodes, 1)
+	assertSelectionIs(t, sel, "#cf2-2")
+}
+
+func TestNextUntilOrder(t *testing.T) {
+	sel := Doc().Find("#cf2-1").NextUntil("#cf2-4")
+	assertLength(t, sel.Nodes, 2)
+	assertSelectionIs(t, sel, "#cf2-2", "#cf2-3")
+}
+
+func TestNextUntilRollback(t *testing.T) {
+	sel := Doc().Find("#cf2-1")
+	sel2 := sel.PrevUntil("#cf2-4").End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestNextUntilSelection(t *testing.T) {
+	sel := Doc2().Find("#n2")
+	sel2 := Doc2().Find("#n4")
+	sel2 = sel.NextUntilSelection(sel2)
+	assertLength(t, sel2.Nodes, 1)
+	assertSelectionIs(t, sel2, "#n3")
+}
+
+func TestNextUntilSelectionRollback(t *testing.T) {
+	sel := Doc2().Find("#n2")
+	sel2 := Doc2().Find("#n4")
+	sel2 = sel.NextUntilSelection(sel2).End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestNextUntilNodes(t *testing.T) {
+	sel := Doc2().Find("#n2")
+	sel2 := Doc2().Find("#n5")
+	sel2 = sel.NextUntilNodes(sel2.Nodes...)
+	assertLength(t, sel2.Nodes, 2)
+	assertSelectionIs(t, sel2, "#n3", "#n4")
+}
+
+func TestNextUntilNodesRollback(t *testing.T) {
+	sel := Doc2().Find("#n2")
+	sel2 := Doc2().Find("#n5")
+	sel2 = sel.NextUntilNodes(sel2.Nodes...).End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestPrevUntil(t *testing.T) {
+	sel := Doc().Find(".alert p").PrevUntil("a")
+	assertLength(t, sel.Nodes, 1)
+	assertSelectionIs(t, sel, "h4")
+}
+
+func TestPrevUntil2(t *testing.T) {
+	sel := Doc().Find("[ng-cloak]").PrevUntil(":not([ng-cloak])")
+	assertLength(t, sel.Nodes, 1)
+	assertSelectionIs(t, sel, "[ng-cloak]")
+}
+
+func TestPrevUntilOrder(t *testing.T) {
+	sel := Doc().Find("#cf2-4").PrevUntil("#cf2-1")
+	assertLength(t, sel.Nodes, 2)
+	assertSelectionIs(t, sel, "#cf2-3", "#cf2-2")
+}
+
+func TestPrevUntilRollback(t *testing.T) {
+	sel := Doc().Find("#cf2-4")
+	sel2 := sel.PrevUntil("#cf2-1").End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestPrevUntilSelection(t *testing.T) {
+	sel := Doc2().Find("#n4")
+	sel2 := Doc2().Find("#n2")
+	sel2 = sel.PrevUntilSelection(sel2)
+	assertLength(t, sel2.Nodes, 1)
+	assertSelectionIs(t, sel2, "#n3")
+}
+
+func TestPrevUntilSelectionRollback(t *testing.T) {
+	sel := Doc2().Find("#n4")
+	sel2 := Doc2().Find("#n2")
+	sel2 = sel.PrevUntilSelection(sel2).End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestPrevUntilNodes(t *testing.T) {
+	sel := Doc2().Find("#n5")
+	sel2 := Doc2().Find("#n2")
+	sel2 = sel.PrevUntilNodes(sel2.Nodes...)
+	assertLength(t, sel2.Nodes, 2)
+	assertSelectionIs(t, sel2, "#n4", "#n3")
+}
+
+func TestPrevUntilNodesRollback(t *testing.T) {
+	sel := Doc2().Find("#n5")
+	sel2 := Doc2().Find("#n2")
+	sel2 = sel.PrevUntilNodes(sel2.Nodes...).End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestNextFilteredUntil(t *testing.T) {
+	sel := Doc2().Find(".two").NextFilteredUntil(".even", ".six")
+	assertLength(t, sel.Nodes, 4)
+	assertSelectionIs(t, sel, "#n3", "#n5", "#nf3", "#nf5")
+}
+
+func TestNextFilteredUntilRollback(t *testing.T) {
+	sel := Doc2().Find(".two")
+	sel2 := sel.NextFilteredUntil(".even", ".six").End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestNextFilteredUntilSelection(t *testing.T) {
+	sel := Doc2().Find(".even")
+	sel2 := Doc2().Find(".five")
+	sel = sel.NextFilteredUntilSelection(".even", sel2)
+	assertLength(t, sel.Nodes, 2)
+	assertSelectionIs(t, sel, "#n3", "#nf3")
+}
+
+func TestNextFilteredUntilSelectionRollback(t *testing.T) {
+	sel := Doc2().Find(".even")
+	sel2 := Doc2().Find(".five")
+	sel3 := sel.NextFilteredUntilSelection(".even", sel2).End()
+	assertEqual(t, sel, sel3)
+}
+
+func TestNextFilteredUntilNodes(t *testing.T) {
+	sel := Doc2().Find(".even")
+	sel2 := Doc2().Find(".four")
+	sel = sel.NextFilteredUntilNodes(".odd", sel2.Nodes...)
+	assertLength(t, sel.Nodes, 4)
+	assertSelectionIs(t, sel, "#n2", "#n6", "#nf2", "#nf6")
+}
+
+func TestNextFilteredUntilNodesRollback(t *testing.T) {
+	sel := Doc2().Find(".even")
+	sel2 := Doc2().Find(".four")
+	sel3 := sel.NextFilteredUntilNodes(".odd", sel2.Nodes...).End()
+	assertEqual(t, sel, sel3)
+}
+
+func TestPrevFilteredUntil(t *testing.T) {
+	sel := Doc2().Find(".five").PrevFilteredUntil(".odd", ".one")
+	assertLength(t, sel.Nodes, 4)
+	assertSelectionIs(t, sel, "#n4", "#n2", "#nf4", "#nf2")
+}
+
+func TestPrevFilteredUntilRollback(t *testing.T) {
+	sel := Doc2().Find(".four")
+	sel2 := sel.PrevFilteredUntil(".odd", ".one").End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestPrevFilteredUntilSelection(t *testing.T) {
+	sel := Doc2().Find(".odd")
+	sel2 := Doc2().Find(".two")
+	sel = sel.PrevFilteredUntilSelection(".odd", sel2)
+	assertLength(t, sel.Nodes, 2)
+	assertSelectionIs(t, sel, "#n4", "#nf4")
+}
+
+func TestPrevFilteredUntilSelectionRollback(t *testing.T) {
+	sel := Doc2().Find(".even")
+	sel2 := Doc2().Find(".five")
+	sel3 := sel.PrevFilteredUntilSelection(".even", sel2).End()
+	assertEqual(t, sel, sel3)
+}
+
+func TestPrevFilteredUntilNodes(t *testing.T) {
+	sel := Doc2().Find(".even")
+	sel2 := Doc2().Find(".four")
+	sel = sel.PrevFilteredUntilNodes(".odd", sel2.Nodes...)
+	assertLength(t, sel.Nodes, 2)
+	assertSelectionIs(t, sel, "#n2", "#nf2")
+}
+
+func TestPrevFilteredUntilNodesRollback(t *testing.T) {
+	sel := Doc2().Find(".even")
+	sel2 := Doc2().Find(".four")
+	sel3 := sel.PrevFilteredUntilNodes(".odd", sel2.Nodes...).End()
+	assertEqual(t, sel, sel3)
+}
+
+func TestClosestItself(t *testing.T) {
+	sel := Doc2().Find(".three")
+	sel2 := sel.Closest(".row")
+	assertLength(t, sel2.Nodes, sel.Length())
+	assertSelectionIs(t, sel2, "#n3", "#nf3")
+}
+
+func TestClosestNoDupes(t *testing.T) {
+	sel := Doc().Find(".span12")
+	sel2 := sel.Closest(".pvk-content")
+	assertLength(t, sel2.Nodes, 1)
+	assertClass(t, sel2, "pvk-content")
+}
+
+func TestClosestNone(t *testing.T) {
+	sel := Doc().Find("h4")
+	sel2 := sel.Closest("a")
+	assertLength(t, sel2.Nodes, 0)
+}
+
+func TestClosestMany(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := sel.Closest(".pvk-content")
+	assertLength(t, sel2.Nodes, 2)
+	assertSelectionIs(t, sel2, "#pc1", "#pc2")
+}
+
+func TestClosestRollback(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := sel.Closest(".pvk-content").End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestClosestSelectionItself(t *testing.T) {
+	sel := Doc2().Find(".three")
+	sel2 := sel.ClosestSelection(Doc2().Find(".row"))
+	assertLength(t, sel2.Nodes, sel.Length())
+}
+
+func TestClosestSelectionNoDupes(t *testing.T) {
+	sel := Doc().Find(".span12")
+	sel2 := sel.ClosestSelection(Doc().Find(".pvk-content"))
+	assertLength(t, sel2.Nodes, 1)
+	assertClass(t, sel2, "pvk-content")
+}
+
+func TestClosestSelectionNone(t *testing.T) {
+	sel := Doc().Find("h4")
+	sel2 := sel.ClosestSelection(Doc().Find("a"))
+	assertLength(t, sel2.Nodes, 0)
+}
+
+func TestClosestSelectionMany(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := sel.ClosestSelection(Doc().Find(".pvk-content"))
+	assertLength(t, sel2.Nodes, 2)
+	assertSelectionIs(t, sel2, "#pc1", "#pc2")
+}
+
+func TestClosestSelectionRollback(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := sel.ClosestSelection(Doc().Find(".pvk-content")).End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestClosestNodesItself(t *testing.T) {
+	sel := Doc2().Find(".three")
+	sel2 := sel.ClosestNodes(Doc2().Find(".row").Nodes...)
+	assertLength(t, sel2.Nodes, sel.Length())
+}
+
+func TestClosestNodesNoDupes(t *testing.T) {
+	sel := Doc().Find(".span12")
+	sel2 := sel.ClosestNodes(Doc().Find(".pvk-content").Nodes...)
+	assertLength(t, sel2.Nodes, 1)
+	assertClass(t, sel2, "pvk-content")
+}
+
+func TestClosestNodesNone(t *testing.T) {
+	sel := Doc().Find("h4")
+	sel2 := sel.ClosestNodes(Doc().Find("a").Nodes...)
+	assertLength(t, sel2.Nodes, 0)
+}
+
+func TestClosestNodesMany(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := sel.ClosestNodes(Doc().Find(".pvk-content").Nodes...)
+	assertLength(t, sel2.Nodes, 2)
+	assertSelectionIs(t, sel2, "#pc1", "#pc2")
+}
+
+func TestClosestNodesRollback(t *testing.T) {
+	sel := Doc().Find(".container-fluid")
+	sel2 := sel.ClosestNodes(Doc().Find(".pvk-content").Nodes...).End()
+	assertEqual(t, sel, sel2)
+}
+
+func TestIssue26(t *testing.T) {
+	img1 := `<img src="assets/images/gallery/thumb-1.jpg" alt="150x150" />`
+	img2 := `<img alt="150x150" src="assets/images/gallery/thumb-1.jpg" />`
+	cases := []struct {
+		s string
+		l int
+	}{
+		{s: img1 + img2, l: 2},
+		{s: img1, l: 1},
+		{s: img2, l: 1},
+	}
+	for _, c := range cases {
+		doc, err := NewDocumentFromReader(strings.NewReader(c.s))
+		if err != nil {
+			t.Fatal(err)
+		}
+		sel := doc.Find("img[src]")
+		assertLength(t, sel.Nodes, c.l)
+	}
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/type.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/type.go
@@ -1,0 +1,113 @@
+package goquery
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+
+	"bosun.org/_third_party/golang.org/x/net/html"
+)
+
+// Document represents an HTML document to be manipulated. Unlike jQuery, which
+// is loaded as part of a DOM document, and thus acts upon its containing
+// document, GoQuery doesn't know which HTML document to act upon. So it needs
+// to be told, and that's what the Document class is for. It holds the root
+// document node to manipulate, and can make selections on this document.
+type Document struct {
+	*Selection
+	Url      *url.URL
+	rootNode *html.Node
+}
+
+// NewDocumentFromNode is a Document constructor that takes a root html Node
+// as argument.
+func NewDocumentFromNode(root *html.Node) *Document {
+	return newDocument(root, nil)
+}
+
+// NewDocument is a Document constructor that takes a string URL as argument.
+// It loads the specified document, parses it, and stores the root Document
+// node, ready to be manipulated.
+func NewDocument(url string) (*Document, error) {
+	// Load the URL
+	res, e := http.Get(url)
+	if e != nil {
+		return nil, e
+	}
+	return NewDocumentFromResponse(res)
+}
+
+// NewDocumentFromReader returns a Document from a generic reader.
+// It returns an error as second value if the reader's data cannot be parsed
+// as html. It does *not* check if the reader is also an io.Closer, so the
+// provided reader is never closed by this call, it is the responsibility
+// of the caller to close it if required.
+func NewDocumentFromReader(r io.Reader) (*Document, error) {
+	root, e := html.Parse(r)
+	if e != nil {
+		return nil, e
+	}
+	return newDocument(root, nil), nil
+}
+
+// NewDocumentFromResponse is another Document constructor that takes an http response as argument.
+// It loads the specified response's document, parses it, and stores the root Document
+// node, ready to be manipulated. The response's body is closed on return.
+func NewDocumentFromResponse(res *http.Response) (*Document, error) {
+	if res == nil {
+		return nil, errors.New("Response is nil pointer")
+	}
+
+	defer res.Body.Close()
+
+	// Parse the HTML into nodes
+	root, e := html.Parse(res.Body)
+	if e != nil {
+		return nil, e
+	}
+
+	// Create and fill the document
+	return newDocument(root, res.Request.URL), nil
+}
+
+// CloneDocument creates a deep-clone of a document.
+func CloneDocument(doc *Document) *Document {
+	return newDocument(cloneNode(doc.rootNode), doc.Url)
+}
+
+// Private constructor, make sure all fields are correctly filled.
+func newDocument(root *html.Node, url *url.URL) *Document {
+	// Create and fill the document
+	d := &Document{nil, url, root}
+	d.Selection = newSingleSelection(root, d)
+	return d
+}
+
+// Selection represents a collection of nodes matching some criteria. The
+// initial Selection can be created by using Document.Find, and then
+// manipulated using the jQuery-like chainable syntax and methods.
+type Selection struct {
+	Nodes    []*html.Node
+	document *Document
+	prevSel  *Selection
+}
+
+// Helper constructor to create an empty selection
+func newEmptySelection(doc *Document) *Selection {
+	return &Selection{nil, doc, nil}
+}
+
+// Helper constructor to create a selection of only one node
+func newSingleSelection(node *html.Node, doc *Document) *Selection {
+	return &Selection{[]*html.Node{node}, doc, nil}
+}
+
+// Matcher is an interface that defines the methods to match
+// HTML nodes against a compiled selector string. Cascadia's
+// Selector implements this interface.
+type Matcher interface {
+	Match(*html.Node) bool
+	MatchAll(*html.Node) []*html.Node
+	Filter([]*html.Node) []*html.Node
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/type_test.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/type_test.go
@@ -1,0 +1,192 @@
+package goquery
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+
+	"bosun.org/_third_party/golang.org/x/net/html"
+)
+
+// Test helper functions and members
+var doc *Document
+var doc2 *Document
+var doc3 *Document
+var docB *Document
+var docW *Document
+
+func Doc() *Document {
+	if doc == nil {
+		doc = loadDoc("page.html")
+	}
+	return doc
+}
+func DocClone() *Document {
+	return CloneDocument(Doc())
+}
+func Doc2() *Document {
+	if doc2 == nil {
+		doc2 = loadDoc("page2.html")
+	}
+	return doc2
+}
+func Doc2Clone() *Document {
+	return CloneDocument(Doc2())
+}
+func Doc3() *Document {
+	if doc3 == nil {
+		doc3 = loadDoc("page3.html")
+	}
+	return doc3
+}
+func Doc3Clone() *Document {
+	return CloneDocument(Doc3())
+}
+func DocB() *Document {
+	if docB == nil {
+		docB = loadDoc("gotesting.html")
+	}
+	return docB
+}
+func DocBClone() *Document {
+	return CloneDocument(DocB())
+}
+func DocW() *Document {
+	if docW == nil {
+		docW = loadDoc("gowiki.html")
+	}
+	return docW
+}
+func DocWClone() *Document {
+	return CloneDocument(DocW())
+}
+
+func assertLength(t *testing.T, nodes []*html.Node, length int) {
+	if len(nodes) != length {
+		t.Errorf("Expected %d nodes, found %d.", length, len(nodes))
+		for i, n := range nodes {
+			t.Logf("Node %d: %+v.", i, n)
+		}
+	}
+}
+
+func assertClass(t *testing.T, sel *Selection, class string) {
+	if !sel.HasClass(class) {
+		t.Errorf("Expected node to have class %s, found %+v.", class, sel.Get(0))
+	}
+}
+
+func assertPanic(t *testing.T) {
+	if e := recover(); e == nil {
+		t.Error("Expected a panic.")
+	}
+}
+
+func assertEqual(t *testing.T, s1 *Selection, s2 *Selection) {
+	if s1 != s2 {
+		t.Error("Expected selection objects to be the same.")
+	}
+}
+
+func assertSelectionIs(t *testing.T, sel *Selection, is ...string) {
+	for i := 0; i < sel.Length(); i++ {
+		if !sel.Eq(i).Is(is[i]) {
+			t.Errorf("Expected node %d to be %s, found %+v", i, is[i], sel.Get(i))
+		}
+	}
+}
+
+func printSel(t *testing.T, sel *Selection) {
+	if testing.Verbose() {
+		h, err := sel.Html()
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Log(h)
+	}
+}
+
+func loadDoc(page string) *Document {
+	var f *os.File
+	var e error
+
+	if f, e = os.Open(fmt.Sprintf("./testdata/%s", page)); e != nil {
+		panic(e.Error())
+	}
+	defer f.Close()
+
+	var node *html.Node
+	if node, e = html.Parse(f); e != nil {
+		panic(e.Error())
+	}
+	return NewDocumentFromNode(node)
+}
+
+func TestNewDocument(t *testing.T) {
+	if f, e := os.Open("./testdata/page.html"); e != nil {
+		t.Error(e.Error())
+	} else {
+		defer f.Close()
+		if node, e := html.Parse(f); e != nil {
+			t.Error(e.Error())
+		} else {
+			doc = NewDocumentFromNode(node)
+		}
+	}
+}
+
+func TestNewDocumentFromReader(t *testing.T) {
+	cases := []struct {
+		src string
+		err bool
+		sel string
+		cnt int
+	}{
+		0: {
+			src: `
+<html>
+<head>
+<title>Test</title>
+<body>
+<h1>Hi</h1>
+</body>
+</html>`,
+			sel: "h1",
+			cnt: 1,
+		},
+		1: {
+			// Actually pretty hard to make html.Parse return an error
+			// based on content...
+			src: `<html><body><aef<eqf>>>qq></body></ht>`,
+		},
+	}
+	buf := bytes.NewBuffer(nil)
+
+	for i, c := range cases {
+		buf.Reset()
+		buf.WriteString(c.src)
+
+		d, e := NewDocumentFromReader(buf)
+		if (e != nil) != c.err {
+			if c.err {
+				t.Errorf("[%d] - expected error, got none", i)
+			} else {
+				t.Errorf("[%d] - expected no error, got %s", i, e)
+			}
+		}
+		if c.sel != "" {
+			s := d.Find(c.sel)
+			if s.Length() != c.cnt {
+				t.Errorf("[%d] - expected %d nodes, found %d", i, c.cnt, s.Length())
+			}
+		}
+	}
+}
+
+func TestNewDocumentFromResponseNil(t *testing.T) {
+	_, e := NewDocumentFromResponse(nil)
+	if e == nil {
+		t.Error("Expected error, got none")
+	}
+}

--- a/_third_party/github.com/PuerkitoBio/goquery/utilities.go
+++ b/_third_party/github.com/PuerkitoBio/goquery/utilities.go
@@ -1,0 +1,84 @@
+package goquery
+
+import (
+	"bosun.org/_third_party/golang.org/x/net/html"
+)
+
+func getChildren(n *html.Node) (result []*html.Node) {
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		result = append(result, c)
+	}
+	return result
+}
+
+// Loop through all container nodes to search for the target node.
+func sliceContains(container []*html.Node, contained *html.Node) bool {
+	for _, n := range container {
+		if nodeContains(n, contained) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Checks if the contained node is within the container node.
+func nodeContains(container *html.Node, contained *html.Node) bool {
+	// Check if the parent of the contained node is the container node, traversing
+	// upward until the top is reached, or the container is found.
+	for contained = contained.Parent; contained != nil; contained = contained.Parent {
+		if container == contained {
+			return true
+		}
+	}
+	return false
+}
+
+// Checks if the target node is in the slice of nodes.
+func isInSlice(slice []*html.Node, node *html.Node) bool {
+	return indexInSlice(slice, node) > -1
+}
+
+// Returns the index of the target node in the slice, or -1.
+func indexInSlice(slice []*html.Node, node *html.Node) int {
+	if node != nil {
+		for i, n := range slice {
+			if n == node {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// Appends the new nodes to the target slice, making sure no duplicate is added.
+// There is no check to the original state of the target slice, so it may still
+// contain duplicates. The target slice is returned because append() may create
+// a new underlying array.
+func appendWithoutDuplicates(target []*html.Node, nodes []*html.Node) []*html.Node {
+	for _, n := range nodes {
+		if !isInSlice(target, n) {
+			target = append(target, n)
+		}
+	}
+
+	return target
+}
+
+// Loop through a selection, returning only those nodes that pass the predicate
+// function.
+func grep(sel *Selection, predicate func(i int, s *Selection) bool) (result []*html.Node) {
+	for i, n := range sel.Nodes {
+		if predicate(i, newSingleSelection(n, sel.document)) {
+			result = append(result, n)
+		}
+	}
+	return result
+}
+
+// Creates a new Selection object based on the specified nodes, and keeps the
+// source Selection object on the stack (linked list).
+func pushStack(fromSel *Selection, nodes []*html.Node) *Selection {
+	result := &Selection{nodes, fromSel.document, fromSel}
+	return result
+}

--- a/_third_party/github.com/andybalholm/cascadia/LICENSE
+++ b/_third_party/github.com/andybalholm/cascadia/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2011 Andy Balholm. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/_third_party/github.com/andybalholm/cascadia/README.md
+++ b/_third_party/github.com/andybalholm/cascadia/README.md
@@ -1,0 +1,1 @@
+The Cascadia package implements CSS selectors for use with the parse trees produced by the html package.

--- a/_third_party/github.com/andybalholm/cascadia/benchmark_test.go
+++ b/_third_party/github.com/andybalholm/cascadia/benchmark_test.go
@@ -1,0 +1,53 @@
+package cascadia
+
+import (
+	"strings"
+	"testing"
+
+	"bosun.org/_third_party/golang.org/x/net/html"
+)
+
+func MustParseHTML(doc string) *html.Node {
+	dom, err := html.Parse(strings.NewReader(doc))
+	if err != nil {
+		panic(err)
+	}
+	return dom
+}
+
+var selector = MustCompile(`div.matched`)
+var doc = `<!DOCTYPE html>
+<html>
+<body>
+<div class="matched">
+  <div>
+    <div class="matched"></div>
+    <div class="matched"></div>
+    <div class="matched"></div>
+    <div class="matched"></div>
+    <div class="matched"></div>
+    <div class="matched"></div>
+    <div class="matched"></div>
+    <div class="matched"></div>
+    <div class="matched"></div>
+    <div class="matched"></div>
+    <div class="matched"></div>
+    <div class="matched"></div>
+    <div class="matched"></div>
+    <div class="matched"></div>
+    <div class="matched"></div>
+    <div class="matched"></div>
+  </div>
+</div>
+</body>
+</html>
+`
+var dom = MustParseHTML(doc)
+
+func BenchmarkMatchAll(b *testing.B) {
+	var matches []*html.Node
+	for i := 0; i < b.N; i++ {
+		matches = selector.MatchAll(dom)
+	}
+	_ = matches
+}

--- a/_third_party/github.com/andybalholm/cascadia/parser.go
+++ b/_third_party/github.com/andybalholm/cascadia/parser.go
@@ -1,0 +1,813 @@
+// The cascadia package is an implementation of CSS selectors.
+package cascadia
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"bosun.org/_third_party/golang.org/x/net/html"
+)
+
+// a parser for CSS selectors
+type parser struct {
+	s string // the source text
+	i int    // the current position
+}
+
+// parseEscape parses a backslash escape.
+func (p *parser) parseEscape() (result string, err error) {
+	if len(p.s) < p.i+2 || p.s[p.i] != '\\' {
+		return "", errors.New("invalid escape sequence")
+	}
+
+	start := p.i + 1
+	c := p.s[start]
+	switch {
+	case c == '\r' || c == '\n' || c == '\f':
+		return "", errors.New("escaped line ending outside string")
+	case hexDigit(c):
+		// unicode escape (hex)
+		var i int
+		for i = start; i < p.i+6 && i < len(p.s) && hexDigit(p.s[i]); i++ {
+			// empty
+		}
+		v, _ := strconv.ParseUint(p.s[start:i], 16, 21)
+		if len(p.s) > i {
+			switch p.s[i] {
+			case '\r':
+				i++
+				if len(p.s) > i && p.s[i] == '\n' {
+					i++
+				}
+			case ' ', '\t', '\n', '\f':
+				i++
+			}
+		}
+		p.i = i
+		return string(rune(v)), nil
+	}
+
+	// Return the literal character after the backslash.
+	result = p.s[start : start+1]
+	p.i += 2
+	return result, nil
+}
+
+func hexDigit(c byte) bool {
+	return '0' <= c && c <= '9' || 'a' <= c && c <= 'f' || 'A' <= c && c <= 'F'
+}
+
+// nameStart returns whether c can be the first character of an identifier
+// (not counting an initial hyphen, or an escape sequence).
+func nameStart(c byte) bool {
+	return 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' || c == '_' || c > 127
+}
+
+// nameChar returns whether c can be a character within an identifier
+// (not counting an escape sequence).
+func nameChar(c byte) bool {
+	return 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' || c == '_' || c > 127 ||
+		c == '-' || '0' <= c && c <= '9'
+}
+
+// parseIdentifier parses an identifier.
+func (p *parser) parseIdentifier() (result string, err error) {
+	startingDash := false
+	if len(p.s) > p.i && p.s[p.i] == '-' {
+		startingDash = true
+		p.i++
+	}
+
+	if len(p.s) <= p.i {
+		return "", errors.New("expected identifier, found EOF instead")
+	}
+
+	if c := p.s[p.i]; !(nameStart(c) || c == '\\') {
+		return "", fmt.Errorf("expected identifier, found %c instead", c)
+	}
+
+	result, err = p.parseName()
+	if startingDash && err == nil {
+		result = "-" + result
+	}
+	return
+}
+
+// parseName parses a name (which is like an identifier, but doesn't have
+// extra restrictions on the first character).
+func (p *parser) parseName() (result string, err error) {
+	i := p.i
+loop:
+	for i < len(p.s) {
+		c := p.s[i]
+		switch {
+		case nameChar(c):
+			start := i
+			for i < len(p.s) && nameChar(p.s[i]) {
+				i++
+			}
+			result += p.s[start:i]
+		case c == '\\':
+			p.i = i
+			val, err := p.parseEscape()
+			if err != nil {
+				return "", err
+			}
+			i = p.i
+			result += val
+		default:
+			break loop
+		}
+	}
+
+	if result == "" {
+		return "", errors.New("expected name, found EOF instead")
+	}
+
+	p.i = i
+	return result, nil
+}
+
+// parseString parses a single- or double-quoted string.
+func (p *parser) parseString() (result string, err error) {
+	i := p.i
+	if len(p.s) < i+2 {
+		return "", errors.New("expected string, found EOF instead")
+	}
+
+	quote := p.s[i]
+	i++
+
+loop:
+	for i < len(p.s) {
+		switch p.s[i] {
+		case '\\':
+			if len(p.s) > i+1 {
+				switch c := p.s[i+1]; c {
+				case '\r':
+					if len(p.s) > i+2 && p.s[i+2] == '\n' {
+						i += 3
+						continue loop
+					}
+					fallthrough
+				case '\n', '\f':
+					i += 2
+					continue loop
+				}
+			}
+			p.i = i
+			val, err := p.parseEscape()
+			if err != nil {
+				return "", err
+			}
+			i = p.i
+			result += val
+		case quote:
+			break loop
+		case '\r', '\n', '\f':
+			return "", errors.New("unexpected end of line in string")
+		default:
+			start := i
+			for i < len(p.s) {
+				if c := p.s[i]; c == quote || c == '\\' || c == '\r' || c == '\n' || c == '\f' {
+					break
+				}
+				i++
+			}
+			result += p.s[start:i]
+		}
+	}
+
+	if i >= len(p.s) {
+		return "", errors.New("EOF in string")
+	}
+
+	// Consume the final quote.
+	i++
+
+	p.i = i
+	return result, nil
+}
+
+// parseRegex parses a regular expression; the end is defined by encountering an
+// unmatched closing ')' or ']' which is not consumed
+func (p *parser) parseRegex() (rx *regexp.Regexp, err error) {
+	i := p.i
+	if len(p.s) < i+2 {
+		return nil, errors.New("expected regular expression, found EOF instead")
+	}
+
+	// number of open parens or brackets;
+	// when it becomes negative, finished parsing regex
+	open := 0
+
+loop:
+	for i < len(p.s) {
+		switch p.s[i] {
+		case '(', '[':
+			open++
+		case ')', ']':
+			open--
+			if open < 0 {
+				break loop
+			}
+		}
+		i++
+	}
+
+	if i >= len(p.s) {
+		return nil, errors.New("EOF in regular expression")
+	}
+	rx, err = regexp.Compile(p.s[p.i:i])
+	p.i = i
+	return rx, err
+}
+
+// skipWhitespace consumes whitespace characters and comments.
+// It returns true if there was actually anything to skip.
+func (p *parser) skipWhitespace() bool {
+	i := p.i
+	for i < len(p.s) {
+		switch p.s[i] {
+		case ' ', '\t', '\r', '\n', '\f':
+			i++
+			continue
+		case '/':
+			if strings.HasPrefix(p.s[i:], "/*") {
+				end := strings.Index(p.s[i+len("/*"):], "*/")
+				if end != -1 {
+					i += end + len("/**/")
+					continue
+				}
+			}
+		}
+		break
+	}
+
+	if i > p.i {
+		p.i = i
+		return true
+	}
+
+	return false
+}
+
+// consumeParenthesis consumes an opening parenthesis and any following
+// whitespace. It returns true if there was actually a parenthesis to skip.
+func (p *parser) consumeParenthesis() bool {
+	if p.i < len(p.s) && p.s[p.i] == '(' {
+		p.i++
+		p.skipWhitespace()
+		return true
+	}
+	return false
+}
+
+// consumeClosingParenthesis consumes a closing parenthesis and any preceding
+// whitespace. It returns true if there was actually a parenthesis to skip.
+func (p *parser) consumeClosingParenthesis() bool {
+	i := p.i
+	p.skipWhitespace()
+	if p.i < len(p.s) && p.s[p.i] == ')' {
+		p.i++
+		return true
+	}
+	p.i = i
+	return false
+}
+
+// parseTypeSelector parses a type selector (one that matches by tag name).
+func (p *parser) parseTypeSelector() (result Selector, err error) {
+	tag, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+
+	return typeSelector(tag), nil
+}
+
+// parseIDSelector parses a selector that matches by id attribute.
+func (p *parser) parseIDSelector() (Selector, error) {
+	if p.i >= len(p.s) {
+		return nil, fmt.Errorf("expected id selector (#id), found EOF instead")
+	}
+	if p.s[p.i] != '#' {
+		return nil, fmt.Errorf("expected id selector (#id), found '%c' instead", p.s[p.i])
+	}
+
+	p.i++
+	id, err := p.parseName()
+	if err != nil {
+		return nil, err
+	}
+
+	return attributeEqualsSelector("id", id), nil
+}
+
+// parseClassSelector parses a selector that matches by class attribute.
+func (p *parser) parseClassSelector() (Selector, error) {
+	if p.i >= len(p.s) {
+		return nil, fmt.Errorf("expected class selector (.class), found EOF instead")
+	}
+	if p.s[p.i] != '.' {
+		return nil, fmt.Errorf("expected class selector (.class), found '%c' instead", p.s[p.i])
+	}
+
+	p.i++
+	class, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+
+	return attributeIncludesSelector("class", class), nil
+}
+
+// parseAttributeSelector parses a selector that matches by attribute value.
+func (p *parser) parseAttributeSelector() (Selector, error) {
+	if p.i >= len(p.s) {
+		return nil, fmt.Errorf("expected attribute selector ([attribute]), found EOF instead")
+	}
+	if p.s[p.i] != '[' {
+		return nil, fmt.Errorf("expected attribute selector ([attribute]), found '%c' instead", p.s[p.i])
+	}
+
+	p.i++
+	p.skipWhitespace()
+	key, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+
+	p.skipWhitespace()
+	if p.i >= len(p.s) {
+		return nil, errors.New("unexpected EOF in attribute selector")
+	}
+
+	if p.s[p.i] == ']' {
+		p.i++
+		return attributeExistsSelector(key), nil
+	}
+
+	if p.i+2 >= len(p.s) {
+		return nil, errors.New("unexpected EOF in attribute selector")
+	}
+
+	op := p.s[p.i : p.i+2]
+	if op[0] == '=' {
+		op = "="
+	} else if op[1] != '=' {
+		return nil, fmt.Errorf(`expected equality operator, found "%s" instead`, op)
+	}
+	p.i += len(op)
+
+	p.skipWhitespace()
+	if p.i >= len(p.s) {
+		return nil, errors.New("unexpected EOF in attribute selector")
+	}
+	var val string
+	var rx *regexp.Regexp
+	if op == "#=" {
+		rx, err = p.parseRegex()
+	} else {
+		switch p.s[p.i] {
+		case '\'', '"':
+			val, err = p.parseString()
+		default:
+			val, err = p.parseIdentifier()
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	p.skipWhitespace()
+	if p.i >= len(p.s) {
+		return nil, errors.New("unexpected EOF in attribute selector")
+	}
+	if p.s[p.i] != ']' {
+		return nil, fmt.Errorf("expected ']', found '%c' instead", p.s[p.i])
+	}
+	p.i++
+
+	switch op {
+	case "=":
+		return attributeEqualsSelector(key, val), nil
+	case "~=":
+		return attributeIncludesSelector(key, val), nil
+	case "|=":
+		return attributeDashmatchSelector(key, val), nil
+	case "^=":
+		return attributePrefixSelector(key, val), nil
+	case "$=":
+		return attributeSuffixSelector(key, val), nil
+	case "*=":
+		return attributeSubstringSelector(key, val), nil
+	case "#=":
+		return attributeRegexSelector(key, rx), nil
+	}
+
+	return nil, fmt.Errorf("attribute operator %q is not supported", op)
+}
+
+var expectedParenthesis = errors.New("expected '(' but didn't find it")
+var expectedClosingParenthesis = errors.New("expected ')' but didn't find it")
+
+// parsePseudoclassSelector parses a pseudoclass selector like :not(p).
+func (p *parser) parsePseudoclassSelector() (Selector, error) {
+	if p.i >= len(p.s) {
+		return nil, fmt.Errorf("expected pseudoclass selector (:pseudoclass), found EOF instead")
+	}
+	if p.s[p.i] != ':' {
+		return nil, fmt.Errorf("expected attribute selector (:pseudoclass), found '%c' instead", p.s[p.i])
+	}
+
+	p.i++
+	name, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	name = toLowerASCII(name)
+
+	switch name {
+	case "not", "has", "haschild":
+		if !p.consumeParenthesis() {
+			return nil, expectedParenthesis
+		}
+		sel, err := p.parseSelectorGroup()
+		if err != nil {
+			return nil, err
+		}
+		if !p.consumeClosingParenthesis() {
+			return nil, expectedClosingParenthesis
+		}
+
+		switch name {
+		case "not":
+			return negatedSelector(sel), nil
+		case "has":
+			return hasDescendantSelector(sel), nil
+		case "haschild":
+			return hasChildSelector(sel), nil
+		}
+
+	case "contains", "containsown":
+		if !p.consumeParenthesis() {
+			return nil, expectedParenthesis
+		}
+		var val string
+		switch p.s[p.i] {
+		case '\'', '"':
+			val, err = p.parseString()
+		default:
+			val, err = p.parseIdentifier()
+		}
+		if err != nil {
+			return nil, err
+		}
+		val = strings.ToLower(val)
+		p.skipWhitespace()
+		if p.i >= len(p.s) {
+			return nil, errors.New("unexpected EOF in pseudo selector")
+		}
+		if !p.consumeClosingParenthesis() {
+			return nil, expectedClosingParenthesis
+		}
+
+		switch name {
+		case "contains":
+			return textSubstrSelector(val), nil
+		case "containsown":
+			return ownTextSubstrSelector(val), nil
+		}
+
+	case "matches", "matchesown":
+		if !p.consumeParenthesis() {
+			return nil, expectedParenthesis
+		}
+		rx, err := p.parseRegex()
+		if err != nil {
+			return nil, err
+		}
+		if p.i >= len(p.s) {
+			return nil, errors.New("unexpected EOF in pseudo selector")
+		}
+		if !p.consumeClosingParenthesis() {
+			return nil, expectedClosingParenthesis
+		}
+
+		switch name {
+		case "matches":
+			return textRegexSelector(rx), nil
+		case "matchesown":
+			return ownTextRegexSelector(rx), nil
+		}
+
+	case "nth-child", "nth-last-child", "nth-of-type", "nth-last-of-type":
+		if !p.consumeParenthesis() {
+			return nil, expectedParenthesis
+		}
+		a, b, err := p.parseNth()
+		if err != nil {
+			return nil, err
+		}
+		if !p.consumeClosingParenthesis() {
+			return nil, expectedClosingParenthesis
+		}
+		return nthChildSelector(a, b,
+				name == "nth-last-child" || name == "nth-last-of-type",
+				name == "nth-of-type" || name == "nth-last-of-type"),
+			nil
+
+	case "first-child":
+		return nthChildSelector(0, 1, false, false), nil
+	case "last-child":
+		return nthChildSelector(0, 1, true, false), nil
+	case "first-of-type":
+		return nthChildSelector(0, 1, false, true), nil
+	case "last-of-type":
+		return nthChildSelector(0, 1, true, true), nil
+	case "only-child":
+		return onlyChildSelector(false), nil
+	case "only-of-type":
+		return onlyChildSelector(true), nil
+	case "empty":
+		return emptyElementSelector, nil
+	}
+
+	return nil, fmt.Errorf("unknown pseudoclass :%s", name)
+}
+
+// parseInteger parses a  decimal integer.
+func (p *parser) parseInteger() (int, error) {
+	i := p.i
+	start := i
+	for i < len(p.s) && '0' <= p.s[i] && p.s[i] <= '9' {
+		i++
+	}
+	if i == start {
+		return 0, errors.New("expected integer, but didn't find it.")
+	}
+	p.i = i
+
+	val, err := strconv.Atoi(p.s[start:i])
+	if err != nil {
+		return 0, err
+	}
+
+	return val, nil
+}
+
+// parseNth parses the argument for :nth-child (normally of the form an+b).
+func (p *parser) parseNth() (a, b int, err error) {
+	// initial state
+	if p.i >= len(p.s) {
+		goto eof
+	}
+	switch p.s[p.i] {
+	case '-':
+		p.i++
+		goto negativeA
+	case '+':
+		p.i++
+		goto positiveA
+	case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		goto positiveA
+	case 'n', 'N':
+		a = 1
+		p.i++
+		goto readN
+	case 'o', 'O', 'e', 'E':
+		id, err := p.parseName()
+		if err != nil {
+			return 0, 0, err
+		}
+		id = toLowerASCII(id)
+		if id == "odd" {
+			return 2, 1, nil
+		}
+		if id == "even" {
+			return 2, 0, nil
+		}
+		return 0, 0, fmt.Errorf("expected 'odd' or 'even', but found '%s' instead", id)
+	default:
+		goto invalid
+	}
+
+positiveA:
+	if p.i >= len(p.s) {
+		goto eof
+	}
+	switch p.s[p.i] {
+	case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		a, err = p.parseInteger()
+		if err != nil {
+			return 0, 0, err
+		}
+		goto readA
+	case 'n', 'N':
+		a = 1
+		p.i++
+		goto readN
+	default:
+		goto invalid
+	}
+
+negativeA:
+	if p.i >= len(p.s) {
+		goto eof
+	}
+	switch p.s[p.i] {
+	case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		a, err = p.parseInteger()
+		if err != nil {
+			return 0, 0, err
+		}
+		a = -a
+		goto readA
+	case 'n', 'N':
+		a = -1
+		p.i++
+		goto readN
+	default:
+		goto invalid
+	}
+
+readA:
+	if p.i >= len(p.s) {
+		goto eof
+	}
+	switch p.s[p.i] {
+	case 'n', 'N':
+		p.i++
+		goto readN
+	default:
+		// The number we read as a is actually b.
+		return 0, a, nil
+	}
+
+readN:
+	p.skipWhitespace()
+	if p.i >= len(p.s) {
+		goto eof
+	}
+	switch p.s[p.i] {
+	case '+':
+		p.i++
+		p.skipWhitespace()
+		b, err = p.parseInteger()
+		if err != nil {
+			return 0, 0, err
+		}
+		return a, b, nil
+	case '-':
+		p.i++
+		p.skipWhitespace()
+		b, err = p.parseInteger()
+		if err != nil {
+			return 0, 0, err
+		}
+		return a, -b, nil
+	default:
+		return a, 0, nil
+	}
+
+eof:
+	return 0, 0, errors.New("unexpected EOF while attempting to parse expression of form an+b")
+
+invalid:
+	return 0, 0, errors.New("unexpected character while attempting to parse expression of form an+b")
+}
+
+// parseSimpleSelectorSequence parses a selector sequence that applies to
+// a single element.
+func (p *parser) parseSimpleSelectorSequence() (Selector, error) {
+	var result Selector
+
+	if p.i >= len(p.s) {
+		return nil, errors.New("expected selector, found EOF instead")
+	}
+
+	switch p.s[p.i] {
+	case '*':
+		// It's the universal selector. Just skip over it, since it doesn't affect the meaning.
+		p.i++
+	case '#', '.', '[', ':':
+		// There's no type selector. Wait to process the other till the main loop.
+	default:
+		r, err := p.parseTypeSelector()
+		if err != nil {
+			return nil, err
+		}
+		result = r
+	}
+
+loop:
+	for p.i < len(p.s) {
+		var ns Selector
+		var err error
+		switch p.s[p.i] {
+		case '#':
+			ns, err = p.parseIDSelector()
+		case '.':
+			ns, err = p.parseClassSelector()
+		case '[':
+			ns, err = p.parseAttributeSelector()
+		case ':':
+			ns, err = p.parsePseudoclassSelector()
+		default:
+			break loop
+		}
+		if err != nil {
+			return nil, err
+		}
+		if result == nil {
+			result = ns
+		} else {
+			result = intersectionSelector(result, ns)
+		}
+	}
+
+	if result == nil {
+		result = func(n *html.Node) bool {
+			return true
+		}
+	}
+
+	return result, nil
+}
+
+// parseSelector parses a selector that may include combinators.
+func (p *parser) parseSelector() (result Selector, err error) {
+	p.skipWhitespace()
+	result, err = p.parseSimpleSelectorSequence()
+	if err != nil {
+		return
+	}
+
+	for {
+		var combinator byte
+		if p.skipWhitespace() {
+			combinator = ' '
+		}
+		if p.i >= len(p.s) {
+			return
+		}
+
+		switch p.s[p.i] {
+		case '+', '>', '~':
+			combinator = p.s[p.i]
+			p.i++
+			p.skipWhitespace()
+		case ',', ')':
+			// These characters can't begin a selector, but they can legally occur after one.
+			return
+		}
+
+		if combinator == 0 {
+			return
+		}
+
+		c, err := p.parseSimpleSelectorSequence()
+		if err != nil {
+			return nil, err
+		}
+
+		switch combinator {
+		case ' ':
+			result = descendantSelector(result, c)
+		case '>':
+			result = childSelector(result, c)
+		case '+':
+			result = siblingSelector(result, c, true)
+		case '~':
+			result = siblingSelector(result, c, false)
+		}
+	}
+
+	panic("unreachable")
+}
+
+// parseSelectorGroup parses a group of selectors, separated by commas.
+func (p *parser) parseSelectorGroup() (result Selector, err error) {
+	result, err = p.parseSelector()
+	if err != nil {
+		return
+	}
+
+	for p.i < len(p.s) {
+		if p.s[p.i] != ',' {
+			return result, nil
+		}
+		p.i++
+		c, err := p.parseSelector()
+		if err != nil {
+			return nil, err
+		}
+		result = unionSelector(result, c)
+	}
+
+	return
+}

--- a/_third_party/github.com/andybalholm/cascadia/parser_test.go
+++ b/_third_party/github.com/andybalholm/cascadia/parser_test.go
@@ -1,0 +1,86 @@
+package cascadia
+
+import (
+	"testing"
+)
+
+var identifierTests = map[string]string{
+	"x":         "x",
+	"96":        "",
+	"-x":        "-x",
+	`r\e9 sumé`: "résumé",
+	`a\"b`:      `a"b`,
+}
+
+func TestParseIdentifier(t *testing.T) {
+	for source, want := range identifierTests {
+		p := &parser{s: source}
+		got, err := p.parseIdentifier()
+
+		if err != nil {
+			if want == "" {
+				// It was supposed to be an error.
+				continue
+			}
+			t.Errorf("parsing %q: got error (%s), want %q", source, err, want)
+			continue
+		}
+
+		if want == "" {
+			if err == nil {
+				t.Errorf("parsing %q: got %q, want error", source, got)
+			}
+			continue
+		}
+
+		if p.i < len(source) {
+			t.Errorf("parsing %q: %d bytes left over", source, len(source)-p.i)
+			continue
+		}
+
+		if got != want {
+			t.Errorf("parsing %q: got %q, want %q", source, got, want)
+		}
+	}
+}
+
+var stringTests = map[string]string{
+	`"x"`:         "x",
+	`'x'`:         "x",
+	`'x`:          "",
+	"'x\\\r\nx'":  "xx",
+	`"r\e9 sumé"`: "résumé",
+	`"a\"b"`:      `a"b`,
+}
+
+func TestParseString(t *testing.T) {
+	for source, want := range stringTests {
+		p := &parser{s: source}
+		got, err := p.parseString()
+
+		if err != nil {
+			if want == "" {
+				// It was supposed to be an error.
+				continue
+			}
+			t.Errorf("parsing %q: got error (%s), want %q", source, err, want)
+			continue
+		}
+
+		if want == "" {
+			if err == nil {
+				t.Errorf("parsing %q: got %q, want error", source, got)
+			}
+			continue
+		}
+
+		if p.i < len(source) {
+			t.Errorf("parsing %q: %d bytes left over", source, len(source)-p.i)
+			continue
+		}
+
+		if got != want {
+			t.Errorf("parsing %q: got %q, want %q", source, got, want)
+		}
+	}
+}

--- a/_third_party/github.com/andybalholm/cascadia/selector.go
+++ b/_third_party/github.com/andybalholm/cascadia/selector.go
@@ -1,0 +1,503 @@
+package cascadia
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"bosun.org/_third_party/golang.org/x/net/html"
+)
+
+// the Selector type, and functions for creating them
+
+// A Selector is a function which tells whether a node matches or not.
+type Selector func(*html.Node) bool
+
+// hasChildMatch returns whether n has any child that matches a.
+func hasChildMatch(n *html.Node, a Selector) bool {
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if a(c) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasDescendantMatch performs a depth-first search of n's descendants,
+// testing whether any of them match a. It returns true as soon as a match is
+// found, or false if no match is found.
+func hasDescendantMatch(n *html.Node, a Selector) bool {
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if a(c) || (c.Type == html.ElementNode && hasDescendantMatch(c, a)) {
+			return true
+		}
+	}
+	return false
+}
+
+// Compile parses a selector and returns, if successful, a Selector object
+// that can be used to match against html.Node objects.
+func Compile(sel string) (Selector, error) {
+	p := &parser{s: sel}
+	compiled, err := p.parseSelectorGroup()
+	if err != nil {
+		return nil, err
+	}
+
+	if p.i < len(sel) {
+		return nil, fmt.Errorf("parsing %q: %d bytes left over", sel, len(sel)-p.i)
+	}
+
+	return compiled, nil
+}
+
+// MustCompile is like Compile, but panics instead of returning an error.
+func MustCompile(sel string) Selector {
+	compiled, err := Compile(sel)
+	if err != nil {
+		panic(err)
+	}
+	return compiled
+}
+
+// MatchAll returns a slice of the nodes that match the selector,
+// from n and its children.
+func (s Selector) MatchAll(n *html.Node) []*html.Node {
+	return s.matchAllInto(n, nil)
+}
+
+func (s Selector) matchAllInto(n *html.Node, storage []*html.Node) []*html.Node {
+	if s(n) {
+		storage = append(storage, n)
+	}
+
+	for child := n.FirstChild; child != nil; child = child.NextSibling {
+		storage = s.matchAllInto(child, storage)
+	}
+
+	return storage
+}
+
+// Match returns true if the node matches the selector.
+func (s Selector) Match(n *html.Node) bool {
+	return s(n)
+}
+
+// MatchFirst returns the first node that matches s, from n and its children.
+func (s Selector) MatchFirst(n *html.Node) *html.Node {
+	if s.Match(n) {
+		return n
+	}
+
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		m := s.MatchFirst(c)
+		if m != nil {
+			return m
+		}
+	}
+	return nil
+}
+
+// Filter returns the nodes in nodes that match the selector.
+func (s Selector) Filter(nodes []*html.Node) (result []*html.Node) {
+	for _, n := range nodes {
+		if s(n) {
+			result = append(result, n)
+		}
+	}
+	return result
+}
+
+// typeSelector returns a Selector that matches elements with a given tag name.
+func typeSelector(tag string) Selector {
+	tag = toLowerASCII(tag)
+	return func(n *html.Node) bool {
+		return n.Type == html.ElementNode && n.Data == tag
+	}
+}
+
+// toLowerASCII returns s with all ASCII capital letters lowercased.
+func toLowerASCII(s string) string {
+	var b []byte
+	for i := 0; i < len(s); i++ {
+		if c := s[i]; 'A' <= c && c <= 'Z' {
+			if b == nil {
+				b = make([]byte, len(s))
+				copy(b, s)
+			}
+			b[i] = s[i] + ('a' - 'A')
+		}
+	}
+
+	if b == nil {
+		return s
+	}
+
+	return string(b)
+}
+
+// attributeSelector returns a Selector that matches elements
+// where the attribute named key satisifes the function f.
+func attributeSelector(key string, f func(string) bool) Selector {
+	key = toLowerASCII(key)
+	return func(n *html.Node) bool {
+		if n.Type != html.ElementNode {
+			return false
+		}
+		for _, a := range n.Attr {
+			if a.Key == key && f(a.Val) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// attributeExistsSelector returns a Selector that matches elements that have
+// an attribute named key.
+func attributeExistsSelector(key string) Selector {
+	return attributeSelector(key, func(string) bool { return true })
+}
+
+// attributeEqualsSelector returns a Selector that matches elements where
+// the attribute named key has the value val.
+func attributeEqualsSelector(key, val string) Selector {
+	return attributeSelector(key,
+		func(s string) bool {
+			return s == val
+		})
+}
+
+// attributeIncludesSelector returns a Selector that matches elements where
+// the attribute named key is a whitespace-separated list that includes val.
+func attributeIncludesSelector(key, val string) Selector {
+	return attributeSelector(key,
+		func(s string) bool {
+			for s != "" {
+				i := strings.IndexAny(s, " \t\r\n\f")
+				if i == -1 {
+					return s == val
+				}
+				if s[:i] == val {
+					return true
+				}
+				s = s[i+1:]
+			}
+			return false
+		})
+}
+
+// attributeDashmatchSelector returns a Selector that matches elements where
+// the attribute named key equals val or starts with val plus a hyphen.
+func attributeDashmatchSelector(key, val string) Selector {
+	return attributeSelector(key,
+		func(s string) bool {
+			if s == val {
+				return true
+			}
+			if len(s) <= len(val) {
+				return false
+			}
+			if s[:len(val)] == val && s[len(val)] == '-' {
+				return true
+			}
+			return false
+		})
+}
+
+// attributePrefixSelector returns a Selector that matches elements where
+// the attribute named key starts with val.
+func attributePrefixSelector(key, val string) Selector {
+	return attributeSelector(key,
+		func(s string) bool {
+			return strings.HasPrefix(s, val)
+		})
+}
+
+// attributeSuffixSelector returns a Selector that matches elements where
+// the attribute named key ends with val.
+func attributeSuffixSelector(key, val string) Selector {
+	return attributeSelector(key,
+		func(s string) bool {
+			return strings.HasSuffix(s, val)
+		})
+}
+
+// attributeSubstringSelector returns a Selector that matches nodes where
+// the attribute named key contains val.
+func attributeSubstringSelector(key, val string) Selector {
+	return attributeSelector(key,
+		func(s string) bool {
+			return strings.Contains(s, val)
+		})
+}
+
+// attributeRegexSelector returns a Selector that matches nodes where
+// the attribute named key matches the regular expression rx
+func attributeRegexSelector(key string, rx *regexp.Regexp) Selector {
+	return attributeSelector(key,
+		func(s string) bool {
+			return rx.MatchString(s)
+		})
+}
+
+// intersectionSelector returns a selector that matches nodes that match
+// both a and b.
+func intersectionSelector(a, b Selector) Selector {
+	return func(n *html.Node) bool {
+		return a(n) && b(n)
+	}
+}
+
+// unionSelector returns a selector that matches elements that match
+// either a or b.
+func unionSelector(a, b Selector) Selector {
+	return func(n *html.Node) bool {
+		return a(n) || b(n)
+	}
+}
+
+// negatedSelector returns a selector that matches elements that do not match a.
+func negatedSelector(a Selector) Selector {
+	return func(n *html.Node) bool {
+		if n.Type != html.ElementNode {
+			return false
+		}
+		return !a(n)
+	}
+}
+
+// writeNodeText writes the text contained in n and its descendants to b.
+func writeNodeText(n *html.Node, b *bytes.Buffer) {
+	switch n.Type {
+	case html.TextNode:
+		b.WriteString(n.Data)
+	case html.ElementNode:
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			writeNodeText(c, b)
+		}
+	}
+}
+
+// nodeText returns the text contained in n and its descendants.
+func nodeText(n *html.Node) string {
+	var b bytes.Buffer
+	writeNodeText(n, &b)
+	return b.String()
+}
+
+// nodeOwnText returns the contents of the text nodes that are direct
+// children of n.
+func nodeOwnText(n *html.Node) string {
+	var b bytes.Buffer
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type == html.TextNode {
+			b.WriteString(c.Data)
+		}
+	}
+	return b.String()
+}
+
+// textSubstrSelector returns a selector that matches nodes that
+// contain the given text.
+func textSubstrSelector(val string) Selector {
+	return func(n *html.Node) bool {
+		text := strings.ToLower(nodeText(n))
+		return strings.Contains(text, val)
+	}
+}
+
+// ownTextSubstrSelector returns a selector that matches nodes that
+// directly contain the given text
+func ownTextSubstrSelector(val string) Selector {
+	return func(n *html.Node) bool {
+		text := strings.ToLower(nodeOwnText(n))
+		return strings.Contains(text, val)
+	}
+}
+
+// textRegexSelector returns a selector that matches nodes whose text matches
+// the specified regular expression
+func textRegexSelector(rx *regexp.Regexp) Selector {
+	return func(n *html.Node) bool {
+		return rx.MatchString(nodeText(n))
+	}
+}
+
+// ownTextRegexSelector returns a selector that matches nodes whose text
+// directly matches the specified regular expression
+func ownTextRegexSelector(rx *regexp.Regexp) Selector {
+	return func(n *html.Node) bool {
+		return rx.MatchString(nodeOwnText(n))
+	}
+}
+
+// hasChildSelector returns a selector that matches elements
+// with a child that matches a.
+func hasChildSelector(a Selector) Selector {
+	return func(n *html.Node) bool {
+		if n.Type != html.ElementNode {
+			return false
+		}
+		return hasChildMatch(n, a)
+	}
+}
+
+// hasDescendantSelector returns a selector that matches elements
+// with any descendant that matches a.
+func hasDescendantSelector(a Selector) Selector {
+	return func(n *html.Node) bool {
+		if n.Type != html.ElementNode {
+			return false
+		}
+		return hasDescendantMatch(n, a)
+	}
+}
+
+// nthChildSelector returns a selector that implements :nth-child(an+b).
+// If last is true, implements :nth-last-child instead.
+// If ofType is true, implements :nth-of-type instead.
+func nthChildSelector(a, b int, last, ofType bool) Selector {
+	return func(n *html.Node) bool {
+		if n.Type != html.ElementNode {
+			return false
+		}
+
+		parent := n.Parent
+		if parent == nil {
+			return false
+		}
+
+		i := -1
+		count := 0
+		for c := parent.FirstChild; c != nil; c = c.NextSibling {
+			if (c.Type != html.ElementNode) || (ofType && c.Data != n.Data) {
+				continue
+			}
+			count++
+			if c == n {
+				i = count
+				if !last {
+					break
+				}
+			}
+		}
+
+		if i == -1 {
+			// This shouldn't happen, since n should always be one of its parent's children.
+			return false
+		}
+
+		if last {
+			i = count - i + 1
+		}
+
+		i -= b
+		if a == 0 {
+			return i == 0
+		}
+
+		return i%a == 0 && i/a >= 0
+	}
+}
+
+// onlyChildSelector returns a selector that implements :only-child.
+// If ofType is true, it implements :only-of-type instead.
+func onlyChildSelector(ofType bool) Selector {
+	return func(n *html.Node) bool {
+		if n.Type != html.ElementNode {
+			return false
+		}
+
+		parent := n.Parent
+		if parent == nil {
+			return false
+		}
+
+		count := 0
+		for c := parent.FirstChild; c != nil; c = c.NextSibling {
+			if (c.Type != html.ElementNode) || (ofType && c.Data != n.Data) {
+				continue
+			}
+			count++
+			if count > 1 {
+				return false
+			}
+		}
+
+		return count == 1
+	}
+}
+
+// emptyElementSelector is a Selector that matches empty elements.
+func emptyElementSelector(n *html.Node) bool {
+	if n.Type != html.ElementNode {
+		return false
+	}
+
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		switch c.Type {
+		case html.ElementNode, html.TextNode:
+			return false
+		}
+	}
+
+	return true
+}
+
+// descendantSelector returns a Selector that matches an element if
+// it matches d and has an ancestor that matches a.
+func descendantSelector(a, d Selector) Selector {
+	return func(n *html.Node) bool {
+		if !d(n) {
+			return false
+		}
+
+		for p := n.Parent; p != nil; p = p.Parent {
+			if a(p) {
+				return true
+			}
+		}
+
+		return false
+	}
+}
+
+// childSelector returns a Selector that matches an element if
+// it matches d and its parent matches a.
+func childSelector(a, d Selector) Selector {
+	return func(n *html.Node) bool {
+		return d(n) && n.Parent != nil && a(n.Parent)
+	}
+}
+
+// siblingSelector returns a Selector that matches an element
+// if it matches s2 and in is preceded by an element that matches s1.
+// If adjacent is true, the sibling must be immediately before the element.
+func siblingSelector(s1, s2 Selector, adjacent bool) Selector {
+	return func(n *html.Node) bool {
+		if !s2(n) {
+			return false
+		}
+
+		if adjacent {
+			for n = n.PrevSibling; n != nil; n = n.PrevSibling {
+				if n.Type == html.TextNode || n.Type == html.CommentNode {
+					continue
+				}
+				return s1(n)
+			}
+			return false
+		}
+
+		// Walk backwards looking for element that matches s1
+		for c := n.PrevSibling; c != nil; c = c.PrevSibling {
+			if s1(c) {
+				return true
+			}
+		}
+
+		return false
+	}
+}

--- a/_third_party/github.com/andybalholm/cascadia/selector_test.go
+++ b/_third_party/github.com/andybalholm/cascadia/selector_test.go
@@ -1,0 +1,537 @@
+package cascadia
+
+import (
+	"strings"
+	"testing"
+
+	"bosun.org/_third_party/golang.org/x/net/html"
+)
+
+type selectorTest struct {
+	HTML, selector string
+	results        []string
+}
+
+func nodeString(n *html.Node) string {
+	switch n.Type {
+	case html.TextNode:
+		return n.Data
+	case html.ElementNode:
+		return html.Token{
+			Type: html.StartTagToken,
+			Data: n.Data,
+			Attr: n.Attr,
+		}.String()
+	}
+	return ""
+}
+
+var selectorTests = []selectorTest{
+	{
+		`<body><address>This address...</address></body>`,
+		"address",
+		[]string{
+			"<address>",
+		},
+	},
+	{
+		`<html><head></head><body></body></html>`,
+		"*",
+		[]string{
+			"",
+			"<html>",
+			"<head>",
+			"<body>",
+		},
+	},
+	{
+		`<p id="foo"><p id="bar">`,
+		"#foo",
+		[]string{
+			`<p id="foo">`,
+		},
+	},
+	{
+		`<ul><li id="t1"><p id="t1">`,
+		"li#t1",
+		[]string{
+			`<li id="t1">`,
+		},
+	},
+	{
+		`<ol><li id="t4"><li id="t44">`,
+		"*#t4",
+		[]string{
+			`<li id="t4">`,
+		},
+	},
+	{
+		`<ul><li class="t1"><li class="t2">`,
+		".t1",
+		[]string{
+			`<li class="t1">`,
+		},
+	},
+	{
+		`<p class="t1 t2">`,
+		"p.t1",
+		[]string{
+			`<p class="t1 t2">`,
+		},
+	},
+	{
+		`<div class="test">`,
+		"div.teST",
+		[]string{},
+	},
+	{
+		`<p class="t1 t2">`,
+		".t1.fail",
+		[]string{},
+	},
+	{
+		`<p class="t1 t2">`,
+		"p.t1.t2",
+		[]string{
+			`<p class="t1 t2">`,
+		},
+	},
+	{
+		`<p><p title="title">`,
+		"p[title]",
+		[]string{
+			`<p title="title">`,
+		},
+	},
+	{
+		`<address><address title="foo"><address title="bar">`,
+		`address[title="foo"]`,
+		[]string{
+			`<address title="foo">`,
+		},
+	},
+	{
+		`<p title="tot foo bar">`,
+		`[    	title        ~=       foo    ]`,
+		[]string{
+			`<p title="tot foo bar">`,
+		},
+	},
+	{
+		`<p title="hello world">`,
+		`[title~="hello world"]`,
+		[]string{},
+	},
+	{
+		`<p lang="en"><p lang="en-gb"><p lang="enough"><p lang="fr-en">`,
+		`[lang|="en"]`,
+		[]string{
+			`<p lang="en">`,
+			`<p lang="en-gb">`,
+		},
+	},
+	{
+		`<p title="foobar"><p title="barfoo">`,
+		`[title^="foo"]`,
+		[]string{
+			`<p title="foobar">`,
+		},
+	},
+	{
+		`<p title="foobar"><p title="barfoo">`,
+		`[title$="bar"]`,
+		[]string{
+			`<p title="foobar">`,
+		},
+	},
+	{
+		`<p title="foobarufoo">`,
+		`[title*="bar"]`,
+		[]string{
+			`<p title="foobarufoo">`,
+		},
+	},
+	{
+		`<p class="t1 t2">`,
+		".t1:not(.t2)",
+		[]string{},
+	},
+	{
+		`<div class="t3">`,
+		`div:not(.t1)`,
+		[]string{
+			`<div class="t3">`,
+		},
+	},
+	{
+		`<ol><li id=1><li id=2><li id=3></ol>`,
+		`li:nth-child(odd)`,
+		[]string{
+			`<li id="1">`,
+			`<li id="3">`,
+		},
+	},
+	{
+		`<ol><li id=1><li id=2><li id=3></ol>`,
+		`li:nth-child(even)`,
+		[]string{
+			`<li id="2">`,
+		},
+	},
+	{
+		`<ol><li id=1><li id=2><li id=3></ol>`,
+		`li:nth-child(-n+2)`,
+		[]string{
+			`<li id="1">`,
+			`<li id="2">`,
+		},
+	},
+	{
+		`<ol><li id=1><li id=2><li id=3></ol>`,
+		`li:nth-child(3n+1)`,
+		[]string{
+			`<li id="1">`,
+		},
+	},
+	{
+		`<ol><li id=1><li id=2><li id=3><li id=4></ol>`,
+		`li:nth-last-child(odd)`,
+		[]string{
+			`<li id="2">`,
+			`<li id="4">`,
+		},
+	},
+	{
+		`<ol><li id=1><li id=2><li id=3><li id=4></ol>`,
+		`li:nth-last-child(even)`,
+		[]string{
+			`<li id="1">`,
+			`<li id="3">`,
+		},
+	},
+	{
+		`<ol><li id=1><li id=2><li id=3><li id=4></ol>`,
+		`li:nth-last-child(-n+2)`,
+		[]string{
+			`<li id="3">`,
+			`<li id="4">`,
+		},
+	},
+	{
+		`<ol><li id=1><li id=2><li id=3><li id=4></ol>`,
+		`li:nth-last-child(3n+1)`,
+		[]string{
+			`<li id="1">`,
+			`<li id="4">`,
+		},
+	},
+	{
+		`<p>some text <span id="1">and a span</span><span id="2"> and another</span></p>`,
+		`span:first-child`,
+		[]string{
+			`<span id="1">`,
+		},
+	},
+	{
+		`<span>a span</span> and some text`,
+		`span:last-child`,
+		[]string{
+			`<span>`,
+		},
+	},
+	{
+		`<address></address><p id=1><p id=2>`,
+		`p:nth-of-type(2)`,
+		[]string{
+			`<p id="2">`,
+		},
+	},
+	{
+		`<address></address><p id=1><p id=2></p><a>`,
+		`p:nth-last-of-type(2)`,
+		[]string{
+			`<p id="1">`,
+		},
+	},
+	{
+		`<address></address><p id=1><p id=2></p><a>`,
+		`p:last-of-type`,
+		[]string{
+			`<p id="2">`,
+		},
+	},
+	{
+		`<address></address><p id=1><p id=2></p><a>`,
+		`p:first-of-type`,
+		[]string{
+			`<p id="1">`,
+		},
+	},
+	{
+		`<div><p id="1"></p><a></a></div><div><p id="2"></p></div>`,
+		`p:only-child`,
+		[]string{
+			`<p id="2">`,
+		},
+	},
+	{
+		`<div><p id="1"></p><a></a></div><div><p id="2"></p><p id="3"></p></div>`,
+		`p:only-of-type`,
+		[]string{
+			`<p id="1">`,
+		},
+	},
+	{
+		`<p id="1"><!-- --><p id="2">Hello<p id="3"><span>`,
+		`:empty`,
+		[]string{
+			`<head>`,
+			`<p id="1">`,
+			`<span>`,
+		},
+	},
+	{
+		`<div><p id="1"><table><tr><td><p id="2"></table></div><p id="3">`,
+		`div p`,
+		[]string{
+			`<p id="1">`,
+			`<p id="2">`,
+		},
+	},
+	{
+		`<div><p id="1"><table><tr><td><p id="2"></table></div><p id="3">`,
+		`div table p`,
+		[]string{
+			`<p id="2">`,
+		},
+	},
+	{
+		`<div><p id="1"><div><p id="2"></div><table><tr><td><p id="3"></table></div>`,
+		`div > p`,
+		[]string{
+			`<p id="1">`,
+			`<p id="2">`,
+		},
+	},
+	{
+		`<p id="1"><p id="2"></p><address></address><p id="3">`,
+		`p ~ p`,
+		[]string{
+			`<p id="2">`,
+			`<p id="3">`,
+		},
+	},
+	{
+		`<p id="1"></p>
+		 <!--comment-->
+		 <p id="2"></p><address></address><p id="3">`,
+		`p + p`,
+		[]string{
+			`<p id="2">`,
+		},
+	},
+	{
+		`<ul><li></li><li></li></ul><p>`,
+		`li, p`,
+		[]string{
+			"<li>",
+			"<li>",
+			"<p>",
+		},
+	},
+	{
+		`<p id="1"><p id="2"></p><address></address><p id="3">`,
+		`p +/*This is a comment*/ p`,
+		[]string{
+			`<p id="2">`,
+		},
+	},
+	{
+		`<p>Text block that <span>wraps inner text</span> and continues</p>`,
+		`p:contains("that wraps")`,
+		[]string{
+			`<p>`,
+		},
+	},
+	{
+		`<p>Text block that <span>wraps inner text</span> and continues</p>`,
+		`p:containsOwn("that wraps")`,
+		[]string{},
+	},
+	{
+		`<p>Text block that <span>wraps inner text</span> and continues</p>`,
+		`:containsOwn("inner")`,
+		[]string{
+			`<span>`,
+		},
+	},
+	{
+		`<p>Text block that <span>wraps inner text</span> and continues</p>`,
+		`p:containsOwn("block")`,
+		[]string{
+			`<p>`,
+		},
+	},
+	{
+		`<div id="d1"><p id="p1"><span>text content</span></p></div><div id="d2"/>`,
+		`div:has(#p1)`,
+		[]string{
+			`<div id="d1">`,
+		},
+	},
+	{
+		`<div id="d1"><p id="p1"><span>contents 1</span></p></div>
+		<div id="d2"><p>contents <em>2</em></p></div>`,
+		`div:has(:containsOwn("2"))`,
+		[]string{
+			`<div id="d2">`,
+		},
+	},
+	{
+		`<body><div id="d1"><p id="p1"><span>contents 1</span></p></div>
+		<div id="d2"><p id="p2">contents <em>2</em></p></div></body>`,
+		`body :has(:containsOwn("2"))`,
+		[]string{
+			`<div id="d2">`,
+			`<p id="p2">`,
+		},
+	},
+	{
+		`<body><div id="d1"><p id="p1"><span>contents 1</span></p></div>
+		<div id="d2"><p id="p2">contents <em>2</em></p></div></body>`,
+		`body :haschild(:containsOwn("2"))`,
+		[]string{
+			`<p id="p2">`,
+		},
+	},
+	{
+		`<p id="p1">0123456789</p><p id="p2">abcdef</p><p id="p3">0123ABCD</p>`,
+		`p:matches([\d])`,
+		[]string{
+			`<p id="p1">`,
+			`<p id="p3">`,
+		},
+	},
+	{
+		`<p id="p1">0123456789</p><p id="p2">abcdef</p><p id="p3">0123ABCD</p>`,
+		`p:matches([a-z])`,
+		[]string{
+			`<p id="p2">`,
+		},
+	},
+	{
+		`<p id="p1">0123456789</p><p id="p2">abcdef</p><p id="p3">0123ABCD</p>`,
+		`p:matches([a-zA-Z])`,
+		[]string{
+			`<p id="p2">`,
+			`<p id="p3">`,
+		},
+	},
+	{
+		`<p id="p1">0123456789</p><p id="p2">abcdef</p><p id="p3">0123ABCD</p>`,
+		`p:matches([^\d])`,
+		[]string{
+			`<p id="p2">`,
+			`<p id="p3">`,
+		},
+	},
+	{
+		`<p id="p1">0123456789</p><p id="p2">abcdef</p><p id="p3">0123ABCD</p>`,
+		`p:matches(^(0|a))`,
+		[]string{
+			`<p id="p1">`,
+			`<p id="p2">`,
+			`<p id="p3">`,
+		},
+	},
+	{
+		`<p id="p1">0123456789</p><p id="p2">abcdef</p><p id="p3">0123ABCD</p>`,
+		`p:matches(^\d+$)`,
+		[]string{
+			`<p id="p1">`,
+		},
+	},
+	{
+		`<p id="p1">0123456789</p><p id="p2">abcdef</p><p id="p3">0123ABCD</p>`,
+		`p:not(:matches(^\d+$))`,
+		[]string{
+			`<p id="p2">`,
+			`<p id="p3">`,
+		},
+	},
+	{
+		`<div><p id="p1">01234<em>567</em>89</p><div>`,
+		`div :matchesOwn(^\d+$)`,
+		[]string{
+			`<p id="p1">`,
+			`<em>`,
+		},
+	},
+	{
+		`<ul>
+			<li><a id="a1" href="http://www.google.com/finance"/>
+			<li><a id="a2" href="http://finance.yahoo.com/"/>
+			<li><a id="a2" href="http://finance.untrusted.com/"/>
+			<li><a id="a3" href="https://www.google.com/news"/>
+			<li><a id="a4" href="http://news.yahoo.com"/>
+		</ul>`,
+		`[href#=(fina)]:not([href#=(\/\/[^\/]+untrusted)])`,
+		[]string{
+			`<a id="a1" href="http://www.google.com/finance">`,
+			`<a id="a2" href="http://finance.yahoo.com/">`,
+		},
+	},
+	{
+		`<ul>
+			<li><a id="a1" href="http://www.google.com/finance"/>
+			<li><a id="a2" href="http://finance.yahoo.com/"/>
+			<li><a id="a3" href="https://www.google.com/news"/>
+			<li><a id="a4" href="http://news.yahoo.com"/>
+		</ul>`,
+		`[href#=(^https:\/\/[^\/]*\/?news)]`,
+		[]string{
+			`<a id="a3" href="https://www.google.com/news">`,
+		},
+	},
+}
+
+func TestSelectors(t *testing.T) {
+	for _, test := range selectorTests {
+		s, err := Compile(test.selector)
+		if err != nil {
+			t.Errorf("error compiling %q: %s", test.selector, err)
+			continue
+		}
+
+		doc, err := html.Parse(strings.NewReader(test.HTML))
+		if err != nil {
+			t.Errorf("error parsing %q: %s", test.HTML, err)
+			continue
+		}
+
+		matches := s.MatchAll(doc)
+		if len(matches) != len(test.results) {
+			t.Errorf("wanted %d elements, got %d instead", len(test.results), len(matches))
+			continue
+		}
+
+		for i, m := range matches {
+			got := nodeString(m)
+			if got != test.results[i] {
+				t.Errorf("wanted %s, got %s instead", test.results[i], got)
+			}
+		}
+
+		firstMatch := s.MatchFirst(doc)
+		if len(test.results) == 0 {
+			if firstMatch != nil {
+				t.Errorf("MatchFirst: want nil, got %s", nodeString(firstMatch))
+			}
+		} else {
+			got := nodeString(firstMatch)
+			if got != test.results[0] {
+				t.Errorf("MatchFirst: want %s, got %s", test.results[0], got)
+			}
+		}
+	}
+}

--- a/_third_party/github.com/aymerick/douceur/css/declaration.go
+++ b/_third_party/github.com/aymerick/douceur/css/declaration.go
@@ -1,0 +1,60 @@
+package css
+
+import "fmt"
+
+// A parsed style property
+type Declaration struct {
+	Property  string
+	Value     string
+	Important bool
+}
+
+// Instanciate a new Declaration
+func NewDeclaration() *Declaration {
+	return &Declaration{}
+}
+
+// Returns string representation of the Declaration
+func (decl *Declaration) String() string {
+	return decl.StringWithImportant(true)
+}
+
+// Returns string representation with optional !important part
+func (decl *Declaration) StringWithImportant(option bool) string {
+	result := fmt.Sprintf("%s: %s", decl.Property, decl.Value)
+
+	if option && decl.Important {
+		result += " !important"
+	}
+
+	result += ";"
+
+	return result
+}
+
+// Returns true if both Declarations are equals
+func (decl *Declaration) Equal(other *Declaration) bool {
+	return (decl.Property == other.Property) && (decl.Value == other.Value) && (decl.Important == other.Important)
+}
+
+//
+// DeclarationsByProperty
+//
+
+// Sortable style declarations
+type DeclarationsByProperty []*Declaration
+
+// Implements sort.Interface
+func (declarations DeclarationsByProperty) Len() int {
+	return len(declarations)
+}
+
+// Implements sort.Interface
+func (declarations DeclarationsByProperty) Swap(i, j int) {
+	declarations[i], declarations[j] = declarations[j], declarations[i]
+}
+
+// Implements sort.Interface
+func (declarations DeclarationsByProperty) Less(i, j int) bool {
+	return declarations[i].Property < declarations[j].Property
+}

--- a/_third_party/github.com/aymerick/douceur/css/rule.go
+++ b/_third_party/github.com/aymerick/douceur/css/rule.go
@@ -1,0 +1,229 @@
+package css
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	IDENT_SPACES = 2
+)
+
+type RuleKind int
+
+// Rule kinds
+const (
+	QUALIFIED_RULE RuleKind = iota
+	AT_RULE
+)
+
+// At Rules than have Rules inside their block instead of Declarations
+var atRulesWithRulesBlock = []string{
+	"@document", "@font-feature-values", "@keyframes", "@media", "@supports",
+}
+
+// A parsed CSS rule
+type Rule struct {
+	Kind RuleKind
+
+	// At Rule name (eg: "@media")
+	Name string
+
+	// Raw prelude
+	Prelude string
+
+	// Qualified Rule selectors parsed from prelude
+	Selectors []string
+
+	// Style properties
+	Declarations []*Declaration
+
+	// At Rule embedded rules
+	Rules []*Rule
+
+	// Current rule embedding level
+	EmbedLevel int
+}
+
+// Instanciate a new Rule
+func NewRule(kind RuleKind) *Rule {
+	return &Rule{
+		Kind: kind,
+	}
+}
+
+// Returns string representation of rule kind
+func (kind RuleKind) String() string {
+	switch kind {
+	case QUALIFIED_RULE:
+		return "Qualified Rule"
+	case AT_RULE:
+		return "At Rule"
+	default:
+		return "WAT"
+	}
+}
+
+// Returns true if this rule embeds another rules
+func (rule *Rule) EmbedsRules() bool {
+	if rule.Kind == AT_RULE {
+		for _, atRuleName := range atRulesWithRulesBlock {
+			if rule.Name == atRuleName {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// Returns true if both rules are equals
+func (rule *Rule) Equal(other *Rule) bool {
+	if (rule.Kind != other.Kind) ||
+		(rule.Prelude != other.Prelude) ||
+		(rule.Name != other.Name) {
+		return false
+	}
+
+	if (len(rule.Selectors) != len(other.Selectors)) ||
+		(len(rule.Declarations) != len(other.Declarations)) ||
+		(len(rule.Rules) != len(other.Rules)) {
+		return false
+	}
+
+	for i, sel := range rule.Selectors {
+		if sel != other.Selectors[i] {
+			return false
+		}
+	}
+
+	for i, decl := range rule.Declarations {
+		if !decl.Equal(other.Declarations[i]) {
+			return false
+		}
+	}
+
+	for i, rule := range rule.Rules {
+		if !rule.Equal(other.Rules[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Returns a string representation of rules differences
+func (rule *Rule) Diff(other *Rule) []string {
+	result := []string{}
+
+	if rule.Kind != other.Kind {
+		result = append(result, fmt.Sprintf("Kind: %s | %s", rule.Kind.String(), other.Kind.String()))
+	}
+
+	if rule.Prelude != other.Prelude {
+		result = append(result, fmt.Sprintf("Prelude: \"%s\" | \"%s\"", rule.Prelude, other.Prelude))
+	}
+
+	if rule.Name != other.Name {
+		result = append(result, fmt.Sprintf("Name: \"%s\" | \"%s\"", rule.Name, other.Name))
+	}
+
+	if len(rule.Selectors) != len(other.Selectors) {
+		result = append(result, fmt.Sprintf("Selectors: %v | %v", strings.Join(rule.Selectors, ", "), strings.Join(other.Selectors, ", ")))
+	} else {
+		for i, sel := range rule.Selectors {
+			if sel != other.Selectors[i] {
+				result = append(result, fmt.Sprintf("Selector: \"%s\" | \"%s\"", sel, other.Selectors[i]))
+			}
+		}
+	}
+
+	if len(rule.Declarations) != len(other.Declarations) {
+		result = append(result, fmt.Sprintf("Declarations Nb: %d | %d", len(rule.Declarations), len(other.Declarations)))
+	} else {
+		for i, decl := range rule.Declarations {
+			if !decl.Equal(other.Declarations[i]) {
+				result = append(result, fmt.Sprintf("Declaration: \"%s\" | \"%s\"", decl.String(), other.Declarations[i].String()))
+			}
+		}
+	}
+
+	if len(rule.Rules) != len(other.Rules) {
+		result = append(result, fmt.Sprintf("Rules Nb: %d | %d", len(rule.Rules), len(other.Rules)))
+	} else {
+
+		for i, rule := range rule.Rules {
+			if !rule.Equal(other.Rules[i]) {
+				result = append(result, fmt.Sprintf("Rule: \"%s\" | \"%s\"", rule.String(), other.Rules[i].String()))
+			}
+		}
+	}
+
+	return result
+}
+
+// Returns the string representation of a rule
+func (rule *Rule) String() string {
+	result := ""
+
+	if rule.Kind == QUALIFIED_RULE {
+		for i, sel := range rule.Selectors {
+			if i != 0 {
+				result += ", "
+			}
+			result += sel
+		}
+	} else {
+		// AT_RULE
+		result += fmt.Sprintf("%s", rule.Name)
+
+		if rule.Prelude != "" {
+			if result != "" {
+				result += " "
+			}
+			result += fmt.Sprintf("%s", rule.Prelude)
+		}
+	}
+
+	if (len(rule.Declarations) == 0) && (len(rule.Rules) == 0) {
+		result += ";"
+	} else {
+		result += " {\n"
+
+		if rule.EmbedsRules() {
+			for _, subRule := range rule.Rules {
+				result += fmt.Sprintf("%s%s\n", rule.indent(), subRule.String())
+			}
+		} else {
+			for _, decl := range rule.Declarations {
+				result += fmt.Sprintf("%s%s\n", rule.indent(), decl.String())
+			}
+		}
+
+		result += fmt.Sprintf("%s}", rule.indentEndBlock())
+	}
+
+	return result
+}
+
+// Returns identation spaces for declarations and rules
+func (rule *Rule) indent() string {
+	result := ""
+
+	for i := 0; i < ((rule.EmbedLevel + 1) * IDENT_SPACES); i++ {
+		result += " "
+	}
+
+	return result
+}
+
+// Returns identation spaces for end of block character
+func (rule *Rule) indentEndBlock() string {
+	result := ""
+
+	for i := 0; i < (rule.EmbedLevel * IDENT_SPACES); i++ {
+		result += " "
+	}
+
+	return result
+}

--- a/_third_party/github.com/aymerick/douceur/css/stylesheet.go
+++ b/_third_party/github.com/aymerick/douceur/css/stylesheet.go
@@ -1,0 +1,25 @@
+package css
+
+// A Parsed stylesheet
+type Stylesheet struct {
+	Rules []*Rule
+}
+
+// Instanciate a new Stylesheet
+func NewStylesheet() *Stylesheet {
+	return &Stylesheet{}
+}
+
+// Returns string representation of the Stylesheet
+func (sheet *Stylesheet) String() string {
+	result := ""
+
+	for _, rule := range sheet.Rules {
+		if result != "" {
+			result += "\n"
+		}
+		result += rule.String()
+	}
+
+	return result
+}

--- a/_third_party/github.com/aymerick/douceur/inliner/element.go
+++ b/_third_party/github.com/aymerick/douceur/inliner/element.go
@@ -1,0 +1,180 @@
+package inliner
+
+import (
+	"sort"
+
+	"bosun.org/_third_party/github.com/PuerkitoBio/goquery"
+
+	"bosun.org/_third_party/github.com/aymerick/douceur/css"
+	"bosun.org/_third_party/github.com/aymerick/douceur/parser"
+)
+
+// An HTML element with matching CSS rules
+type Element struct {
+	// The goquery handler
+	elt *goquery.Selection
+
+	// The style rules to apply on that element
+	styleRules []*StyleRule
+}
+
+type ElementAttr struct {
+	attr     string
+	elements []string
+}
+
+// Index is style property name
+var styleToAttr map[string]*ElementAttr
+
+func init() {
+	// Borrowed from premailer:
+	//   https://github.com/premailer/premailer/blob/master/lib/premailer/premailer.rb
+	styleToAttr = map[string]*ElementAttr{
+		"text-align": &ElementAttr{
+			"align",
+			[]string{"h1", "h2", "h3", "h4", "h5", "h6", "p", "div", "blockquote", "tr", "th", "td"},
+		},
+		"background-color": &ElementAttr{
+			"bgcolor",
+			[]string{"body", "table", "tr", "th", "td"},
+		},
+		"background-image": &ElementAttr{
+			"background",
+			[]string{"table"},
+		},
+		"vertical-align": &ElementAttr{
+			"valign",
+			[]string{"th", "td"},
+		},
+		"float": &ElementAttr{
+			"align",
+			[]string{"img"},
+		},
+		// @todo width and height ?
+	}
+}
+
+// Instanciate a new element
+func NewElement(elt *goquery.Selection) *Element {
+	return &Element{
+		elt: elt,
+	}
+}
+
+// Add a Style Rule to Element
+func (element *Element) addStyleRule(styleRule *StyleRule) {
+	element.styleRules = append(element.styleRules, styleRule)
+}
+
+// Inline styles on element
+func (element *Element) inline() error {
+	// compute declarations
+	declarations, err := element.computeDeclarations()
+	if err != nil {
+		return err
+	}
+
+	// set style attribute
+	styleValue := computeStyleValue(declarations)
+	if styleValue != "" {
+		element.elt.SetAttr("style", styleValue)
+	}
+
+	// set additionnal attributes
+	element.setAttributesFromStyle(declarations)
+
+	return nil
+}
+
+// Compute css declarations
+func (element *Element) computeDeclarations() ([]*css.Declaration, error) {
+	result := []*css.Declaration{}
+
+	styles := make(map[string]*StyleDeclaration)
+
+	// First: parsed stylesheets rules
+	mergeStyleDeclarations(element.styleRules, styles)
+
+	// Then: inline rules
+	inlineRules, err := element.parseInlineStyle()
+	if err != nil {
+		return result, err
+	}
+
+	mergeStyleDeclarations(inlineRules, styles)
+
+	// map to array
+	for _, styleDecl := range styles {
+		result = append(result, styleDecl.Declaration)
+	}
+
+	// sort declarations by property name
+	sort.Sort(css.DeclarationsByProperty(result))
+
+	return result, nil
+}
+
+// Parse inline style rules
+func (element *Element) parseInlineStyle() ([]*StyleRule, error) {
+	result := []*StyleRule{}
+
+	styleValue, exists := element.elt.Attr("style")
+	if (styleValue == "") || !exists {
+		return result, nil
+	}
+
+	declarations, err := parser.ParseDeclarations(styleValue)
+	if err != nil {
+		return result, err
+	}
+
+	result = append(result, NewStyleRule(INLINE_FAKE_SELECTOR, declarations))
+
+	return result, nil
+}
+
+// Set additional attributes from style declarations
+func (element *Element) setAttributesFromStyle(declarations []*css.Declaration) {
+	// for each style declarations
+	for _, declaration := range declarations {
+		if eltAttr := styleToAttr[declaration.Property]; eltAttr != nil {
+			// check if element is allowed for that attribute
+			for _, eltAllowed := range eltAttr.elements {
+				if element.elt.Nodes[0].Data == eltAllowed {
+					element.elt.SetAttr(eltAttr.attr, declaration.Value)
+
+					break
+				}
+			}
+		}
+	}
+}
+
+// helper
+func computeStyleValue(declarations []*css.Declaration) string {
+	result := ""
+
+	// set style attribute value
+	for _, declaration := range declarations {
+		if result != "" {
+			result += " "
+		}
+
+		result += declaration.StringWithImportant(false)
+	}
+
+	return result
+}
+
+// helper
+func mergeStyleDeclarations(styleRules []*StyleRule, output map[string]*StyleDeclaration) {
+	for _, styleRule := range styleRules {
+		for _, declaration := range styleRule.Declarations {
+			styleDecl := NewStyleDeclaration(styleRule, declaration)
+
+			if (output[declaration.Property] == nil) || (styleDecl.Specificity() >= output[declaration.Property].Specificity()) {
+				output[declaration.Property] = styleDecl
+			}
+		}
+	}
+}

--- a/_third_party/github.com/aymerick/douceur/inliner/inliner.go
+++ b/_third_party/github.com/aymerick/douceur/inliner/inliner.go
@@ -1,0 +1,243 @@
+package inliner
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"bosun.org/_third_party/github.com/PuerkitoBio/goquery"
+	"bosun.org/_third_party/github.com/aymerick/douceur/css"
+	"bosun.org/_third_party/github.com/aymerick/douceur/parser"
+	"bosun.org/_third_party/golang.org/x/net/html"
+)
+
+const (
+	ELT_MARKER_ATTR = "douceur-mark"
+)
+
+var unsupportedSelectors = []string{
+	":active", ":after", ":before", ":checked", ":disabled", ":enabled",
+	":first-line", ":first-letter", ":focus", ":hover", ":invalid", ":in-range",
+	":lang", ":link", ":root", ":selection", ":target", ":valid", ":visited"}
+
+// CSS Inliner
+type Inliner struct {
+	// Raw HTML
+	html string
+
+	// Parsed HTML document
+	doc *goquery.Document
+
+	// Parsed stylesheets
+	stylesheets []*css.Stylesheet
+
+	// Collected inlinable style rules
+	rules []*StyleRule
+
+	// HTML elements matching collected inlinable style rules
+	elements map[string]*Element
+
+	// CSS rules that are not inlinable but that must be inserted in output document
+	rawRules []fmt.Stringer
+
+	// current element marker value
+	eltMarker int
+}
+
+// Instanciate a new Inliner
+func NewInliner(html string) *Inliner {
+	return &Inliner{
+		html:     html,
+		elements: make(map[string]*Element),
+	}
+}
+
+// Inlines css into html document
+func Inline(html string) (string, error) {
+	result, err := NewInliner(html).Inline()
+	if err != nil {
+		return "", err
+	} else {
+		return result, nil
+	}
+}
+
+// Inlines CSS and returns HTML
+func (inliner *Inliner) Inline() (string, error) {
+	// parse HTML document
+	if err := inliner.parseHTML(); err != nil {
+		return "", err
+	}
+
+	// parse stylesheets
+	if err := inliner.parseStylesheets(); err != nil {
+		return "", err
+	}
+
+	// collect elements and style rules
+	inliner.collectElementsAndRules()
+
+	// inline css
+	if err := inliner.inlineStyleRules(); err != nil {
+		return "", err
+	}
+
+	// insert raw stylesheet
+	inliner.insertRawStylesheet()
+
+	// generate HTML document
+	return inliner.genHTML()
+}
+
+// Parses raw html
+func (inliner *Inliner) parseHTML() error {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(inliner.html))
+	if err != nil {
+		return err
+	}
+
+	inliner.doc = doc
+
+	return nil
+}
+
+// Parses and removes stylesheets from HTML document
+func (inliner *Inliner) parseStylesheets() error {
+	var result error
+
+	inliner.doc.Find("style").EachWithBreak(func(i int, s *goquery.Selection) bool {
+		stylesheet, err := parser.Parse(s.Text())
+		if err != nil {
+			result = err
+			return false
+		}
+
+		inliner.stylesheets = append(inliner.stylesheets, stylesheet)
+
+		// removes parsed stylesheet
+		s.Remove()
+
+		return true
+	})
+
+	return result
+}
+
+// Collects HTML elements matching parsed stylesheets, and thus collect used style rules
+func (inliner *Inliner) collectElementsAndRules() {
+	for _, stylesheet := range inliner.stylesheets {
+		for _, rule := range stylesheet.Rules {
+			if rule.Kind == css.QUALIFIED_RULE {
+				// Let's go!
+				inliner.handleQualifiedRule(rule)
+			} else {
+				// Keep it 'as is'
+				inliner.rawRules = append(inliner.rawRules, rule)
+			}
+		}
+	}
+}
+
+// Handles parsed qualified rule
+func (inliner *Inliner) handleQualifiedRule(rule *css.Rule) {
+	for _, selector := range rule.Selectors {
+		if Inlinable(selector) {
+			inliner.doc.Find(selector).Each(func(i int, s *goquery.Selection) {
+				// get marker
+				eltMarker, exists := s.Attr(ELT_MARKER_ATTR)
+				if !exists {
+					// mark element
+					eltMarker = strconv.Itoa(inliner.eltMarker)
+					s.SetAttr(ELT_MARKER_ATTR, eltMarker)
+					inliner.eltMarker += 1
+
+					// add new element
+					inliner.elements[eltMarker] = NewElement(s)
+				}
+
+				// add style rule for element
+				inliner.elements[eltMarker].addStyleRule(NewStyleRule(selector, rule.Declarations))
+			})
+		} else {
+			// Keep it 'as is'
+			inliner.rawRules = append(inliner.rawRules, NewStyleRule(selector, rule.Declarations))
+		}
+	}
+}
+
+// Inline style rules in HTML document
+func (inliner *Inliner) inlineStyleRules() error {
+	for _, element := range inliner.elements {
+		// remove marker
+		element.elt.RemoveAttr(ELT_MARKER_ATTR)
+
+		// inline element
+		err := element.inline()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Computes raw CSS rules
+func (inliner *Inliner) computeRawCSS() string {
+	result := ""
+
+	for _, rawRule := range inliner.rawRules {
+		result += rawRule.String()
+		result += "\n"
+	}
+
+	return result
+}
+
+// Insert raw CSS rules into HTML document
+func (inliner *Inliner) insertRawStylesheet() {
+	rawCSS := inliner.computeRawCSS()
+	if rawCSS != "" {
+		// create <style> element
+		cssNode := &html.Node{
+			Type: html.TextNode,
+			Data: "\n" + rawCSS,
+		}
+
+		styleNode := &html.Node{
+			Type: html.ElementNode,
+			Data: "style",
+			Attr: []html.Attribute{html.Attribute{Key: "type", Val: "text/css"}},
+		}
+
+		styleNode.AppendChild(cssNode)
+
+		// append to <head> element
+		headNode := inliner.doc.Find("head")
+		if headNode == nil {
+			// @todo Create head node !
+			panic("NOT IMPLEMENTED: create missing <head> node")
+		}
+
+		headNode.AppendNodes(styleNode)
+	}
+}
+
+// Generates HTML
+func (inliner *Inliner) genHTML() (string, error) {
+	return inliner.doc.Html()
+}
+
+// Returns true if given selector is inlinable
+func Inlinable(selector string) bool {
+	if strings.Contains(selector, "::") {
+		return false
+	}
+
+	for _, badSel := range unsupportedSelectors {
+		if strings.Contains(selector, badSel) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/_third_party/github.com/aymerick/douceur/inliner/inliner_test.go
+++ b/_third_party/github.com/aymerick/douceur/inliner/inliner_test.go
@@ -1,0 +1,288 @@
+package inliner
+
+import (
+	"fmt"
+	"testing"
+)
+
+// Simple rule inlining with two declarations
+func TestInliner(t *testing.T) {
+	input := `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<style type="text/css">
+  p {
+    font-family: 'Helvetica Neue', Verdana, sans-serif;
+    color: #eee;
+  }
+</style>
+  </head>
+  <body>
+    <p>
+      Inline me please!
+    </p>
+</body>
+</html>`
+
+	expectedOutput := `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+
+  </head>
+  <body>
+    <p style="color: #eee; font-family: &#39;Helvetica Neue&#39;, Verdana, sans-serif;">
+      Inline me please!
+    </p>
+
+</body></html>`
+
+	output, err := Inline(input)
+	if err != nil {
+		t.Fatal("Failed to inline html:", err)
+	}
+
+	if output != expectedOutput {
+		t.Fatal(fmt.Sprintf("CSS inliner error\nExpected:\n\"%s\"\nGot:\n\"%s\"", expectedOutput, output))
+	}
+}
+
+// Already inlined style has more priority than <style>
+func TestInlineStylePriority(t *testing.T) {
+	input := `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<style type="text/css">
+  p {
+    font-family: 'Helvetica Neue', Verdana, sans-serif;
+    color: #eee;
+  }
+</style>
+  </head>
+  <body>
+    <p style="color: #222;">
+      Inline me please!
+    </p>
+</body>
+</html>`
+
+	expectedOutput := `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+
+  </head>
+  <body>
+    <p style="color: #222; font-family: &#39;Helvetica Neue&#39;, Verdana, sans-serif;">
+      Inline me please!
+    </p>
+
+</body></html>`
+
+	output, err := Inline(input)
+	if err != nil {
+		t.Fatal("Failed to inline html:", err)
+	}
+
+	if output != expectedOutput {
+		t.Fatal(fmt.Sprintf("CSS inliner error\nExpected:\n\"%s\"\nGot:\n\"%s\"", expectedOutput, output))
+	}
+}
+
+// !important has highest priority
+func TestImportantPriority(t *testing.T) {
+	input := `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<style type="text/css">
+  p#test {
+    color: #000;
+  }
+  p {
+    color: #eee !important;
+  }
+</style>
+  </head>
+  <body>
+    <p id="test" style="color: #222;">
+      Inline me please!
+    </p>
+</body>
+</html>`
+
+	expectedOutput := `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+
+  </head>
+  <body>
+    <p id="test" style="color: #eee;">
+      Inline me please!
+    </p>
+
+</body></html>`
+
+	output, err := Inline(input)
+	if err != nil {
+		t.Fatal("Failed to inline html:", err)
+	}
+
+	if output != expectedOutput {
+		t.Fatal(fmt.Sprintf("CSS inliner error\nExpected:\n\"%s\"\nGot:\n\"%s\"", expectedOutput, output))
+	}
+}
+
+// Pseudo-class selectors can't be inlined
+func TestNotInlinable(t *testing.T) {
+	input := `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<style type="text/css">
+    @media only screen and (max-width: 600px) {
+      table[class="body"] .container {
+        width: 95% !important;
+      }
+    }
+
+    a:hover {
+      color: #2795b6 !important;
+    }
+
+    a:active {
+      color: #2795b6 !important;
+    }
+
+    a:visited {
+      color: #2795b6 !important;
+    }
+</style>
+  </head>
+  <body>
+    <p>
+      <a href="http://aymerick.com">Superbe website</a>
+    </p>
+</body>
+</html>`
+
+	expectedOutput := `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+
+  <style type="text/css">
+@media only screen and (max-width: 600px) {
+  table[class="body"] .container {
+    width: 95% !important;
+  }
+}
+a:hover {
+  color: #2795b6 !important;
+}
+a:active {
+  color: #2795b6 !important;
+}
+a:visited {
+  color: #2795b6 !important;
+}
+</style></head>
+  <body>
+    <p>
+      <a href="http://aymerick.com">Superbe website</a>
+    </p>
+
+</body></html>`
+
+	output, err := Inline(input)
+	if err != nil {
+		t.Fatal("Failed to inline html:", err)
+	}
+
+	if output != expectedOutput {
+		t.Fatal(fmt.Sprintf("CSS inliner error\nExpected:\n\"%s\"\nGot:\n\"%s\"", expectedOutput, output))
+	}
+}
+
+// Some styles causes insertion of additional element attributes
+func TestStyleToAttr(t *testing.T) {
+	input := `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<style type="text/css">
+  h1, h2, h3, h4, h5, h6, p, div, blockquote, tr, th, td {
+    text-align: left;
+  }
+  body, table, tr, th, td {
+    background-color: #f2f2f2;
+  }
+  table {
+    background-image: url(my_image.png);
+  }
+  th, td {
+    vertical-align: top;
+  }
+  img {
+    float: left;
+  }
+</style>
+  </head>
+  <body>
+    <h1>test</h1>
+    <h2>test</h2>
+    <h3>test</h3>
+    <h4>test</h4>
+    <h5>test</h5>
+    <h6>test</h6>
+    <p>
+      <img src="my_image.png"/>
+    </p>
+    <div>test</div>
+    <blockquote>test</blockquote>
+    <table>
+      <tbody>
+        <tr>
+          <th>
+          </th>
+          <td>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+</body>
+</html>`
+
+	expectedOutput := `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+
+  </head>
+  <body style="background-color: #f2f2f2;" bgcolor="#f2f2f2">
+    <h1 style="text-align: left;" align="left">test</h1>
+    <h2 style="text-align: left;" align="left">test</h2>
+    <h3 style="text-align: left;" align="left">test</h3>
+    <h4 style="text-align: left;" align="left">test</h4>
+    <h5 style="text-align: left;" align="left">test</h5>
+    <h6 style="text-align: left;" align="left">test</h6>
+    <p style="text-align: left;" align="left">
+      <img src="my_image.png" style="float: left;" align="left"/>
+    </p>
+    <div style="text-align: left;" align="left">test</div>
+    <blockquote style="text-align: left;" align="left">test</blockquote>
+    <table style="background-color: #f2f2f2; background-image: url(my_image.png);" bgcolor="#f2f2f2" background="url(my_image.png)">
+      <tbody>
+        <tr style="background-color: #f2f2f2; text-align: left;" bgcolor="#f2f2f2" align="left">
+          <th style="background-color: #f2f2f2; text-align: left; vertical-align: top;" bgcolor="#f2f2f2" align="left" valign="top">
+          </th>
+          <td style="background-color: #f2f2f2; text-align: left; vertical-align: top;" bgcolor="#f2f2f2" align="left" valign="top">
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+</body></html>`
+
+	output, err := Inline(input)
+	if err != nil {
+		t.Fatal("Failed to inline html:", err)
+	}
+
+	if output != expectedOutput {
+		t.Fatal(fmt.Sprintf("CSS inliner error\nExpected:\n\"%s\"\nGot:\n\"%s\"", expectedOutput, output))
+	}
+}

--- a/_third_party/github.com/aymerick/douceur/inliner/style_declaration.go
+++ b/_third_party/github.com/aymerick/douceur/inliner/style_declaration.go
@@ -1,0 +1,24 @@
+package inliner
+
+import "bosun.org/_third_party/github.com/aymerick/douceur/css"
+
+type StyleDeclaration struct {
+	StyleRule   *StyleRule
+	Declaration *css.Declaration
+}
+
+func NewStyleDeclaration(styleRule *StyleRule, declaration *css.Declaration) *StyleDeclaration {
+	return &StyleDeclaration{
+		StyleRule:   styleRule,
+		Declaration: declaration,
+	}
+}
+
+// Computes style declaration specificity
+func (styleDecl *StyleDeclaration) Specificity() int {
+	if styleDecl.Declaration.Important {
+		return 10000
+	}
+
+	return styleDecl.StyleRule.Specificity
+}

--- a/_third_party/github.com/aymerick/douceur/inliner/style_rule.go
+++ b/_third_party/github.com/aymerick/douceur/inliner/style_rule.go
@@ -1,0 +1,87 @@
+package inliner
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"bosun.org/_third_party/github.com/aymerick/douceur/css"
+)
+
+const (
+	INLINE_FAKE_SELECTOR = "*INLINE*"
+
+	// Regular expressions borrowed from premailer:
+	//   https://github.com/premailer/css_parser/blob/master/lib/css_parser/regexps.rb
+	NON_ID_ATTRIBUTES_AND_PSEUDO_CLASSES_REGEXP = `(?i)(\.[\w]+)|\[(\w+)|(\:(link|visited|active|hover|focus|lang|target|enabled|disabled|checked|indeterminate|root|nth-child|nth-last-child|nth-of-type|nth-last-of-type|first-child|last-child|first-of-type|last-of-type|only-child|only-of-type|empty|contains))`
+	ELEMENTS_AND_PSEUDO_ELEMENTS_REGEXP         = `(?i)((^|[\s\+\>\~]+)[\w]+|\:{1,2}(after|before|first-letter|first-line|selection))`
+)
+
+var (
+	nonIDAttrAndPseudoClassesRegexp *regexp.Regexp
+	elementsAndPseudoElementsRegexp *regexp.Regexp
+)
+
+// A Qualifier Rule for a uniq selector
+type StyleRule struct {
+	// The style rule selector
+	Selector string
+
+	// The style rule properties
+	Declarations []*css.Declaration
+
+	// Selector specificity
+	Specificity int
+}
+
+func init() {
+	nonIDAttrAndPseudoClassesRegexp, _ = regexp.Compile(NON_ID_ATTRIBUTES_AND_PSEUDO_CLASSES_REGEXP)
+	elementsAndPseudoElementsRegexp, _ = regexp.Compile(ELEMENTS_AND_PSEUDO_ELEMENTS_REGEXP)
+}
+
+// Instanciate a new StyleRule
+func NewStyleRule(selector string, declarations []*css.Declaration) *StyleRule {
+	return &StyleRule{
+		Selector:     selector,
+		Declarations: declarations,
+		Specificity:  ComputeSpecificity(selector),
+	}
+}
+
+// Returns the string representation of a style rule
+func (styleRule *StyleRule) String() string {
+	result := ""
+
+	result += styleRule.Selector
+
+	if len(styleRule.Declarations) == 0 {
+		result += ";"
+	} else {
+		result += " {\n"
+
+		for _, decl := range styleRule.Declarations {
+			result += fmt.Sprintf("  %s\n", decl.String())
+		}
+
+		result += "}"
+	}
+
+	return result
+}
+
+// Computes style rule specificity
+//
+// cf. http://www.w3.org/TR/selectors/#specificity
+func ComputeSpecificity(selector string) int {
+	result := 0
+
+	if selector == INLINE_FAKE_SELECTOR {
+		result += 1000
+	}
+
+	result += 100 * strings.Count(selector, "#")
+	result += 10 * len(nonIDAttrAndPseudoClassesRegexp.FindAllStringSubmatch(selector, -1))
+	result += len(elementsAndPseudoElementsRegexp.FindAllStringSubmatch(selector, -1))
+
+	return result
+}

--- a/_third_party/github.com/aymerick/douceur/inliner/style_rule_test.go
+++ b/_third_party/github.com/aymerick/douceur/inliner/style_rule_test.go
@@ -1,0 +1,53 @@
+package inliner
+
+import "testing"
+
+// Reference: http://www.w3.org/TR/selectors/#specificity
+//
+// *               /* a=0 b=0 c=0 -> specificity =   0 */
+// LI              /* a=0 b=0 c=1 -> specificity =   1 */
+// UL LI           /* a=0 b=0 c=2 -> specificity =   2 */
+// UL OL+LI        /* a=0 b=0 c=3 -> specificity =   3 */
+// H1 + *[REL=up]  /* a=0 b=1 c=1 -> specificity =  11 */
+// UL OL LI.red    /* a=0 b=1 c=3 -> specificity =  13 */
+// LI.red.level    /* a=0 b=2 c=1 -> specificity =  21 */
+// #x34y           /* a=1 b=0 c=0 -> specificity = 100 */
+// #s12:not(FOO)   /* a=1 b=0 c=1 -> specificity = 101 */
+func TestComputeSpecificity(t *testing.T) {
+	if val := ComputeSpecificity("*"); val != 0 {
+		t.Fatal("Failed to compute specificity: ", val)
+	}
+
+	if val := ComputeSpecificity("LI"); val != 1 {
+		t.Fatal("Failed to compute specificity: ", val)
+	}
+
+	if val := ComputeSpecificity("UL LI"); val != 2 {
+		t.Fatal("Failed to compute specificity: ", val)
+	}
+
+	if val := ComputeSpecificity("UL OL+LI "); val != 3 {
+		t.Fatal("Failed to compute specificity: ", val)
+	}
+
+	if val := ComputeSpecificity("H1 + *[REL=up]"); val != 11 {
+		t.Fatal("Failed to compute specificity: ", val)
+	}
+
+	if val := ComputeSpecificity("UL OL LI.red"); val != 13 {
+		t.Fatal("Failed to compute specificity: ", val)
+	}
+
+	if val := ComputeSpecificity("LI.red.level"); val != 21 {
+		t.Fatal("Failed to compute specificity: ", val)
+	}
+
+	if val := ComputeSpecificity("#x34y"); val != 100 {
+		t.Fatal("Failed to compute specificity: ", val)
+	}
+
+	// This one fails ! \o/
+	// if val := ComputeSpecificity("#s12:not(FOO)"); val != 101 {
+	// 	t.Fatal("Failed to compute specificity: ", val)
+	// }
+}

--- a/_third_party/github.com/aymerick/douceur/parser/parser.go
+++ b/_third_party/github.com/aymerick/douceur/parser/parser.go
@@ -1,0 +1,408 @@
+package parser
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"bosun.org/_third_party/github.com/gorilla/css/scanner"
+
+	"bosun.org/_third_party/github.com/aymerick/douceur/css"
+)
+
+const (
+	IMPORTANT_SUFFIX_REGEXP = `(?i)\s*!important\s*$`
+)
+
+var (
+	importantRegexp *regexp.Regexp
+)
+
+type Parser struct {
+	scan *scanner.Scanner // Tokenizer
+
+	// Tokens parsed but not consumed yet
+	tokens []*scanner.Token
+
+	// Rule embedding level
+	embedLevel int
+}
+
+func init() {
+	importantRegexp, _ = regexp.Compile(IMPORTANT_SUFFIX_REGEXP)
+}
+
+// Instanciate a new parser
+func NewParser(txt string) *Parser {
+	return &Parser{
+		scan: scanner.New(txt),
+	}
+}
+
+// Parse a whole stylesheet
+func Parse(text string) (*css.Stylesheet, error) {
+	result, err := NewParser(text).ParseStylesheet()
+	if err != nil {
+		return nil, err
+	} else {
+		return result, nil
+	}
+}
+
+// Parse CSS declarations
+func ParseDeclarations(text string) ([]*css.Declaration, error) {
+	result, err := NewParser(text).ParseDeclarations()
+	if err != nil {
+		return nil, err
+	} else {
+		return result, nil
+	}
+}
+
+// Parse a stylesheet
+func (parser *Parser) ParseStylesheet() (*css.Stylesheet, error) {
+	result := css.NewStylesheet()
+
+	// Parse BOM
+	if _, err := parser.parseBOM(); err != nil {
+		return result, err
+	}
+
+	// Parse list of rules
+	rules, err := parser.ParseRules()
+	if err != nil {
+		return result, err
+	}
+
+	result.Rules = rules
+
+	return result, nil
+}
+
+// Parse a list of rules
+func (parser *Parser) ParseRules() ([]*css.Rule, error) {
+	result := []*css.Rule{}
+
+	inBlock := false
+	if parser.tokenChar("{") {
+		// parsing a block of rules
+		inBlock = true
+		parser.embedLevel += 1
+
+		parser.shiftToken()
+	}
+
+	for parser.tokenParsable() {
+		if parser.tokenIgnorable() {
+			parser.shiftToken()
+		} else if parser.tokenChar("}") {
+			if !inBlock {
+				errMsg := fmt.Sprintf("Unexpected } character: %s", parser.nextToken().String())
+				return result, errors.New(errMsg)
+			}
+
+			parser.shiftToken()
+			parser.embedLevel -= 1
+
+			// finished
+			break
+		} else {
+			rule, err := parser.ParseRule()
+			if err != nil {
+				return result, err
+			}
+
+			rule.EmbedLevel = parser.embedLevel
+			result = append(result, rule)
+		}
+	}
+
+	return result, parser.err()
+}
+
+// Parse a rule
+func (parser *Parser) ParseRule() (*css.Rule, error) {
+	if parser.tokenAtKeyword() {
+		return parser.parseAtRule()
+	} else {
+		return parser.parseQualifiedRule()
+	}
+}
+
+// Parse a list of declarations
+func (parser *Parser) ParseDeclarations() ([]*css.Declaration, error) {
+	result := []*css.Declaration{}
+
+	if parser.tokenChar("{") {
+		parser.shiftToken()
+	}
+
+	for parser.tokenParsable() {
+		if parser.tokenIgnorable() {
+			parser.shiftToken()
+		} else if parser.tokenChar("}") {
+			// end of block
+			parser.shiftToken()
+			break
+		} else {
+			declaration, err := parser.ParseDeclaration()
+			if err != nil {
+				return result, err
+			}
+
+			result = append(result, declaration)
+		}
+	}
+
+	return result, parser.err()
+}
+
+// Parse a declaration
+func (parser *Parser) ParseDeclaration() (*css.Declaration, error) {
+	result := css.NewDeclaration()
+	curValue := ""
+
+	for parser.tokenParsable() {
+		if parser.tokenChar(":") {
+			result.Property = strings.TrimSpace(curValue)
+			curValue = ""
+
+			parser.shiftToken()
+		} else if parser.tokenChar(";") || parser.tokenChar("}") {
+			if result.Property == "" {
+				errMsg := fmt.Sprintf("Unexpected ; character: %s", parser.nextToken().String())
+				return result, errors.New(errMsg)
+			}
+
+			if importantRegexp.MatchString(curValue) {
+				result.Important = true
+				curValue = importantRegexp.ReplaceAllString(curValue, "")
+			}
+
+			result.Value = strings.TrimSpace(curValue)
+
+			if parser.tokenChar(";") {
+				parser.shiftToken()
+			}
+
+			// finished
+			break
+		} else {
+			token := parser.shiftToken()
+			curValue += token.Value
+		}
+	}
+
+	// log.Printf("[parsed] Declaration: %s", result.String())
+
+	return result, parser.err()
+}
+
+// Parse an At Rule
+func (parser *Parser) parseAtRule() (*css.Rule, error) {
+	// parse rule name (eg: "@import")
+	token := parser.shiftToken()
+
+	result := css.NewRule(css.AT_RULE)
+	result.Name = token.Value
+
+	for parser.tokenParsable() {
+		if parser.tokenChar(";") {
+			parser.shiftToken()
+
+			// finished
+			break
+		} else if parser.tokenChar("{") {
+			if result.EmbedsRules() {
+				// parse rules block
+				rules, err := parser.ParseRules()
+				if err != nil {
+					return result, err
+				}
+
+				result.Rules = rules
+			} else {
+				// parse declarations block
+				declarations, err := parser.ParseDeclarations()
+				if err != nil {
+					return result, err
+				}
+
+				result.Declarations = declarations
+			}
+
+			// finished
+			break
+		} else {
+			// parse prelude
+			prelude, err := parser.parsePrelude()
+			if err != nil {
+				return result, err
+			}
+
+			result.Prelude = prelude
+		}
+	}
+
+	// log.Printf("[parsed] Rule: %s", result.String())
+
+	return result, parser.err()
+}
+
+// Parse a Qualified Rule
+func (parser *Parser) parseQualifiedRule() (*css.Rule, error) {
+	result := css.NewRule(css.QUALIFIED_RULE)
+
+	for parser.tokenParsable() {
+		if parser.tokenChar("{") {
+			if result.Prelude == "" {
+				errMsg := fmt.Sprintf("Unexpected { character: %s", parser.nextToken().String())
+				return result, errors.New(errMsg)
+			}
+
+			// parse declarations block
+			declarations, err := parser.ParseDeclarations()
+			if err != nil {
+				return result, err
+			}
+
+			result.Declarations = declarations
+
+			// finished
+			break
+		} else {
+			// parse prelude
+			prelude, err := parser.parsePrelude()
+			if err != nil {
+				return result, err
+			}
+
+			result.Prelude = prelude
+		}
+	}
+
+	result.Selectors = strings.Split(result.Prelude, ",")
+	for i, sel := range result.Selectors {
+		result.Selectors[i] = strings.TrimSpace(sel)
+	}
+
+	// log.Printf("[parsed] Rule: %s", result.String())
+
+	return result, parser.err()
+}
+
+// Parse Rule prelude
+func (parser *Parser) parsePrelude() (string, error) {
+	result := ""
+
+	for parser.tokenParsable() && !parser.tokenEndOfPrelude() {
+		token := parser.shiftToken()
+		result += token.Value
+	}
+
+	result = strings.TrimSpace(result)
+
+	// log.Printf("[parsed] prelude: %s", result)
+
+	return result, parser.err()
+}
+
+// Parse BOM
+func (parser *Parser) parseBOM() (bool, error) {
+	if parser.nextToken().Type == scanner.TokenBOM {
+		parser.shiftToken()
+		return true, nil
+	} else {
+		return false, parser.err()
+	}
+}
+
+// Returns next token without removing it from tokens buffer
+func (parser *Parser) nextToken() *scanner.Token {
+	if len(parser.tokens) == 0 {
+		// fetch next token
+		nextToken := parser.scan.Next()
+
+		// log.Printf("[token] %s => %v", nextToken.Type.String(), nextToken.Value)
+
+		// queue it
+		parser.tokens = append(parser.tokens, nextToken)
+	}
+
+	return parser.tokens[0]
+}
+
+// Returns next token and remove it from the tokens buffer
+func (parser *Parser) shiftToken() *scanner.Token {
+	var result *scanner.Token
+
+	result, parser.tokens = parser.tokens[0], parser.tokens[1:]
+	return result
+}
+
+// Returns tokenizer error, or nil if no error
+func (parser *Parser) err() error {
+	if parser.tokenError() {
+		token := parser.nextToken()
+		return errors.New(fmt.Sprintf("Tokenizer error: %s", token.String()))
+	} else {
+		return nil
+	}
+}
+
+// Returns true if next token is Error
+func (parser *Parser) tokenError() bool {
+	return parser.nextToken().Type == scanner.TokenError
+}
+
+// Returns true if next token is EOF
+func (parser *Parser) tokenEOF() bool {
+	return parser.nextToken().Type == scanner.TokenEOF
+}
+
+// Returns true if next token is a whitespace
+func (parser *Parser) tokenWS() bool {
+	return parser.nextToken().Type == scanner.TokenS
+}
+
+// Returns true if next token is a comment
+func (parser *Parser) tokenComment() bool {
+	return parser.nextToken().Type == scanner.TokenComment
+}
+
+// Returns true if next token is a CDO or a CDC
+func (parser *Parser) tokenCDOorCDC() bool {
+	switch parser.nextToken().Type {
+	case scanner.TokenCDO, scanner.TokenCDC:
+		return true
+	default:
+		return false
+	}
+}
+
+// Returns true if next token is ignorable
+func (parser *Parser) tokenIgnorable() bool {
+	return parser.tokenWS() || parser.tokenComment() || parser.tokenCDOorCDC()
+}
+
+// Returns true if next token is parsable
+func (parser *Parser) tokenParsable() bool {
+	return !parser.tokenEOF() && !parser.tokenError()
+}
+
+// Returns true if next token is an At Rule keyword
+func (parser *Parser) tokenAtKeyword() bool {
+	return parser.nextToken().Type == scanner.TokenAtKeyword
+}
+
+// Returns true if next token is given character
+func (parser *Parser) tokenChar(value string) bool {
+	token := parser.nextToken()
+	return (token.Type == scanner.TokenChar) && (token.Value == value)
+}
+
+// Returns true if next token marks the end of a prelude
+func (parser *Parser) tokenEndOfPrelude() bool {
+	return parser.tokenChar(";") || parser.tokenChar("{")
+}

--- a/_third_party/github.com/aymerick/douceur/parser/parser_test.go
+++ b/_third_party/github.com/aymerick/douceur/parser/parser_test.go
@@ -1,0 +1,631 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"bosun.org/_third_party/github.com/aymerick/douceur/css"
+)
+
+func MustParse(t *testing.T, txt string, nbRules int) *css.Stylesheet {
+	stylesheet, err := Parse(txt)
+	if err != nil {
+		t.Fatal("Failed to parse css", err, txt)
+	}
+
+	if len(stylesheet.Rules) != nbRules {
+		t.Fatal("Failed to parse Qualified Rules", txt)
+	}
+
+	return stylesheet
+}
+
+func MustEqualRule(t *testing.T, parsedRule *css.Rule, expectedRule *css.Rule) {
+	if !parsedRule.Equal(expectedRule) {
+		diff := parsedRule.Diff(expectedRule)
+
+		t.Fatal(fmt.Sprintf("Rule parsing error\nExpected:\n\"%s\"\nGot:\n\"%s\"\nDiff:\n%s", expectedRule, parsedRule, strings.Join(diff, "\n")))
+	}
+}
+
+func MustEqualCSS(t *testing.T, ruleString string, expected string) {
+	if ruleString != expected {
+		t.Fatal(fmt.Sprintf("CSS generation error\n   Expected:\n\"%s\"\n   Got:\n\"%s\"", expected, ruleString))
+	}
+}
+
+func TestQualifiedRule(t *testing.T) {
+	input := `/* This is a comment */
+p > a {
+    color: blue;
+    text-decoration: underline; /* This is a comment */
+}`
+
+	expectedRule := &css.Rule{
+		Kind:      css.QUALIFIED_RULE,
+		Prelude:   "p > a",
+		Selectors: []string{"p > a"},
+		Declarations: []*css.Declaration{
+			&css.Declaration{
+				Property: "color",
+				Value:    "blue",
+			},
+			&css.Declaration{
+				Property: "text-decoration",
+				Value:    "underline",
+			},
+		},
+	}
+
+	expectedOutput := `p > a {
+  color: blue;
+  text-decoration: underline;
+}`
+
+	stylesheet := MustParse(t, input, 1)
+	rule := stylesheet.Rules[0]
+
+	MustEqualRule(t, rule, expectedRule)
+
+	MustEqualCSS(t, stylesheet.String(), expectedOutput)
+}
+
+func TestQualifiedRuleImportant(t *testing.T) {
+	input := `/* This is a comment */
+p > a {
+    color: blue;
+    text-decoration: underline !important;
+    font-weight: normal   !IMPORTANT    ;
+}`
+
+	expectedRule := &css.Rule{
+		Kind:      css.QUALIFIED_RULE,
+		Prelude:   "p > a",
+		Selectors: []string{"p > a"},
+		Declarations: []*css.Declaration{
+			&css.Declaration{
+				Property:  "color",
+				Value:     "blue",
+				Important: false,
+			},
+			&css.Declaration{
+				Property:  "text-decoration",
+				Value:     "underline",
+				Important: true,
+			},
+			&css.Declaration{
+				Property:  "font-weight",
+				Value:     "normal",
+				Important: true,
+			},
+		},
+	}
+
+	expectedOutput := `p > a {
+  color: blue;
+  text-decoration: underline !important;
+  font-weight: normal !important;
+}`
+
+	stylesheet := MustParse(t, input, 1)
+	rule := stylesheet.Rules[0]
+
+	MustEqualRule(t, rule, expectedRule)
+
+	MustEqualCSS(t, stylesheet.String(), expectedOutput)
+}
+
+func TestQualifiedRuleSelectors(t *testing.T) {
+	input := `table, tr, td {
+  padding: 0;
+}
+
+body,
+  h1,   h2,
+    h3   {
+  color: #fff;
+}`
+
+	expectedRule1 := &css.Rule{
+		Kind:      css.QUALIFIED_RULE,
+		Prelude:   "table, tr, td",
+		Selectors: []string{"table", "tr", "td"},
+		Declarations: []*css.Declaration{
+			&css.Declaration{
+				Property: "padding",
+				Value:    "0",
+			},
+		},
+	}
+
+	expectedRule2 := &css.Rule{
+		Kind: css.QUALIFIED_RULE,
+		Prelude: `body,
+  h1,   h2,
+    h3`,
+		Selectors: []string{"body", "h1", "h2", "h3"},
+		Declarations: []*css.Declaration{
+			&css.Declaration{
+				Property: "color",
+				Value:    "#fff",
+			},
+		},
+	}
+
+	expectedOutput := `table, tr, td {
+  padding: 0;
+}
+body, h1, h2, h3 {
+  color: #fff;
+}`
+
+	stylesheet := MustParse(t, input, 2)
+
+	MustEqualRule(t, stylesheet.Rules[0], expectedRule1)
+	MustEqualRule(t, stylesheet.Rules[1], expectedRule2)
+
+	MustEqualCSS(t, stylesheet.String(), expectedOutput)
+}
+
+func TestAtRuleCharset(t *testing.T) {
+	input := `@charset "UTF-8";`
+
+	expectedRule := &css.Rule{
+		Kind:    css.AT_RULE,
+		Name:    "@charset",
+		Prelude: "\"UTF-8\"",
+	}
+
+	expectedOutput := `@charset "UTF-8";`
+
+	stylesheet := MustParse(t, input, 1)
+	rule := stylesheet.Rules[0]
+
+	MustEqualRule(t, rule, expectedRule)
+
+	MustEqualCSS(t, stylesheet.String(), expectedOutput)
+}
+
+func TestAtRuleCounterStyle(t *testing.T) {
+	input := `@counter-style footnote {
+  system: symbolic;
+  symbols: '*' ⁑ † ‡;
+  suffix: '';
+}`
+
+	expectedRule := &css.Rule{
+		Kind:    css.AT_RULE,
+		Name:    "@counter-style",
+		Prelude: "footnote",
+		Declarations: []*css.Declaration{
+			&css.Declaration{
+				Property: "system",
+				Value:    "symbolic",
+			},
+			&css.Declaration{
+				Property: "symbols",
+				Value:    "'*' ⁑ † ‡",
+			},
+			&css.Declaration{
+				Property: "suffix",
+				Value:    "''",
+			},
+		},
+	}
+
+	stylesheet := MustParse(t, input, 1)
+	rule := stylesheet.Rules[0]
+
+	MustEqualRule(t, rule, expectedRule)
+
+	MustEqualCSS(t, stylesheet.String(), input)
+}
+
+func TestAtRuleDocument(t *testing.T) {
+	input := `@document url(http://www.w3.org/),
+               url-prefix(http://www.w3.org/Style/),
+               domain(mozilla.org),
+               regexp("https:.*")
+{
+  /* CSS rules here apply to:
+     + The page "http://www.w3.org/".
+     + Any page whose URL begins with "http://www.w3.org/Style/"
+     + Any page whose URL's host is "mozilla.org" or ends with
+       ".mozilla.org"
+     + Any page whose URL starts with "https:" */
+
+  /* make the above-mentioned pages really ugly */
+  body { color: purple; background: yellow; }
+}`
+
+	expectedRule := &css.Rule{
+		Kind: css.AT_RULE,
+		Name: "@document",
+		Prelude: `url(http://www.w3.org/),
+               url-prefix(http://www.w3.org/Style/),
+               domain(mozilla.org),
+               regexp("https:.*")`,
+		Rules: []*css.Rule{
+			&css.Rule{
+				Kind:      css.QUALIFIED_RULE,
+				Prelude:   "body",
+				Selectors: []string{"body"},
+				Declarations: []*css.Declaration{
+					&css.Declaration{
+						Property: "color",
+						Value:    "purple",
+					},
+					&css.Declaration{
+						Property: "background",
+						Value:    "yellow",
+					},
+				},
+			},
+		},
+	}
+
+	expectCSS := `@document url(http://www.w3.org/),
+               url-prefix(http://www.w3.org/Style/),
+               domain(mozilla.org),
+               regexp("https:.*") {
+  body {
+    color: purple;
+    background: yellow;
+  }
+}`
+
+	stylesheet := MustParse(t, input, 1)
+	rule := stylesheet.Rules[0]
+
+	MustEqualRule(t, rule, expectedRule)
+
+	MustEqualCSS(t, stylesheet.String(), expectCSS)
+}
+
+func TestAtRuleFontFace(t *testing.T) {
+	input := `@font-face {
+  font-family: MyHelvetica;
+  src: local("Helvetica Neue Bold"),
+       local("HelveticaNeue-Bold"),
+       url(MgOpenModernaBold.ttf);
+  font-weight: bold;
+}`
+
+	expectedRule := &css.Rule{
+		Kind: css.AT_RULE,
+		Name: "@font-face",
+		Declarations: []*css.Declaration{
+			&css.Declaration{
+				Property: "font-family",
+				Value:    "MyHelvetica",
+			},
+			&css.Declaration{
+				Property: "src",
+				Value: `local("Helvetica Neue Bold"),
+       local("HelveticaNeue-Bold"),
+       url(MgOpenModernaBold.ttf)`,
+			},
+			&css.Declaration{
+				Property: "font-weight",
+				Value:    "bold",
+			},
+		},
+	}
+
+	stylesheet := MustParse(t, input, 1)
+	rule := stylesheet.Rules[0]
+
+	MustEqualRule(t, rule, expectedRule)
+
+	MustEqualCSS(t, stylesheet.String(), input)
+}
+
+func TestAtRuleFontFeatureValues(t *testing.T) {
+	input := `@font-feature-values Font Two { /* How to activate nice-style in Font Two */
+  @styleset {
+    nice-style: 4;
+  }
+}`
+	expectedRule := &css.Rule{
+		Kind:    css.AT_RULE,
+		Name:    "@font-feature-values",
+		Prelude: "Font Two",
+		Rules: []*css.Rule{
+			&css.Rule{
+				Kind: css.AT_RULE,
+				Name: "@styleset",
+				Declarations: []*css.Declaration{
+					&css.Declaration{
+						Property: "nice-style",
+						Value:    "4",
+					},
+				},
+			},
+		},
+	}
+
+	expectedOutput := `@font-feature-values Font Two {
+  @styleset {
+    nice-style: 4;
+  }
+}`
+
+	stylesheet := MustParse(t, input, 1)
+	rule := stylesheet.Rules[0]
+
+	MustEqualRule(t, rule, expectedRule)
+
+	MustEqualCSS(t, stylesheet.String(), expectedOutput)
+}
+
+func TestAtRuleImport(t *testing.T) {
+	input := `@import "my-styles.css";
+@import url('landscape.css') screen and (orientation:landscape);`
+
+	expectedRule1 := &css.Rule{
+		Kind:    css.AT_RULE,
+		Name:    "@import",
+		Prelude: "\"my-styles.css\"",
+	}
+
+	expectedRule2 := &css.Rule{
+		Kind:    css.AT_RULE,
+		Name:    "@import",
+		Prelude: "url('landscape.css') screen and (orientation:landscape)",
+	}
+
+	stylesheet := MustParse(t, input, 2)
+
+	MustEqualRule(t, stylesheet.Rules[0], expectedRule1)
+	MustEqualRule(t, stylesheet.Rules[1], expectedRule2)
+
+	MustEqualCSS(t, stylesheet.String(), input)
+}
+
+func TestAtRuleKeyframes(t *testing.T) {
+	input := `@keyframes identifier {
+  0% { top: 0; left: 0; }
+  100% { top: 100px; left: 100%; }
+}`
+	expectedRule := &css.Rule{
+		Kind:    css.AT_RULE,
+		Name:    "@keyframes",
+		Prelude: "identifier",
+		Rules: []*css.Rule{
+			&css.Rule{
+				Kind:      css.QUALIFIED_RULE,
+				Prelude:   "0%",
+				Selectors: []string{"0%"},
+				Declarations: []*css.Declaration{
+					&css.Declaration{
+						Property: "top",
+						Value:    "0",
+					},
+					&css.Declaration{
+						Property: "left",
+						Value:    "0",
+					},
+				},
+			},
+			&css.Rule{
+				Kind:      css.QUALIFIED_RULE,
+				Prelude:   "100%",
+				Selectors: []string{"100%"},
+				Declarations: []*css.Declaration{
+					&css.Declaration{
+						Property: "top",
+						Value:    "100px",
+					},
+					&css.Declaration{
+						Property: "left",
+						Value:    "100%",
+					},
+				},
+			},
+		},
+	}
+
+	expectedOutput := `@keyframes identifier {
+  0% {
+    top: 0;
+    left: 0;
+  }
+  100% {
+    top: 100px;
+    left: 100%;
+  }
+}`
+
+	stylesheet := MustParse(t, input, 1)
+	rule := stylesheet.Rules[0]
+
+	MustEqualRule(t, rule, expectedRule)
+
+	MustEqualCSS(t, stylesheet.String(), expectedOutput)
+}
+
+func TestAtRuleMedia(t *testing.T) {
+	input := `@media screen, print {
+  body { line-height: 1.2 }
+}`
+	expectedRule := &css.Rule{
+		Kind:    css.AT_RULE,
+		Name:    "@media",
+		Prelude: "screen, print",
+		Rules: []*css.Rule{
+			&css.Rule{
+				Kind:      css.QUALIFIED_RULE,
+				Prelude:   "body",
+				Selectors: []string{"body"},
+				Declarations: []*css.Declaration{
+					&css.Declaration{
+						Property: "line-height",
+						Value:    "1.2",
+					},
+				},
+			},
+		},
+	}
+
+	expectedOutput := `@media screen, print {
+  body {
+    line-height: 1.2;
+  }
+}`
+
+	stylesheet := MustParse(t, input, 1)
+	rule := stylesheet.Rules[0]
+
+	MustEqualRule(t, rule, expectedRule)
+
+	MustEqualCSS(t, stylesheet.String(), expectedOutput)
+}
+
+func TestAtRuleNamespace(t *testing.T) {
+	input := `@namespace svg url(http://www.w3.org/2000/svg);`
+	expectedRule := &css.Rule{
+		Kind:    css.AT_RULE,
+		Name:    "@namespace",
+		Prelude: "svg url(http://www.w3.org/2000/svg)",
+	}
+
+	stylesheet := MustParse(t, input, 1)
+	rule := stylesheet.Rules[0]
+
+	MustEqualRule(t, rule, expectedRule)
+
+	MustEqualCSS(t, stylesheet.String(), input)
+}
+
+func TestAtRulePage(t *testing.T) {
+	input := `@page :left {
+  margin-left: 4cm;
+  margin-right: 3cm;
+}`
+	expectedRule := &css.Rule{
+		Kind:    css.AT_RULE,
+		Name:    "@page",
+		Prelude: ":left",
+		Declarations: []*css.Declaration{
+			&css.Declaration{
+				Property: "margin-left",
+				Value:    "4cm",
+			},
+			&css.Declaration{
+				Property: "margin-right",
+				Value:    "3cm",
+			},
+		},
+	}
+
+	stylesheet := MustParse(t, input, 1)
+	rule := stylesheet.Rules[0]
+
+	MustEqualRule(t, rule, expectedRule)
+
+	MustEqualCSS(t, stylesheet.String(), input)
+}
+
+func TestAtRuleSupports(t *testing.T) {
+	input := `@supports (animation-name: test) {
+    /* specific CSS applied when animations are supported unprefixed */
+    @keyframes { /* @supports being a CSS conditional group at-rule, it can includes other relevent at-rules */
+      0% { top: 0; left: 0; }
+      100% { top: 100px; left: 100%; }
+    }
+}`
+	expectedRule := &css.Rule{
+		Kind:    css.AT_RULE,
+		Name:    "@supports",
+		Prelude: "(animation-name: test)",
+		Rules: []*css.Rule{
+			&css.Rule{
+				Kind: css.AT_RULE,
+				Name: "@keyframes",
+				Rules: []*css.Rule{
+					&css.Rule{
+						Kind:      css.QUALIFIED_RULE,
+						Prelude:   "0%",
+						Selectors: []string{"0%"},
+						Declarations: []*css.Declaration{
+							&css.Declaration{
+								Property: "top",
+								Value:    "0",
+							},
+							&css.Declaration{
+								Property: "left",
+								Value:    "0",
+							},
+						},
+					},
+					&css.Rule{
+						Kind:      css.QUALIFIED_RULE,
+						Prelude:   "100%",
+						Selectors: []string{"100%"},
+						Declarations: []*css.Declaration{
+							&css.Declaration{
+								Property: "top",
+								Value:    "100px",
+							},
+							&css.Declaration{
+								Property: "left",
+								Value:    "100%",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expectedOutput := `@supports (animation-name: test) {
+  @keyframes {
+    0% {
+      top: 0;
+      left: 0;
+    }
+    100% {
+      top: 100px;
+      left: 100%;
+    }
+  }
+}`
+
+	stylesheet := MustParse(t, input, 1)
+	rule := stylesheet.Rules[0]
+
+	MustEqualRule(t, rule, expectedRule)
+
+	MustEqualCSS(t, stylesheet.String(), expectedOutput)
+}
+
+func TestParseDeclarations(t *testing.T) {
+	input := `color: blue; text-decoration:underline;`
+
+	declarations, err := ParseDeclarations(input)
+	if err != nil {
+		t.Fatal("Failed to parse Declarations:", input)
+	}
+
+	expectedOutput := []*css.Declaration{
+		&css.Declaration{
+			Property: "color",
+			Value:    "blue",
+		},
+		&css.Declaration{
+			Property: "text-decoration",
+			Value:    "underline",
+		},
+	}
+
+	if len(declarations) != len(expectedOutput) {
+		t.Fatal("Failed to parse Declarations:", input)
+	}
+
+	for i, decl := range declarations {
+		if !decl.Equal(expectedOutput[i]) {
+			t.Fatal("Failed to parse Declarations: ", decl.String(), expectedOutput[i].String())
+		}
+	}
+}

--- a/_third_party/github.com/gorilla/css/scanner/doc.go
+++ b/_third_party/github.com/gorilla/css/scanner/doc.go
@@ -1,0 +1,33 @@
+// Copyright 2012 The Gorilla Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+Package gorilla/css/scanner generates tokens for a CSS3 input.
+
+It follows the CSS3 specification located at:
+
+	http://www.w3.org/TR/css3-syntax/
+
+To use it, create a new scanner for a given CSS string and call Next() until
+the token returned has type TokenEOF or TokenError:
+
+	s := scanner.New(myCSS)
+	for {
+		token := s.Next()
+		if token.Type == scanner.TokenEOF || token.Type == scanner.TokenError {
+			break
+		}
+		// Do something with the token...
+	}
+
+Following the CSS3 specification, an error can only occur when the scanner
+finds an unclosed quote or unclosed comment. In these cases the text becomes
+"untokenizable". Everything else is tokenizable and it is up to a parser
+to make sense of the token stream (or ignore nonsensical token sequences).
+
+Note: the scanner doesn't perform lexical analysis or, in other words, it
+doesn't care about the token context. It is intended to be used by a
+lexer or parser.
+*/
+package scanner

--- a/_third_party/github.com/gorilla/css/scanner/scanner.go
+++ b/_third_party/github.com/gorilla/css/scanner/scanner.go
@@ -1,0 +1,348 @@
+// Copyright 2012 The Gorilla Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package scanner
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// tokenType identifies the type of lexical tokens.
+type tokenType int
+
+// String returns a string representation of the token type.
+func (t tokenType) String() string {
+	return tokenNames[t]
+}
+
+// Token represents a token and the corresponding string.
+type Token struct {
+	Type   tokenType
+	Value  string
+	Line   int
+	Column int
+}
+
+// String returns a string representation of the token.
+func (t *Token) String() string {
+	if len(t.Value) > 10 {
+		return fmt.Sprintf("%s (line: %d, column: %d): %.10q...",
+			t.Type, t.Line, t.Column, t.Value)
+	}
+	return fmt.Sprintf("%s (line: %d, column: %d): %q",
+		t.Type, t.Line, t.Column, t.Value)
+}
+
+// All tokens -----------------------------------------------------------------
+
+// The complete list of tokens in CSS3.
+const (
+	// Scanner flags.
+	TokenError tokenType = iota
+	TokenEOF
+	// From now on, only tokens from the CSS specification.
+	TokenIdent
+	TokenAtKeyword
+	TokenString
+	TokenHash
+	TokenNumber
+	TokenPercentage
+	TokenDimension
+	TokenURI
+	TokenUnicodeRange
+	TokenCDO
+	TokenCDC
+	TokenS
+	TokenComment
+	TokenFunction
+	TokenIncludes
+	TokenDashMatch
+	TokenPrefixMatch
+	TokenSuffixMatch
+	TokenSubstringMatch
+	TokenChar
+	TokenBOM
+)
+
+// tokenNames maps tokenType's to their names. Used for conversion to string.
+var tokenNames = map[tokenType]string{
+	TokenError:          "error",
+	TokenEOF:            "EOF",
+	TokenIdent:          "IDENT",
+	TokenAtKeyword:      "ATKEYWORD",
+	TokenString:         "STRING",
+	TokenHash:           "HASH",
+	TokenNumber:         "NUMBER",
+	TokenPercentage:     "PERCENTAGE",
+	TokenDimension:      "DIMENSION",
+	TokenURI:            "URI",
+	TokenUnicodeRange:   "UNICODE-RANGE",
+	TokenCDO:            "CDO",
+	TokenCDC:            "CDC",
+	TokenS:              "S",
+	TokenComment:        "COMMENT",
+	TokenFunction:       "FUNCTION",
+	TokenIncludes:       "INCLUDES",
+	TokenDashMatch:      "DASHMATCH",
+	TokenPrefixMatch:    "PREFIXMATCH",
+	TokenSuffixMatch:    "SUFFIXMATCH",
+	TokenSubstringMatch: "SUBSTRINGMATCH",
+	TokenChar:           "CHAR",
+	TokenBOM:            "BOM",
+}
+
+// Macros and productions -----------------------------------------------------
+// http://www.w3.org/TR/css3-syntax/#tokenization
+
+var macroRegexp = regexp.MustCompile(`\{[a-z]+\}`)
+
+// macros maps macro names to patterns to be expanded.
+var macros = map[string]string{
+	// must be escaped: `\.+*?()|[]{}^$`
+	"ident":      `-?{nmstart}{nmchar}*`,
+	"name":       `{nmchar}+`,
+	"nmstart":    `[a-zA-Z_]|{nonascii}|{escape}`,
+	"nonascii":   "[\u0080-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]",
+	"unicode":    `\\[0-9a-fA-F]{1,6}{wc}?`,
+	"escape":     "{unicode}|\\\\[\u0020-\u007E\u0080-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]",
+	"nmchar":     `[a-zA-Z0-9_-]|{nonascii}|{escape}`,
+	"num":        `[0-9]*\.[0-9]+|[0-9]+`,
+	"string":     `"(?:{stringchar}|')*"|'(?:{stringchar}|")*'`,
+	"stringchar": `{urlchar}|[ ]|\\{nl}`,
+	"urlchar":    "[\u0009\u0021\u0023-\u0026\u0027-\u007E]|{nonascii}|{escape}",
+	"nl":         `[\n\r\f]|\r\n`,
+	"w":          `{wc}*`,
+	"wc":         `[\t\n\f\r ]`,
+}
+
+// productions maps the list of tokens to patterns to be expanded.
+var productions = map[tokenType]string{
+	// Unused regexps (matched using other methods) are commented out.
+	TokenIdent:        `{ident}`,
+	TokenAtKeyword:    `@{ident}`,
+	TokenString:       `{string}`,
+	TokenHash:         `#{name}`,
+	TokenNumber:       `{num}`,
+	TokenPercentage:   `{num}%`,
+	TokenDimension:    `{num}{ident}`,
+	TokenURI:          `url\({w}(?:{string}|{urlchar}*){w}\)`,
+	TokenUnicodeRange: `U\+[0-9A-F\?]{1,6}(?:-[0-9A-F]{1,6})?`,
+	//TokenCDO:            `<!--`,
+	TokenCDC:      `-->`,
+	TokenS:        `{wc}+`,
+	TokenComment:  `/\*[^\*]*[\*]+(?:[^/][^\*]*[\*]+)*/`,
+	TokenFunction: `{ident}\(`,
+	//TokenIncludes:       `~=`,
+	//TokenDashMatch:      `\|=`,
+	//TokenPrefixMatch:    `\^=`,
+	//TokenSuffixMatch:    `\$=`,
+	//TokenSubstringMatch: `\*=`,
+	//TokenChar:           `[^"']`,
+	//TokenBOM:            "\uFEFF",
+}
+
+// matchers maps the list of tokens to compiled regular expressions.
+//
+// The map is filled on init() using the macros and productions defined in
+// the CSS specification.
+var matchers = map[tokenType]*regexp.Regexp{}
+
+// matchOrder is the order to test regexps when first-char shortcuts
+// can't be used.
+var matchOrder = []tokenType{
+	TokenURI,
+	TokenFunction,
+	TokenUnicodeRange,
+	TokenIdent,
+	TokenDimension,
+	TokenPercentage,
+	TokenNumber,
+	TokenCDC,
+}
+
+func init() {
+	// replace macros and compile regexps for productions.
+	replaceMacro := func(s string) string {
+		return "(?:" + macros[s[1:len(s)-1]] + ")"
+	}
+	for t, s := range productions {
+		for macroRegexp.MatchString(s) {
+			s = macroRegexp.ReplaceAllStringFunc(s, replaceMacro)
+		}
+		matchers[t] = regexp.MustCompile("^(?:" + s + ")")
+	}
+}
+
+// Scanner --------------------------------------------------------------------
+
+// New returns a new CSS scanner for the given input.
+func New(input string) *Scanner {
+	// Normalize newlines.
+	input = strings.Replace(input, "\r\n", "\n", -1)
+	return &Scanner{
+		input: input,
+		row:   1,
+		col:   1,
+	}
+}
+
+// Scanner scans an input and emits tokens following the CSS3 specification.
+type Scanner struct {
+	input string
+	pos   int
+	row   int
+	col   int
+	err   *Token
+}
+
+// Next returns the next token from the input.
+//
+// At the end of the input the token type is TokenEOF.
+//
+// If the input can't be tokenized the token type is TokenError. This occurs
+// in case of unclosed quotation marks or comments.
+func (s *Scanner) Next() *Token {
+	if s.err != nil {
+		return s.err
+	}
+	if s.pos >= len(s.input) {
+		s.err = &Token{TokenEOF, "", s.row, s.col}
+		return s.err
+	}
+	if s.pos == 0 {
+		// Test BOM only once, at the beginning of the file.
+		if strings.HasPrefix(s.input, "\uFEFF") {
+			return s.emitSimple(TokenBOM, "\uFEFF")
+		}
+	}
+	// There's a lot we can guess based on the first byte so we'll take a
+	// shortcut before testing multiple regexps.
+	input := s.input[s.pos:]
+	switch input[0] {
+	case '\t', '\n', '\f', '\r', ' ':
+		// Whitespace.
+		return s.emitToken(TokenS, matchers[TokenS].FindString(input))
+	case '.':
+		// Dot is too common to not have a quick check.
+		// We'll test if this is a Char; if it is followed by a number it is a
+		// dimension/percentage/number, and this will be matched later.
+		if len(input) > 1 && !unicode.IsDigit(rune(input[1])) {
+			return s.emitSimple(TokenChar, ".")
+		}
+	case '#':
+		// Another common one: Hash or Char.
+		if match := matchers[TokenHash].FindString(input); match != "" {
+			return s.emitToken(TokenHash, match)
+		}
+		return s.emitSimple(TokenChar, "#")
+	case '@':
+		// Another common one: AtKeyword or Char.
+		if match := matchers[TokenAtKeyword].FindString(input); match != "" {
+			return s.emitSimple(TokenAtKeyword, match)
+		}
+		return s.emitSimple(TokenChar, "@")
+	case ':', ',', ';', '%', '&', '+', '=', '>', '(', ')', '[', ']', '{', '}':
+		// More common chars.
+		return s.emitSimple(TokenChar, string(input[0]))
+	case '"', '\'':
+		// String or error.
+		match := matchers[TokenString].FindString(input)
+		if match != "" {
+			return s.emitToken(TokenString, match)
+		} else {
+			s.err = &Token{TokenError, "unclosed quotation mark", s.row, s.col}
+			return s.err
+		}
+	case '/':
+		// Comment, error or Char.
+		if len(input) > 1 && input[1] == '*' {
+			match := matchers[TokenComment].FindString(input)
+			if match != "" {
+				return s.emitToken(TokenComment, match)
+			} else {
+				s.err = &Token{TokenError, "unclosed comment", s.row, s.col}
+				return s.err
+			}
+		}
+		return s.emitSimple(TokenChar, "/")
+	case '~':
+		// Includes or Char.
+		return s.emitPrefixOrChar(TokenIncludes, "~=")
+	case '|':
+		// DashMatch or Char.
+		return s.emitPrefixOrChar(TokenDashMatch, "|=")
+	case '^':
+		// PrefixMatch or Char.
+		return s.emitPrefixOrChar(TokenPrefixMatch, "^=")
+	case '$':
+		// SuffixMatch or Char.
+		return s.emitPrefixOrChar(TokenSuffixMatch, "$=")
+	case '*':
+		// SubstringMatch or Char.
+		return s.emitPrefixOrChar(TokenSubstringMatch, "*=")
+	case '<':
+		// CDO or Char.
+		return s.emitPrefixOrChar(TokenCDO, "<!--")
+	}
+	// Test all regexps, in order.
+	for _, token := range matchOrder {
+		if match := matchers[token].FindString(input); match != "" {
+			return s.emitToken(token, match)
+		}
+	}
+	// We already handled unclosed quotation marks and comments,
+	// so this can only be a Char.
+	r, width := utf8.DecodeRuneInString(input)
+	token := &Token{TokenChar, string(r), s.row, s.col}
+	s.col += width
+	s.pos += width
+	return token
+}
+
+// updatePosition updates input coordinates based on the consumed text.
+func (s *Scanner) updatePosition(text string) {
+	width := utf8.RuneCountInString(text)
+	lines := strings.Count(text, "\n")
+	s.row += lines
+	if lines == 0 {
+		s.col += width
+	} else {
+		s.col = utf8.RuneCountInString(text[strings.LastIndex(text, "\n"):])
+	}
+	s.pos += len(text) // while col is a rune index, pos is a byte index
+}
+
+// emitToken returns a Token for the string v and updates the scanner position.
+func (s *Scanner) emitToken(t tokenType, v string) *Token {
+	token := &Token{t, v, s.row, s.col}
+	s.updatePosition(v)
+	return token
+}
+
+// emitSimple returns a Token for the string v and updates the scanner
+// position in a simplified manner.
+//
+// The string is known to have only ASCII characters and to not have a newline.
+func (s *Scanner) emitSimple(t tokenType, v string) *Token {
+	token := &Token{t, v, s.row, s.col}
+	s.col += len(v)
+	s.pos += len(v)
+	return token
+}
+
+// emitPrefixOrChar returns a Token for type t if the current position
+// matches the given prefix. Otherwise it returns a Char token using the
+// first character from the prefix.
+//
+// The prefix is known to have only ASCII characters and to not have a newline.
+func (s *Scanner) emitPrefixOrChar(t tokenType, prefix string) *Token {
+	if strings.HasPrefix(s.input[s.pos:], prefix) {
+		return s.emitSimple(t, prefix)
+	}
+	return s.emitSimple(TokenChar, string(prefix[0]))
+}

--- a/_third_party/github.com/gorilla/css/scanner/scanner_test.go
+++ b/_third_party/github.com/gorilla/css/scanner/scanner_test.go
@@ -1,0 +1,58 @@
+// Copyright 2012 The Gorilla Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package scanner
+
+import (
+	"testing"
+)
+
+func TestMatchers(t *testing.T) {
+	// Just basic checks, not exhaustive at all.
+	checkMatch := func(s string, ttList ...interface{}) {
+		scanner := New(s)
+
+		i := 0
+		for i < len(ttList) {
+			tt := ttList[i].(tokenType)
+			tVal := ttList[i+1].(string)
+			if tok := scanner.Next(); tok.Type != tt || tok.Value != tVal {
+				t.Errorf("did not match: %s (got %v)", s, tok)
+			}
+
+			i += 2
+		}
+
+		if tok := scanner.Next(); tok.Type != TokenEOF {
+			t.Errorf("missing EOF after token %s, got %+v", s, tok)
+		}
+	}
+
+	checkMatch("abcd", TokenIdent, "abcd")
+	checkMatch(`"abcd"`, TokenString, `"abcd"`)
+	checkMatch("'abcd'", TokenString, "'abcd'")
+	checkMatch("#name", TokenHash, "#name")
+	checkMatch("42''", TokenNumber, "42", TokenString, "''")
+	checkMatch("4.2", TokenNumber, "4.2")
+	checkMatch(".42", TokenNumber, ".42")
+	checkMatch("42%", TokenPercentage, "42%")
+	checkMatch("4.2%", TokenPercentage, "4.2%")
+	checkMatch(".42%", TokenPercentage, ".42%")
+	checkMatch("42px", TokenDimension, "42px")
+	checkMatch("url('http://www.google.com/')", TokenURI, "url('http://www.google.com/')")
+	checkMatch("U+0042", TokenUnicodeRange, "U+0042")
+	checkMatch("<!--", TokenCDO, "<!--")
+	checkMatch("-->", TokenCDC, "-->")
+	checkMatch("   \n   \t   \n", TokenS, "   \n   \t   \n")
+	checkMatch("/* foo */", TokenComment, "/* foo */")
+	checkMatch("bar(", TokenFunction, "bar(")
+	checkMatch("~=", TokenIncludes, "~=")
+	checkMatch("|=", TokenDashMatch, "|=")
+	checkMatch("^=", TokenPrefixMatch, "^=")
+	checkMatch("$=", TokenSuffixMatch, "$=")
+	checkMatch("*=", TokenSubstringMatch, "*=")
+	checkMatch("{", TokenChar, "{")
+	checkMatch("\uFEFF", TokenBOM, "\uFEFF")
+	checkMatch(`╯︵┻━┻"stuff"`, TokenIdent, "╯︵┻━┻", TokenString, `"stuff"`)
+}

--- a/cmd/bosun/sched/check_test.go
+++ b/cmd/bosun/sched/check_test.go
@@ -486,7 +486,7 @@ func TestCheckCritUnknownEmpty(t *testing.T) {
 				t.Fatalf("expected empty body and subject")
 			}
 		} else {
-			if st.Body != "2" || st.Subject != "1" {
+			if st.Body != "<html><head></head><body>2</body></html>" || st.Subject != "1" {
 				t.Fatalf("expected body and subject")
 			}
 		}


### PR DESCRIPTION
For example:

```
template style {
    body = `<style>p { color: red; }</style>`
}

template generic {
    body = `
    {{ template "style" . }}
    <a href="{{.Ack}}">Acknowledge alert</a>
    <p>Alert definition:
    <p>Name: {{.Alert.Name}}
    <p>Crit: {{.Alert.Crit}}

    <p>Tags

    <table>
        {{range $k, $v := .Group}}
            {{if eq $k "host"}}
                <tr><td>{{$k}}</td><td><a href="{{$.HostView $v}}">{{$v}}</a></td></tr>
            {{else}}
                <tr><td>{{$k}}</td><td>{{$v}}</td></tr>
            {{end}}
        {{end}}
    </table>

    <p>Computation

    <table>
        {{range .Computations}}
            <tr><td>{{.Text}}</td><td>{{.Value}}</td></tr>
        {{end}}
    </table>`
    subject = {{.Last.Status}}: {{.Alert.Name}}:  on {{.Group.host}}
}
```

Results in:

![image](https://cloud.githubusercontent.com/assets/1692624/7715714/54d8bfa8-fe58-11e4-8bba-ea43c6b2a93f.png)

This will allow for css styling in a centralized way that will still work with email. 