### PR TITLE
Add User-Agent to HTTP notifications

### DIFF
--- a/cmd/bosun/main.go
+++ b/cmd/bosun/main.go
@@ -30,12 +30,25 @@ import (
 	"bosun.org/version"
 )
 
+type bosunHttpTransport struct {
+	UserAgent string
+	http.RoundTripper
+}
+
+func (t *bosunHttpTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Add("User-Agent", t.UserAgent)
+	return t.RoundTripper.RoundTrip(req)
+}
+
 func init() {
 	client := &http.Client{
-		Transport: &httpcontrol.Transport{
-			Proxy:          http.ProxyFromEnvironment,
-			RequestTimeout: time.Minute,
-			MaxTries:       3,
+		Transport: &bosunHttpTransport{
+			"Bosun/" + version.ShortVersion(),
+			&httpcontrol.Transport{
+				Proxy:          http.ProxyFromEnvironment,
+				RequestTimeout: time.Minute,
+				MaxTries:       3,
+			},
 		},
 	}
 	http.DefaultClient = client

--- a/version/version.go
+++ b/version/version.go
@@ -24,10 +24,7 @@ var (
 // Get a string representing the version information for the current binary.
 func GetVersionInfo(app string) string {
 	var sha, build string
-	version := Version
-	if OfficialBuild == "" {
-		version += "-dev"
-	}
+	version := ShortVersion()
 	if buildTime, err := time.Parse("20060102150405", VersionDate); err == nil {
 		build = " built " + buildTime.Format(time.RFC3339)
 	}
@@ -35,4 +32,14 @@ func GetVersionInfo(app string) string {
 		sha = fmt.Sprintf(" (%s)", VersionSHA)
 	}
 	return fmt.Sprintf("%s version %s%s%s", app, version, sha, build)
+}
+
+func ShortVersion() string {
+	version := Version
+
+	if OfficialBuild == "" {
+		version += "-dev"
+	}
+
+	return version
 }


### PR DESCRIPTION
Use a custom `http.Client` for sending HTTP notifications, adding a proper `User-Agent` header with the `Bosun/{{version}}` format. The version only includes the version number and release tag, not the most recent commit hash nor build time.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bosun-monitor/bosun/1097)
<!-- Reviewable:end -->
