### PR TITLE
Concrete ls index name

### DIFF
--- a/cmd/bosun/expr/logstash.go
+++ b/cmd/bosun/expr/logstash.go
@@ -153,7 +153,7 @@ func (e *LogstashElasticHosts) GenIndices(r *LogstashRequest) (string, error) {
 		}
 	}
 	if len(selectedIndices) == 0 {
-		return "", fmt.Errorf("no elastic indices available during this time range, start/end: [%s|%s]", start, end)
+		return "", fmt.Errorf("no elastic indices available during this time range")
 	}
 	return strings.Join(selectedIndices, ","), nil
 }

--- a/cmd/bosun/expr/logstash.go
+++ b/cmd/bosun/expr/logstash.go
@@ -122,6 +122,12 @@ func (e *LogstashElasticHosts) GenIndices(r *LogstashRequest) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// Short-circut when using concrete ES index name
+	if len(r.IndexRoot) > 0 {
+		if r.IndexRoot[len(r.IndexRoot)-1] == '/' {
+			return r.IndexRoot[:len(r.IndexRoot)-1], nil
+		}
+	}
 	indices, err := lsClient.IndexNames()
 	if err != nil {
 		return "", err
@@ -147,7 +153,7 @@ func (e *LogstashElasticHosts) GenIndices(r *LogstashRequest) (string, error) {
 		}
 	}
 	if len(selectedIndices) == 0 {
-		return "", fmt.Errorf("no elastic indices available during this time range")
+		return "", fmt.Errorf("no elastic indices available during this time range, start/end: [%s|%s]", start, end)
 	}
 	return strings.Join(selectedIndices, ","), nil
 }

--- a/cmd/bosun/expr/logstash.go
+++ b/cmd/bosun/expr/logstash.go
@@ -123,10 +123,8 @@ func (e *LogstashElasticHosts) GenIndices(r *LogstashRequest) (string, error) {
 		return "", err
 	}
 	// Short-circut when using concrete ES index name
-	if len(r.IndexRoot) > 0 {
-		if r.IndexRoot[len(r.IndexRoot)-1] == '/' {
-			return r.IndexRoot[:len(r.IndexRoot)-1], nil
-		}
+	if strings.HasSuffix(r.IndexRoot, "/") {
+		return r.IndexRoot[:len(r.IndexRoot)-1], nil
 	}
 	indices, err := lsClient.IndexNames()
 	if err != nil {
@@ -153,7 +151,7 @@ func (e *LogstashElasticHosts) GenIndices(r *LogstashRequest) (string, error) {
 		}
 	}
 	if len(selectedIndices) == 0 {
-		return "", fmt.Errorf("no elastic indices available during this time range")
+		return "", fmt.Errorf("no elastic indices available during this time range, index[%s]", r.IndexRoot)
 	}
 	return strings.Join(selectedIndices, ","), nil
 }


### PR DESCRIPTION
Tested '/' functionality as concrete ES index name signaling (without Bosun adding date suffix), works great.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bosun-monitor/bosun/1013)
<!-- Reviewable:end -->
