### PR TITLE
Documentation fetches latest release dynamically

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,3 +1,0 @@
-version:
-  hash: "9adbcee922cb30c89d7158ba033e05862d47c79e"
-  id: 20150515173231

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -44,6 +44,7 @@
 				$(this).addClass("anchor");
 			});
 		});
+    
 	</script>
 
 	<style>
@@ -221,7 +222,7 @@
 						<li class="dropdown">
 							<a href="#" class="dropdown-toggle" data-toggle="dropdown">Project <span class="caret"></span></a>
 							<ul class="dropdown-menu">
-								<li><a href="http://bosun.org/scollector">scollector</a></li>
+								<li><a href="/scollector">scollector</a></li>
 								<li><a href="https://github.com/bosun-monitor/bosun">GitHub</a></li>
 							</ul>
 						</li>

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -2,18 +2,40 @@
 layout: page
 title: Download Bosun
 ---
+<script>
+	$(function(){
+		 $.getJSON("https://api.github.com/repos/bosun-monitor/bosun/releases/latest").done(function (release) {
+            var downloadURLBase = "https://github.com/bosun-monitor/bosun/releases/download/" + release.tag_name + "/";
+			 $('.releaseLink').each(function() {
+				var id = this.id
+				$(this).attr("href",downloadURLBase+id)
+			});
+			$("#releaseLink").attr("href", release.html_url);
+			$("#releaseTag").text(release.tag_name)
+			$("#releaseDate").text(release.created_at);
+			$("#releaseAuthor").text(release.author.login)
+			$("#releaseInfo").show();
+        });
+	})
 
+</script>
+<div class="row" id="releaseInfo" style='display:none;'>
+	<div class="col-md-12"  >
+		<h3>Latest release: <a id='releaseLink'><span id='releaseTag'></span></a></h3>
+		<h4>Published <span id='releaseDate'></span> by <span id='releaseAuthor'></span> </h4>
+	</div>
+</div>
 <div class="row">
 	<div class="col-md-12">
 		<h2 id="binaries">Binaries</h2>
 		<p>Binaries are provided below. All web assets are already bundled. Source instructions provided for developers.</p>
 		<ul>
-			<li><a href="https://github.com/bosun-monitor/bosun/releases/download/{{site.version.id}}/bosun-linux-amd64"><strong>Linux</strong> amd64</a></li>
-			<li><a href="https://github.com/bosun-monitor/bosun/releases/download/{{site.version.id}}/bosun-linux-386"><strong>Linux</strong> 386</a></li>
-			<li><a href="https://github.com/bosun-monitor/bosun/releases/download/{{site.version.id}}/bosun-windows-amd64.exe"><strong>Windows</strong> amd64</a></li>
-			<li><a href="https://github.com/bosun-monitor/bosun/releases/download/{{site.version.id}}/bosun-windows-386.exe"><strong>Windows</strong> 386</a></li>
-			<li><a href="https://github.com/bosun-monitor/bosun/releases/download/{{site.version.id}}/bosun-darwin-amd64"><strong>Mac</strong> amd64</a></li>
-			<li><a href="https://github.com/bosun-monitor/bosun/releases/download/{{site.version.id}}/bosun-darwin-386"><strong>Mac</strong> 386</a></li>
+			<li><a class='releaseLink' href="https://github.com/bosun-monitor/bosun/releases/latest" id="bosun-linux-amd64"><strong>Linux</strong> amd64</a></li>
+			<li><a class='releaseLink' href="https://github.com/bosun-monitor/bosun/releases/latest" id="bosun-linux-386"><strong>Linux</strong> 386</a></li>
+			<li><a class='releaseLink' href="https://github.com/bosun-monitor/bosun/releases/latest" id="bosun-windows-amd64.exe"><strong>Windows</strong> amd64</a></li>
+			<li><a class='releaseLink' href="https://github.com/bosun-monitor/bosun/releases/latest" id="bosun-windows-386.exe"><strong>Windows</strong> 386</a></li>
+			<li><a class='releaseLink' href="https://github.com/bosun-monitor/bosun/releases/latest" id="bosun-darwin-amd64"><strong>Mac</strong> amd64</a></li>
+			<li><a class='releaseLink' href="https://github.com/bosun-monitor/bosun/releases/latest" id="bosun-darwin-386"><strong>Mac</strong> 386</a></li>
 		</ul>
 		<h2>From Source</h2>
 		<code>$ go get bosun.org/cmd/bosun</code>

