### PR TITLE
cmd/scollector: process_linux process start_time and uptime

### DIFF
--- a/cmd/scollector/collectors/processes_linux.go
+++ b/cmd/scollector/collectors/processes_linux.go
@@ -39,6 +39,11 @@ func WatchProcesses() {
 func linuxProcMonitor(w *WatchedProc, md *opentsdb.MultiDataPoint) error {
 	var err error
 	for pid, id := range w.Processes {
+		file_status, e := os.Stat("/proc/" + pid)
+		if e != nil {
+			w.Remove(pid)
+			continue
+		}
 		stats_file, e := ioutil.ReadFile("/proc/" + pid + "/stat")
 		if e != nil {
 			w.Remove(pid)
@@ -91,6 +96,7 @@ func linuxProcMonitor(w *WatchedProc, md *opentsdb.MultiDataPoint) error {
 				}
 			}
 		}
+		start_ts := file_status.ModTime().Unix()
 		Add(md, "linux.proc.cpu", stats[13], opentsdb.TagSet{"type": "user"}.Merge(tags), metadata.Counter, metadata.Pct, descLinuxProcCPUUser)
 		Add(md, "linux.proc.cpu", stats[14], opentsdb.TagSet{"type": "system"}.Merge(tags), metadata.Counter, metadata.Pct, descLinuxProcCPUSystem)
 		Add(md, "linux.proc.mem.fault", stats[9], opentsdb.TagSet{"type": "minflt"}.Merge(tags), metadata.Counter, metadata.Fault, descLinuxProcMemFaultMin)
@@ -104,6 +110,8 @@ func linuxProcMonitor(w *WatchedProc, md *opentsdb.MultiDataPoint) error {
 		Add(md, "linux.proc.io_bytes", io[4], opentsdb.TagSet{"type": "read"}.Merge(tags), metadata.Counter, metadata.Bytes, descLinuxProcIoBytesRead)
 		Add(md, "linux.proc.io_bytes", io[5], opentsdb.TagSet{"type": "write"}.Merge(tags), metadata.Counter, metadata.Bytes, descLinuxProcIoBytesWrite)
 		Add(md, "linux.proc.num_fds", len(fds), tags, metadata.Gauge, metadata.Files, descLinuxProcFd)
+		Add(md, "linux.proc.start_time", start_ts, tags, metadata.Gauge, metadata.Timestamp, descLinuxProcStartTS)
+		Add(md, "linux.proc.uptime", now()-start_ts, tags, metadata.Gauge, metadata.Second, descLinuxProcUptime)
 	}
 	return err
 }
@@ -124,6 +132,8 @@ const (
 	descLinuxProcFd           = "The number of open file descriptors."
 	descLinuxSoftFileLimit    = "The soft limit on the number of open file descriptors."
 	descLinuxHardFileLimit    = "The hard limit on the number of open file descriptors."
+	descLinuxProcUptime       = "The length of time, in seconds, since the process was started."
+	descLinuxProcStartTS      = "The timestamp of process start."
 )
 
 func getLinuxProccesses() ([]*Process, error) {


### PR DESCRIPTION
Calculate process start time and uptime from file stat data of /proc/<pid> directory.

P.S. Chose this because it's way simpler than querying uptime, `getconf CLK_TCK` , parsing stat and jiffies. There were times when `/proc/<pid>` stat data was modifiable but that's fixed now.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bosun-monitor/bosun/1087)
<!-- Reviewable:end -->
