### PR TITLE
bosun: Adding instrumentation around schedule lock.

### DIFF
--- a/cmd/bosun/sched/bolt.go
+++ b/cmd/bosun/sched/bolt.go
@@ -24,7 +24,7 @@ var savePending bool
 
 func (s *Schedule) Save() {
 	go func() {
-		s.Lock()
+		s.Lock("Save")
 		defer s.Unlock()
 		if savePending {
 			return
@@ -124,7 +124,7 @@ func (s *Schedule) save() {
 func (s *Schedule) RestoreState() error {
 	log.Println("RestoreState")
 	start := time.Now()
-	s.Lock()
+	s.Lock("RestoreState")
 	defer s.Unlock()
 	s.Search.Lock()
 	defer s.Search.Unlock()

--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -41,14 +41,14 @@ func NewStatus(ak expr.AlertKey) *State {
 }
 
 func (s *Schedule) GetStatus(ak expr.AlertKey) *State {
-	s.Lock()
+	s.Lock("GetStatus")
 	state := s.status[ak]
 	s.Unlock()
 	return state
 }
 
 func (s *Schedule) GetOrCreateStatus(ak expr.AlertKey) *State {
-	s.Lock()
+	s.Lock("GetOrCreateStatus")
 	state := s.status[ak]
 	if state == nil {
 		state = NewStatus(ak)
@@ -92,7 +92,7 @@ func (s *Schedule) NewRunHistory(start time.Time, cache *cache.Cache) *RunHistor
 func (s *Schedule) RunHistory(r *RunHistory) {
 	checkNotify := false
 	silenced := s.Silenced()
-	s.Lock()
+	s.Lock("RunHistory")
 	defer s.Unlock()
 	for ak, event := range r.Events {
 		state := s.status[ak]
@@ -345,7 +345,7 @@ func (r *RunHistory) GetUnknownAndUnevaluatedAlertKeys(alert string) (unknown, u
 		}
 	}
 	if !anyFound {
-		r.schedule.Lock()
+		r.schedule.Lock("GetUnknownUneval")
 		for ak, st := range r.schedule.status {
 			if ak.Name() != alert {
 				continue
@@ -386,7 +386,7 @@ func (s *Schedule) findUnknownAlerts(now time.Time) []expr.AlertKey {
 	if time.Now().Sub(bosunStartupTime) < s.Conf.CheckFrequency {
 		return keys
 	}
-	s.Lock()
+	s.Lock("FindUnknown")
 	for ak, st := range s.status {
 		if st.Forgotten || st.Status() == StError {
 			continue

--- a/cmd/bosun/sched/notify.go
+++ b/cmd/bosun/sched/notify.go
@@ -38,7 +38,7 @@ func (s *Schedule) Notify(st *State, n *conf.Notification) {
 // duration until the soonest notification triggers.
 func (s *Schedule) CheckNotifications() time.Duration {
 	silenced := s.Silenced()
-	s.Lock()
+	s.Lock("CheckNotifications")
 	defer s.Unlock()
 	notifications := s.Notifications
 	s.Notifications = nil

--- a/cmd/bosun/sched/silence.go
+++ b/cmd/bosun/sched/silence.go
@@ -67,7 +67,7 @@ func (s Silence) ID() string {
 func (s *Schedule) Silenced() map[expr.AlertKey]Silence {
 	aks := make(map[expr.AlertKey]Silence)
 	now := time.Now()
-	s.Lock()
+	s.Lock("Silenced")
 	for _, si := range s.Silence {
 		for ak := range s.status {
 			if si.Silenced(now, ak.Name(), ak.Group()) {
@@ -108,7 +108,7 @@ func (s *Schedule) AddSilence(start, end time.Time, alert, tagList string, forge
 		}
 		si.Tags = tags
 	}
-	s.Lock()
+	s.Lock("AddSilence")
 	defer s.Unlock()
 	if confirm {
 		delete(s.Silence, edit)
@@ -126,7 +126,7 @@ func (s *Schedule) AddSilence(start, end time.Time, alert, tagList string, forge
 }
 
 func (s *Schedule) ClearSilence(id string) error {
-	s.Lock()
+	s.Lock("ClearSilence")
 	delete(s.Silence, id)
 	s.Unlock()
 	s.Save()


### PR DESCRIPTION
Here we emit metrics about how long a method spent waiting for a lock, as well as how long it held it.

I suspect the slowness on the dashboard is related to lock contention, and this should help diagnose it.