### PR TITLE
Fixes for InfluxDB queries

### DIFF
--- a/cmd/bosun/expr/influx.go
+++ b/cmd/bosun/expr/influx.go
@@ -20,7 +20,7 @@ const influxTimeFmt = "2006-01-02 15:04:05"
 var Influx = map[string]parse.Func{
 	"influx": {
 		Args:   []parse.FuncType{parse.TypeString, parse.TypeString, parse.TypeString, parse.TypeString, parse.TypeString},
-		Return: parse.TypeSeries,
+		Return: parse.TypeSeriesSet,
 		Tags:   influxTag,
 		F:      InfluxQuery,
 	},

--- a/cmd/bosun/expr/parse/lex.go
+++ b/cmd/bosun/expr/parse/lex.go
@@ -181,6 +181,8 @@ Loop:
 			l.emit(itemRightParen)
 		case r == '"':
 			return lexString
+		case r == '`':
+			return lexStringBacktick
 		case r == '\'':
 			return lexStringSingle
 		case r == ',':
@@ -281,6 +283,18 @@ func lexString(l *lexer) stateFn {
 	for {
 		switch l.next() {
 		case '"':
+			l.emit(itemString)
+			return lexItem
+		case eof:
+			return l.errorf("unterminated string")
+		}
+	}
+}
+
+func lexStringBacktick(l *lexer) stateFn {
+	for {
+		switch l.next() {
+		case '`':
 			l.emit(itemString)
 			return lexItem
 		case eof:

--- a/cmd/bosun/expr/parse/lex_test.go
+++ b/cmd/bosun/expr/parse/lex_test.go
@@ -97,14 +97,14 @@ var lexTests = []lexTest{
 		{itemNumber, 0, "1.2e-4"},
 		tEOF,
 	}},
-	{"expression", `avg(q("sum:sys.cpu.user{host=*-web*}", "1m")) < 0.2 || avg(q("sum:sys.cpu.user{host=*-web*}", "1m")) > 0.4`, []item{
+	{"expression", "avg(q(\"sum:sys.cpu.user{host=*-web*}\", `1m`)) < 0.2 || avg(q(`sum:sys.cpu.user{host=*-web*}`, \"1m\")) > 0.4", []item{
 		{itemFunc, 0, "avg"},
 		tLpar,
 		{itemFunc, 0, "q"},
 		tLpar,
 		{itemString, 0, `"sum:sys.cpu.user{host=*-web*}"`},
 		tComma,
-		{itemString, 0, `"1m"`},
+		{itemString, 0, "`1m`"},
 		tRpar,
 		tRpar,
 		tLt,
@@ -114,7 +114,7 @@ var lexTests = []lexTest{
 		tLpar,
 		{itemFunc, 0, "q"},
 		tLpar,
-		{itemString, 0, `"sum:sys.cpu.user{host=*-web*}"`},
+		{itemString, 0, "`sum:sys.cpu.user{host=*-web*}`"},
 		tComma,
 		{itemString, 0, `"1m"`},
 		tRpar,
@@ -125,6 +125,9 @@ var lexTests = []lexTest{
 	}},
 	// errors
 	{"unclosed quote", "\"", []item{
+		{itemError, 0, "unterminated string"},
+	}},
+	{"unclosed backtick", "`", []item{
 		{itemError, 0, "unterminated string"},
 	}},
 }


### PR DESCRIPTION
- Fix a typo to allow building
- Add support for backtick-quoted strings, because double-quotes are really a necessity for InfluxDB queries