### PR TITLE
bosun: making save rely on fewer goroutines needing to acquire the lock.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: false
 go:
-  - tip
+  - 1.4.2
 
 notifications:
   email: false

--- a/cmd/bosun/sched/bolt.go
+++ b/cmd/bosun/sched/bolt.go
@@ -30,6 +30,13 @@ func (s *Schedule) Save() {
 func (s *Schedule) performSave() {
 	for range s.saveNeeded {
 		time.Sleep(5 * time.Second) // wait 5 seconds to throttle.
+
+		// if channel has an item on it, pull it off now to avoid re-saving later.
+		select {
+		case <-s.saveNeeded:
+		default:
+		}
+
 		s.Lock("Save")
 		defer s.Unlock()
 		s.save()

--- a/cmd/bosun/sched/bolt.go
+++ b/cmd/bosun/sched/bolt.go
@@ -20,18 +20,20 @@ import (
 	"bosun.org/opentsdb"
 )
 
-var savePending bool
-
 func (s *Schedule) Save() {
-	go func() {
+	select {
+	case s.saveNeeded <- struct{}{}:
+	default:
+	}
+}
+
+func (s *Schedule) performSave() {
+	for range s.saveNeeded {
+		time.Sleep(5 * time.Second) // wait 5 seconds to throttle.
 		s.Lock("Save")
 		defer s.Unlock()
-		if savePending {
-			return
-		}
-		savePending = true
-		time.AfterFunc(time.Second*5, s.save)
-	}()
+		s.save()
+	}
 }
 
 type counterWriter struct {
@@ -60,9 +62,6 @@ const (
 )
 
 func (s *Schedule) save() {
-	defer func() {
-		savePending = false
-	}()
 	if s.db == nil {
 		return
 	}


### PR DESCRIPTION
Uses a single, buffered channel to signal a save is needed. A single worker goroutine monitors this channel and saves as needed. 

In the case of multiple saves in fast succession, this should reduce lock contention on the schedule lock.