### PR TITLE
cmd/bosun: Export time.ParseDuration as ParseDuration to templates

### DIFF
--- a/cmd/bosun/conf/conf.go
+++ b/cmd/bosun/conf/conf.go
@@ -675,6 +675,7 @@ var defaultFuncs = ttemplate.FuncMap{
 	"short": func(v string) string {
 		return strings.SplitN(v, ".", 2)[0]
 	},
+	"parseDuration": time.ParseDuration,
 }
 
 func (c *Conf) loadTemplate(s *parse.SectionNode) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,6 +148,7 @@ Global template functions:
 * pct: formats the float argument as a percentage. For example: `{{5.1 | pct}}` -> `5.10%`.
 * replace: [strings.Replace](http://golang.org/pkg/strings/#Replace)
 * short: Trims the string to everything before the first period. Useful for turning a FQDN into a shortname. For example: `{{short "foo.baz.com"}}` -> `foo`.
+* parseDuration: [time.ParseDuration](http://golang.org/pkg/time/#ParseDuration). Useful when working with an alert's .Last.Time.Add method to generate urls to other systems.
 
 All body templates are associated, and so may be executed from another. Use the name of the other template section for inclusion. Subject templates are similarly associated.
 


### PR DESCRIPTION
Fixes #1014