### PR TITLE
docs: Creating form for auto-inviting to slack

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ order: 1
 	</div>
 	<div class="col-md-4">
 		<h3>Get Help</h3>
-		<p>Join us in our Slack room. It requires an invite but you can use that IRC bridge #bosun-monitor on freenode. You can <strong><a href="https://github.com/bosun-monitor/bosun/issues">open issues on GitHub</a></strong> to report bugs or discuss new features.</p>
+		<p>Join us in our Slack room. <a href="/slackinvite.html">Get an invite.</a> You can <strong><a href="https://github.com/bosun-monitor/bosun/issues">open issues on GitHub</a></strong> to report bugs or discuss new features.</p>
 	</div>
 </div>
 <div class="row" style="padding-top: 75px"><h2 class="text-center feature-header">Features</h2></div>

--- a/docs/slackInvite.html
+++ b/docs/slackInvite.html
@@ -1,0 +1,36 @@
+---
+layout: page
+title: Slack invite
+---
+
+<p>Many bosun devs and users are usually availible on our slack channel. If you have any questions or issues this is the best place to 
+get help. Please fill out this form to automatically receive an invitation to join us:</p>
+
+	<div class="form-group">
+		<label for="email">Email address</label>
+		<input type="email" class="form-control" id="email" placeholder="Enter email">
+	</div>
+  	<button id="submit" class="btn btn-default">Submit</button>
+	<div class="alert alert-success" role="alert" style="display:none">Success! Check your email!</div>
+	<div class="alert alert-danger" role="alert" style="display:none"></div>
+
+<script>
+$(function(){
+	$("#submit").click(function(){
+		$(".alert").hide();
+		$("#submit").prop('disabled', true);
+		var email = $("#email").val();
+		var fname = $("#fname").val();
+		var lname = $("#lname").val();
+		var url = "https://www.runhook.com/eaakslsvhhtcu3bvkcijmcvpju?email=" + email;
+		$.get(url, function(data){
+			$(".alert-success").show();
+			
+		}) .fail(function(jqXHR) {
+			$(".alert-danger").show();
+			$(".alert-danger").text(jqXHR.responseText);
+			$("#submit").prop('disabled', false);
+  		})
+	})
+})
+</script>


### PR DESCRIPTION
This depends on a little script I made on hookscript.com which runs a little go script on a webhook. It keeps our access tokens secret and runs only when needed, using undocumented slack apis to do the magic.