### PR TITLE
cmd/scollector: Add linux.percent_cpu for easier reporting

### DIFF
--- a/cmd/scollector/collectors/procstats_linux.go
+++ b/cmd/scollector/collectors/procstats_linux.go
@@ -114,6 +114,7 @@ func c_procstats_linux() (opentsdb.MultiDataPoint, error) {
 			return nil
 		}
 		if strings.HasPrefix(m[1], "cpu") {
+			total_cpu := 0.0
 			metric_percpu := ""
 			tag_cpu := ""
 			cpu_m := statCPURE.FindStringSubmatch(m[1])
@@ -123,6 +124,13 @@ func c_procstats_linux() (opentsdb.MultiDataPoint, error) {
 				tag_cpu = cpu_m[1]
 			}
 			fields := strings.Fields(m[2])
+			for _, value := range fields {
+				vf, err := strconv.ParseFloat(value, 64)
+				if err != nil {
+					return nil
+				}
+				total_cpu += vf
+			}
 			for i, value := range fields {
 				if i >= len(CPU_FIELDS) {
 					break
@@ -134,6 +142,12 @@ func c_procstats_linux() (opentsdb.MultiDataPoint, error) {
 					tags["cpu"] = tag_cpu
 				}
 				Add(&md, "linux.cpu"+metric_percpu, value, tags, metadata.Counter, metadata.CHz, cpu_stat_desc[CPU_FIELDS[i]])
+
+				vf, err := strconv.ParseFloat(value, 64)
+				if err != nil {
+					return nil
+				}
+				Add(&md, "linux.percent_cpu"+metric_percpu, vf/total_cpu*100.0, tags, metadata.Counter, metadata.Pct, cpu_stat_desc[CPU_FIELDS[i]])
 			}
 			if metric_percpu == "" {
 				if len(fields) < 3 {


### PR DESCRIPTION
We've found iowait and steal percentages to be useful alert metrics