### PR TITLE
Function to make incident link available to templates

### DIFF
--- a/cmd/bosun/sched/template.go
+++ b/cmd/bosun/sched/template.go
@@ -93,6 +93,12 @@ func (c *Context) Rule() (string, error) {
 	return c.schedule.Conf.MakeLink("/config", &p), nil
 }
 
+func (c *Context) Incident() string {
+	return c.schedule.Conf.MakeLink("/incident", &url.Values{
+		"id": []string{fmt.Sprint(c.State.Last().IncidentId)},
+	})
+}
+
 func (s *Schedule) ExecuteBody(rh *RunHistory, a *conf.Alert, st *State, isEmail bool) ([]byte, []*conf.Attachment, error) {
 	t := a.Template
 	if t == nil || t.Body == nil {


### PR DESCRIPTION
`{{.Incident}}` should give link to incident on correct host. `{{.State.Last.IncidentId}}` should give just id.