### PR TITLE
Change Elasticsearch backend configuration key

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,7 +45,7 @@ Every variable is optional, though you should enable at least 1 backend.
   * The graph page's tag list.
 * graphiteHost: an ip, hostname, ip:port, hostname:port or a URL, defaults to standard http/https ports, defaults to "/render" path.  Any non-zero path (even "/" overrides path)
 * graphiteHeader: a http header to be sent to graphite on each request in 'key:value' format. optional. can be specified multiple times.
-* logstashElasticHost: Elasticsearch host populated by logstash. Same format as tsdbHost.
+* logstashElasticHosts: Elasticsearch host populated by logstash. Same format as tsdbHost.
 
 #### settings
 


### PR DESCRIPTION
logstashElasticHost is not used in code base, only 'logstashElasticHosts'