### PR TITLE
bosun: Ability to throttle log notifications

### DIFF
--- a/cmd/bosun/conf/conf.go
+++ b/cmd/bosun/conf/conf.go
@@ -832,7 +832,7 @@ func (c *Conf) loadAlert(s *parse.SectionNode) {
 				c.errorf("unknown duration must be at least 1s")
 			}
 			a.Unknown = d
-		case "maxLogFrequancy":
+		case "maxLogFrequency":
 			od, err := opentsdb.ParseDuration(v)
 			if err != nil {
 				c.error(err)

--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -175,11 +175,12 @@ func (s *Schedule) RunHistory(r *RunHistory) {
 		// Do nothing if state did not change.
 		notify := func(ns *conf.Notifications) {
 			if a.Log {
-				lastLogTime, ok := s.lastLogTimes[ak]
-				if ok && lastLogTime.Add(a.MaxLogFrequency).After(time.Now()) {
+				lastLogTime := state.LastLogTime
+				now := time.Now()
+				if now.Before(lastLogTime.Add(a.MaxLogFrequency)) {
 					return
 				}
-				s.lastLogTimes[ak] = time.Now()
+				state.LastLogTime = now
 			}
 			nots := ns.Get(s.Conf, state.Group)
 			for _, n := range nots {

--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -174,6 +174,13 @@ func (s *Schedule) RunHistory(r *RunHistory) {
 		// If the old alert was not acknowledged, do nothing.
 		// Do nothing if state did not change.
 		notify := func(ns *conf.Notifications) {
+			if a.Log {
+				lastLogTime, ok := s.lastLogTimes[ak]
+				if ok && lastLogTime.Add(a.MaxLogFrequency).After(time.Now()) {
+					return
+				}
+				s.lastLogTimes[ak] = time.Now()
+			}
 			nots := ns.Get(s.Conf, state.Group)
 			for _, n := range nots {
 				s.Notify(state, n)

--- a/cmd/bosun/sched/sched.go
+++ b/cmd/bosun/sched/sched.go
@@ -43,6 +43,7 @@ type Schedule struct {
 	LastCheck     time.Time
 	nc            chan interface{}
 	notifications map[*conf.Notification][]*State
+	lastLogTimes  map[expr.AlertKey]time.Time
 	metalock      sync.Mutex
 	maxIncidentId uint64
 	incidentLock  sync.Mutex
@@ -374,6 +375,7 @@ func (s *Schedule) Init(c *conf.Conf) error {
 	s.Group = make(map[time.Time]expr.AlertKeys)
 	s.Metadata = make(map[metadata.Metakey]*Metavalue)
 	s.Incidents = make(map[uint64]*Incident)
+	s.lastLogTimes = make(map[expr.AlertKey]time.Time)
 	s.status = make(States)
 	s.Search = search.NewSearch()
 	s.checkRunning = make(chan bool, 1)

--- a/cmd/bosun/sched/sched.go
+++ b/cmd/bosun/sched/sched.go
@@ -43,7 +43,6 @@ type Schedule struct {
 	LastCheck     time.Time
 	nc            chan interface{}
 	notifications map[*conf.Notification][]*State
-	lastLogTimes  map[expr.AlertKey]time.Time
 	metalock      sync.Mutex
 	maxIncidentId uint64
 	incidentLock  sync.Mutex
@@ -375,7 +374,6 @@ func (s *Schedule) Init(c *conf.Conf) error {
 	s.Group = make(map[time.Time]expr.AlertKeys)
 	s.Metadata = make(map[metadata.Metakey]*Metavalue)
 	s.Incidents = make(map[uint64]*Incident)
-	s.lastLogTimes = make(map[expr.AlertKey]time.Time)
 	s.status = make(States)
 	s.Search = search.NewSearch()
 	s.checkRunning = make(chan bool, 1)
@@ -507,6 +505,7 @@ type State struct {
 	Open         bool
 	Forgotten    bool
 	Unevaluated  bool
+	LastLogTime  time.Time
 }
 
 func (s *State) AlertKey() expr.AlertKey {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -208,6 +208,8 @@ An alert is an evaluated expression which can trigger actions like emailing or l
 * unknown: time at which to mark an alert unknown if it cannot be evaluated; defaults to global checkFrequency
 * warn: expression of a warning alert (viewable on the web interface)
 * warnNotification: identical to critNotification, but for warnings
+* log: setting `log = true` will make the alert behave as a "log alert". It will never show up on the dashboard, but will execute notifications every check interval where the status is abnormal.
+* maxLogFrequency: will throttle log notifications to the specified duration. `maxLogFrequency = 5m` will ensure that notifications only fire once every 5 minutes for any given alert key. Only valid on log alerts.
 
 Example of notification lookups:
 


### PR DESCRIPTION
Adds `maxLogFrequency` key to alerts that can control how often notification gets run. Only valid on log alerts. 

Fixes #975