### PR TITLE
Allow alerts to run on different schedules.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,6 +51,7 @@ Every variable is optional, though you should enable at least 1 backend.
 #### settings
 
 * checkFrequency: time between alert checks, defaults to `5m`
+* defaultRunEvery: default multiplier of check frequency to run alerts. Defaults to `1`.
 * emailFrom: from address for notification emails, required for email notifications
 * httpListen: HTTP listen address, defaults to `:8070`
 * hostname: when generating links in templates, use this value as the hostname instead of using the system's hostname
@@ -201,6 +202,7 @@ An alert is an evaluated expression which can trigger actions like emailing or l
 * crit: expression of a critical alert (which will send an email)
 * critNotification: comma-separated list of notifications to trigger on critical. This line may appear multiple times and duplicate notifications, which will be merged so only one of each notification is triggered. Lookup tables may be used when `lookup("table", "key")` is an entire `critNotification` value. See example below.
 * ignoreUnknown: if present, will prevent alert from becoming unknown
+* runEvery: multiple of global `checkFrequency` at which to run this alert. If unspecified, the global `defaultRunEvery` will be used.
 * squelch: <a name="squelch"></a> comma-separated list of `tagk=tagv` pairs. `tagv` is a regex. If the current tag group matches all values, the alert is squelched, and will not trigger as crit or warn. For example, `squelch = host=ny-web.*,tier=prod` will match any group that has at least that host and tier. Note that the group may have other tags assigned to it, but since all elements of the squelch list were met, it is considered a match. Multiple squelch lines may appear; a tag group matches if any of the squelch lines match.
 * template: name of template
 * unjoinedOk: if present, will ignore unjoined expression errors


### PR DESCRIPTION
Adds a few config options:

1. Alert level `runEvery` which determines how many intervals between checks on this alert.
2. Global `defaultRunEvery` to determine the default modulo.

With a `defaultRunEvery` of 5 and a `confFrequency = 1m`, each alert will run every 5m unless explicitely set to `runEvery = 1` to run every minute.

Fixes #976