--- a/docs/scollector/index.html
+++ b/docs/scollector/index.html
@@ -13,6 +13,22 @@
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	<script>
+	$(function(){
+		 $.getJSON("https://api.github.com/repos/bosun-monitor/bosun/releases/latest").done(function (release) {
+            var downloadURLBase = "https://github.com/bosun-monitor/bosun/releases/download/" + release.tag_name + "/";
+			 $('.releaseLink').each(function() {
+				var id = this.id
+				$(this).attr("href",downloadURLBase+id)
+			});
+			$("#releaseLink").attr("href", release.html_url);
+			$("#releaseTag").text(release.tag_name)
+			$("#releaseDate").text(release.created_at.substring(0,10));
+			$("#releaseInfo").show();
+        });
+	})		
+	</script>
   </head>
   <body>
     <div class="wrapper">
@@ -22,24 +38,24 @@
 
         <h2>Download Binaries</h2>
 
-	<p>Version <a href="https://github.com/bosun-monitor/bosun/releases/tag/{{ site.version.id }}">{{ site.version.id }}</a> ({{ site.time | date_to_string }})</p>
+	<p id="releaseInfo" style="display:none;">Version <a id="releaseLink"><span id="releaseTag"></span></a> (<span id="releaseDate"></span>)</p>
 
         <ul>
-          <li><a href="https://github.com/bosun-monitor/bosun/releases/download/{{site.version.id}}/scollector-linux-amd64"><strong>Linux</strong> amd64</a></li>
-          <li><a href="https://github.com/bosun-monitor/bosun/releases/download/{{site.version.id}}/scollector-windows-amd64.exe"><strong>Windows</strong> amd64</a></li>
-          <li><a href="https://github.com/bosun-monitor/bosun/releases/download/{{site.version.id}}/scollector-darwin-amd64"><strong>Mac</strong> amd64</a></li>
+          <li><a class='releaseLink' href="https://github.com/bosun-monitor/bosun/releases/latest" id="scollector-linux-amd64"><strong>Linux</strong> amd64</a></li>
+          <li><a class='releaseLink' href="https://github.com/bosun-monitor/bosun/releases/latest" id="scollector-windows-amd64.exe"><strong>Windows</strong> amd64</a></li>
+          <li><a class='releaseLink' href="https://github.com/bosun-monitor/bosun/releases/latest" id="scollector-darwin-amd64"><strong>Mac</strong> amd64</a></li>
         </ul>
 
         <ul>
-          <li><a href="https://github.com/bosun-monitor/bosun/releases/download/{{site.version.id}}/scollector-linux-386"><strong>Linux</strong> 386</a></li>
-          <li><a href="https://github.com/bosun-monitor/bosun/releases/download/{{site.version.id}}/scollector-windows-386.exe"><strong>Windows</strong> 386</a></li>
-          <li><a href="https://github.com/bosun-monitor/bosun/releases/download/{{site.version.id}}/scollector-darwin-386"><strong>Mac</strong> 386</a></li>
+          <li><a class='releaseLink' href="https://github.com/bosun-monitor/bosun/releases/latest" id="scollector-linux-386"><strong>Linux</strong> 386</a></li>
+          <li><a class='releaseLink' href="https://github.com/bosun-monitor/bosun/releases/latest" id="scollector-windows-386.exe"><strong>Windows</strong> 386</a></li>
+          <li><a class='releaseLink' href="https://github.com/bosun-monitor/bosun/releases/latest" id="scollector-darwin-386"><strong>Mac</strong> 386</a></li>
         </ul>
 
         <ul>
-          <li><a href="https://github.com/bosun-monitor/bosun/releases/download/{{site.version.id}}/scollector-linux-arm5"><strong>ARMv5</strong></a></li>
-          <li><a href="https://github.com/bosun-monitor/bosun/releases/download/{{site.version.id}}/scollector-linux-arm6"><strong>ARMv6</strong></a></li>
-          <li><a href="https://github.com/bosun-monitor/bosun/releases/download/{{site.version.id}}/scollector-linux-arm7"><strong>ARMv7</strong></a></li>
+          <li><a class='releaseLink' href="https://github.com/bosun-monitor/bosun/releases/latest" id="scollector-linux-arm5"><strong>ARMv5</strong></a></li>
+          <li><a class='releaseLink' href="https://github.com/bosun-monitor/bosun/releases/latest" id="scollector-linux-arm6"><strong>ARMv6</strong></a></li>
+          <li><a class='releaseLink' href="https://github.com/bosun-monitor/bosun/releases/latest" id="scollector-linux-arm7"><strong>ARMv7</strong></a></li>
         </ul>
 
         <p class="view"><a href="https://github.com/bosun-monitor/bosun/tree/master/cmd/scollector">View the Project on GitHub</a></p>


### PR DESCRIPTION
The download pages will now get the latest release info from github via ajax request. 

If the ajax fails, the download links will simply take the user to the github latest release page, so they can still access it.