### PR TITLE
bosun: Requiring no schedule lock to render dashboard.

### DIFF
--- a/cmd/bosun/sched/bolt.go
+++ b/cmd/bosun/sched/bolt.go
@@ -229,6 +229,7 @@ func (s *Schedule) RestoreState() error {
 		s.createHistoricIncidents()
 	}
 	s.Search.Copy()
+	s.readStatus = s.status.Copy()
 	log.Println("RestoreState done in", time.Since(start))
 	return nil
 }

--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -216,6 +216,7 @@ func (s *Schedule) RunHistory(r *RunHistory) {
 		s.nc <- true
 	}
 	s.CollectStates()
+	s.readStatus = s.status.Copy()
 }
 
 func (s *Schedule) executeTemplates(state *State, event *Event, a *conf.Alert, r *RunHistory) {


### PR DESCRIPTION
Two main fixes:

1. Reading silences does not require schedule lock, but a more localized silence lock, which is a RWMutex that should take very few Writes.
2. Schedule now has a `readStatus` that is a copy of the authoritative `status`. This should be copied in full at the end of each `RunHistory`.