### PR TITLE
making save run on a fixed clock

### DIFF
--- a/cmd/bosun/sched/bolt.go
+++ b/cmd/bosun/sched/bolt.go
@@ -20,17 +20,10 @@ import (
 	"bosun.org/opentsdb"
 )
 
-func (s *Schedule) Save() {
-	select {
-	case s.saveNeeded <- struct{}{}:
-	default:
-	}
-}
-
 func (s *Schedule) performSave() {
-	for range s.saveNeeded {
+	for {
+		time.Sleep(60 * time.Second) // wait 60 seconds to throttle.
 		s.save()
-		time.Sleep(10 * time.Second) // wait 10 seconds to throttle.
 	}
 }
 

--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -248,7 +248,6 @@ func (s *Schedule) RunHistory(r *RunHistory) {
 		s.nc <- true
 	}
 	s.CollectStates()
-	s.Save()
 }
 
 // CollectStates sends various state information to bosun with collect.

--- a/cmd/bosun/sched/notify.go
+++ b/cmd/bosun/sched/notify.go
@@ -18,7 +18,6 @@ import (
 func (s *Schedule) Poll() {
 	for {
 		timeout := s.CheckNotifications()
-		s.Save()
 		// Wait for one of these two.
 		select {
 		case <-time.After(timeout):

--- a/cmd/bosun/sched/silence.go
+++ b/cmd/bosun/sched/silence.go
@@ -131,7 +131,6 @@ func (s *Schedule) AddSilence(start, end time.Time, alert, tagList string, forge
 	if confirm {
 		delete(s.Silence, edit)
 		s.Silence[si.ID()] = si
-		s.Save()
 		return nil, nil
 	}
 	aks := make(map[expr.AlertKey]bool)
@@ -147,6 +146,5 @@ func (s *Schedule) ClearSilence(id string) error {
 	s.Lock("ClearSilence")
 	delete(s.Silence, id)
 	s.Unlock()
-	s.Save()
 	return nil
 }


### PR DESCRIPTION
Save is now taking too long every 10 seconds in our install, because of the time needed to gob encode everything. 

This reduces the save frequency to once a minute, and removes all of the tricky triggers and just does it in a loop.