### PR TITLE
cmd/bosun: Refactor filter expr func to also filter out zero valued results

### DIFF
--- a/cmd/bosun/expr/funcs.go
+++ b/cmd/bosun/expr/funcs.go
@@ -360,7 +360,9 @@ func Filter(e *State, T miniprofiler.Timer, series *Results, number *Results) (*
 	for _, sr := range series.Results {
 		for _, nr := range number.Results {
 			if sr.Group.Subset(nr.Group) || nr.Group.Subset(sr.Group) {
-				ns = append(ns, sr)
+				if nr.Value.Value().(Number) != 0 {
+					ns = append(ns, sr)
+				}
 			}
 		}
 	}

--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -370,9 +370,7 @@ Returns the Unix epoch in seconds of the expression start time (scalar).
 
 ## filter(seriesSet, numberSet) seriesSet
 
-Returns all results in series that are a subset of anything in number, or
-that have number as a subset. Useful with the limit and sort functions to
-return the top X results of a query.
+Returns all results in seriesSet that are a subset of numberSet and have a non-zero value. Useful with the limit and sort functions to return the top X results of a query.
 
 ## limit(numberSet, count scalar) numberSet
 


### PR DESCRIPTION
…esults (false)

This is a breaking change. Fixes #1100