### PR TITLE
metadata: Make time a pointer

### DIFF
--- a/cmd/bosun/sched/sched.go
+++ b/cmd/bosun/sched/sched.go
@@ -136,7 +136,7 @@ func (s *Schedule) GetMetadata(metric string, subset opentsdb.TagSet) []metadata
 			Tags:   k.TagSet(),
 			Name:   k.Name,
 			Value:  mv.Value,
-			Time:   mv.Time,
+			Time:   &mv.Time,
 		})
 	}
 	s.metalock.Unlock()

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -213,7 +213,7 @@ type Metasend struct {
 	Tags   opentsdb.TagSet `json:",omitempty"`
 	Name   string          `json:",omitempty"`
 	Value  interface{}
-	Time   time.Time `json:",omitempty"`
+	Time   *time.Time `json:",omitempty"`
 }
 
 func sendMetadata(ms []Metasend) {


### PR DESCRIPTION
This is needed so that go programs using the Metasend type can send a nil
time.