### PR TITLE
cmd/scollector: fix missing call to AddProcessDotNetConfig

### DIFF
--- a/cmd/scollector/collectors/collectors.go
+++ b/cmd/scollector/collectors/collectors.go
@@ -10,6 +10,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"bosun.org/cmd/scollector/conf"
 	"bosun.org/metadata"
 	"bosun.org/opentsdb"
 	"bosun.org/util"
@@ -87,7 +88,7 @@ var (
 	tlock     sync.Mutex
 	AddTags   opentsdb.TagSet
 
-	AddProcessDotNetConfig = func(line string) error {
+	AddProcessDotNetConfig = func(params conf.ProcessDotNet) error {
 		return fmt.Errorf("process_dotnet watching not implemented on this platform")
 	}
 	WatchProcessesDotNet = func() {}

--- a/cmd/scollector/collectors/dotnet_windows.go
+++ b/cmd/scollector/collectors/dotnet_windows.go
@@ -1,10 +1,12 @@
 package collectors
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
 	"bosun.org/_third_party/github.com/StackExchange/wmi"
+	"bosun.org/cmd/scollector/conf"
 	"bosun.org/metadata"
 	"bosun.org/opentsdb"
 )
@@ -12,8 +14,11 @@ import (
 var regexesDotNet = []*regexp.Regexp{}
 
 func init() {
-	AddProcessDotNetConfig = func(line string) error {
-		reg, err := regexp.Compile(line)
+	AddProcessDotNetConfig = func(params conf.ProcessDotNet) error {
+		if params.Name == "" {
+			return fmt.Errorf("empty dotnet process name")
+		}
+		reg, err := regexp.Compile(params.Name)
 		if err != nil {
 			return err
 		}

--- a/cmd/scollector/main.go
+++ b/cmd/scollector/main.go
@@ -109,6 +109,9 @@ func main() {
 	for _, p := range conf.Process {
 		check(collectors.AddProcessConfig(p))
 	}
+	for _, p := range conf.ProcessDotNet {
+		check(collectors.AddProcessDotNetConfig(p))
+	}
 	for _, h := range conf.HTTPUnit {
 		if h.TOML != "" {
 			check(collectors.HTTPUnitTOML(h.TOML))


### PR DESCRIPTION
the call to AddProcessDotNetConfig in main.go was removed in the e5235d3a4d818057ada4fd41e414a20416aca0f9 commit (conf->toml) which caused many of our dotnet.* metrics to stop reporting about 20 days ago. 

This PR wires up the AddProcessDotNetConfig method similar to how the AddProcessConfig methos is currently used.