### PR TITLE
cmd/bosun: png/svg graph style changes

### DIFF
--- a/cmd/bosun/web/chart.go
+++ b/cmd/bosun/web/chart.go
@@ -122,7 +122,7 @@ func Graph(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (interf
 	}
 	if _, present := r.Form["png"]; present {
 		c := chart.ScatterChart{
-			Title: fmt.Sprintf("%v - %v", oreq.Start, oreq.End),
+			Title: fmt.Sprintf("%v - %v", oreq.Start, queries),
 		}
 		c.XRange.Time = true
 		if min, err := strconv.ParseFloat(r.FormValue("min"), 64); err == nil {
@@ -208,7 +208,7 @@ func ExprGraph(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (in
 	if err != nil {
 		return nil, err
 	}
-	if err := schedule.ExprSVG(t, w, 800, 600, res.Results, q, now); err != nil {
+	if err := schedule.ExprSVG(t, w, 800, 600, "", res.Results); err != nil {
 		return nil, err
 	}
 	return nil, nil

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,8 +131,8 @@ Templates are the message body for emails that are sent when an alert is trigger
 * Eval(string): executes the given expression and returns the first result with identical tags, or `nil` tags if none exists, otherwise `nil`.
 * EvalAll(string): executes the given expression and returns all results.
 * GetMeta(metric, name, tags): Returns metadata data for the given combination of metric, metadata name, and tag. `metric` and `name` are strings. `tags` may be a tag string (`"tagk=tagv,tag2=val2"`) or a tag set (`.Group`). If If `name` is the empty string, a slice of metadata matching the metric and tag is returned. Otherwise, only the metadata value is returned for the given name, or `nil` for no match.
-* Graph(string): returns an SVG graph of the expression with identical tags
-* GraphAll(string): returns an SVG graph of the expression
+* Graph(expression, y_label): returns an SVG graph of the expression with tags identical to the alert instance. `expression` is a string or an expression and `y_label` is a string. `y_label` is an optional argument.
+* GraphAll(expression, y_label): returns an SVG graph of the expression. `expression` is a string or an expression and `y_label` is a string. `y_label` is an optional argument.
 * LeftJoin(expr, expr[, expr...]): results of the first expression (which may be a string or an expression) are left joined to results from all following expressions.
 * Lookup("table", "key"): Looks up the value for the key based on the tagset of the alert in the specified lookup table
 * LookupAll("table", "key", "tag=val,tag2=val2"): Looks up the value for the key based on the tagset specified in the given lookup table


### PR DESCRIPTION
Before:

![warning__os_cpu__on_skippygohungles_-_kyle_stackoverflow_com_-_stack_exchange_mail](https://cloud.githubusercontent.com/assets/1692624/7861058/dd2312a4-051b-11e5-881d-778734c64dc0.jpg)

After:

![warning__os_cpu__on_skippygohungles_-_kyle_stackoverflow_com_-_stack_exchange_mail](https://cloud.githubusercontent.com/assets/1692624/7861065/efc694f8-051b-11e5-9f99-afe685fc79c3.jpg)

The new argument to Graph is a list of units for the axis. It is vargs so this isn't breaking change (you can omit the second argument). The "title" has been moved to notes at the bottom of the graph, and moved outside of the svg/png. This means they can be copied and pasted when it comes in an email, and there is no issue with text being cut off.