### PR TITLE
cmd/bosun: Fix template functions to use the same time as the alert

### DIFF
--- a/cmd/bosun/sched/template.go
+++ b/cmd/bosun/sched/template.go
@@ -100,7 +100,7 @@ func (c *Context) GraphLink(v string) string {
 func (c *Context) Rule() (string, error) {
 	p := url.Values{}
 	//There might be something better when we tie the notifications to evaluation time issue #395
-	time := time.Now().UTC()
+	time := c.runHistory.Start
 	p.Add("alert", c.Alert.Name)
 	p.Add("fromDate", time.Format("2006-01-02"))
 	p.Add("fromTime", time.Format("15:04"))
@@ -473,7 +473,7 @@ func (c *Context) LSQuery(index_root, filter, sduration, eduration string, size 
 }
 
 func (c *Context) LSQueryAll(index_root, keystring, filter, sduration, eduration string, size int) (interface{}, error) {
-	req, err := expr.LSBaseQuery(time.Now(), index_root, c.runHistory.Logstash, keystring, filter, sduration, eduration, size)
+	req, err := expr.LSBaseQuery(c.runHistory.Start, index_root, c.runHistory.Logstash, keystring, filter, sduration, eduration, size)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
A couple functions were using the current wall clock time and not the schedule's start time.