### PR TITLE
cmd/bosun: Change diff to be a reduction function

### DIFF
--- a/cmd/bosun/expr/funcs.go
+++ b/cmd/bosun/expr/funcs.go
@@ -117,12 +117,6 @@ var TSDB = map[string]parse.Func{
 		nil,
 		Count,
 	},
-	"diff": {
-		[]parse.FuncType{parse.TypeString, parse.TypeString, parse.TypeString},
-		parse.TypeNumber,
-		tagQuery,
-		Diff,
-	},
 	"q": {
 		[]parse.FuncType{parse.TypeString, parse.TypeString, parse.TypeString},
 		parse.TypeSeries,
@@ -145,6 +139,12 @@ var builtins = map[string]parse.Func{
 		parse.TypeNumber,
 		tagFirst,
 		Dev,
+	},
+	"diff": {
+		[]parse.FuncType{parse.TypeSeries},
+		parse.TypeNumber,
+		tagFirst,
+		Diff,
 	},
 	"first": {
 		[]parse.FuncType{parse.TypeSeries},
@@ -767,19 +767,6 @@ func change(dps Series, args ...float64) float64 {
 	return avg(dps) * args[0]
 }
 
-func Diff(e *State, T miniprofiler.Timer, query, sduration, eduration string) (r *Results, err error) {
-	r, err = Query(e, T, query, sduration, eduration)
-	if err != nil {
-		return
-	}
-	r, err = reduce(e, T, r, diff)
-	return
-}
-
-func diff(dps Series, args ...float64) float64 {
-	return last(dps) - first(dps)
-}
-
 func reduce(e *State, T miniprofiler.Timer, series *Results, F func(Series, ...float64) float64, args ...float64) (*Results, error) {
 	res := *series
 	res.Results = nil
@@ -803,6 +790,14 @@ func Abs(e *State, T miniprofiler.Timer, series *Results) *Results {
 		s.Value = Number(math.Abs(float64(s.Value.Value().(Number))))
 	}
 	return series
+}
+
+func Diff(e *State, T miniprofiler.Timer, series *Results) (r *Results, err error) {
+	return reduce(e, T, series, diff)
+}
+
+func diff(dps Series, args ...float64) float64 {
+	return last(dps) - first(dps)
 }
 
 func Avg(e *State, T miniprofiler.Timer, series *Results) (*Results, error) {

--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -170,10 +170,6 @@ Note that this is implemented using the bosun's `avg` function. The following is
 
 Count returns the number of groups in the query as an ungrouped scalar.
 
-### diff(query, startDuration, endDuration)
-
-Diff returns the last point of the series minus the first point.
-
 ### q(query, startDuration, endDuration)
 
 Generic query from endDuration to startDuration ago. If endDuration is the empty string (`""`), now is used. Support d( units are listed in [the docs](http://opentsdb.net/docs/build/html/user_guide/query/dates.html). Refer to [the docs](http://opentsdb.net/docs/build/html/user_guide/query/index.html) for query syntax. The query argument is the value part of the `m=...` expressions. `*` and `|` are fully supported. In addition, queries like `sys.cpu.user{host=ny-*}` are supported. These are performed by an additional step which determines valid matches, and replaces `ny-*` with `ny-web01|ny-web02|...|ny-web10` to achieve the same result. This lookup is kept in memory by the system and does not incur any additional OpenTSDB API requests, but does require tcollector instances pointed to the bosun server.
@@ -189,6 +185,10 @@ Average.
 ## dev(series)
 
 Standard deviation.
+
+## diff(series)
+
+Diff returns the last point of the series minus the first point.
 
 ## first(series)
 


### PR DESCRIPTION
This way it can be used with the upcoming window function. It was made a query function when only OpenTSDB existed, therefore diff(q(...)) was not needed, but now that there are different types of query functions it is useful as a generic reduction function.