### PR TITLE
Update logstashElasticHosts format

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,7 +45,7 @@ Every variable is optional, though you should enable at least 1 backend.
   * The graph page's tag list.
 * graphiteHost: an ip, hostname, ip:port, hostname:port or a URL, defaults to standard http/https ports, defaults to "/render" path.  Any non-zero path (even "/" overrides path)
 * graphiteHeader: a http header to be sent to graphite on each request in 'key:value' format. optional. can be specified multiple times.
-* logstashElasticHosts: Elasticsearch host populated by logstash. Same format as tsdbHost.
+* logstashElasticHosts: Elasticsearch host populated by logstash. Must be a URL.
 
 #### settings
 


### PR DESCRIPTION
The original says it uses the same format as `tsdbHost`, but it doesn't work if you just use `host:port`. Looking at the code, bosun passes the value(s) here directly to the elastic library which is expecting a URL. Once I used `http://host:port` I was able to query. The error message given before came directly from the elastic library with a generic error message about there being no hosts available so there was no indication that the configuration format was incorrect.