### PR TITLE
Return a NaN value instead of an error when the result is of zero len…

### DIFF
--- a/cmd/bosun/sched/template.go
+++ b/cmd/bosun/sched/template.go
@@ -279,7 +279,7 @@ func (c *Context) Eval(v interface{}) (interface{}, error) {
 		return nil, err
 	}
 	if len(res) == 0 {
-		return nil, fmt.Errorf("no results returned")
+		return math.NaN(), nil
 	}
 	// TODO: don't choose a random result, make sure there's exactly 1
 	return res[0].Value, nil


### PR DESCRIPTION
…gth.

There is no way to check for an error, so the only way to prevent the template for aborting is to not error. I think that is okay with Eval since we just the raw value or pipe it to printf float formating.