### PR TITLE
Compile error fixes + negative filter patterns + total_time metric for httpunit collector

### DIFF
--- a/cmd/scollector/collectors/httpunit.go
+++ b/cmd/scollector/collectors/httpunit.go
@@ -10,33 +10,34 @@ import (
 	"bosun.org/opentsdb"
 )
 
-func HTTPUnitTOML(filename string) error {
+func HTTPUnitTOML(filename string, freq time.Duration) error {
 	var plans httpunit.Plans
 	if _, err := toml.DecodeFile(filename, &plans); err != nil {
 		return err
 	}
-	HTTPUnitPlans(filename, &plans)
+	HTTPUnitPlans(filename, &plans, freq)
 	return nil
 }
 
-func HTTPUnitHiera(filename string) error {
+func HTTPUnitHiera(filename string, freq time.Duration) error {
 	plans, err := httpunit.ExtractHiera(filename)
 	if err != nil {
 		return err
 	}
-	HTTPUnitPlans(filename, &httpunit.Plans{
-		Plans: plans,
-	})
+	HTTPUnitPlans(filename, &httpunit.Plans{Plans: plans}, freq)
 	return nil
 }
 
-func HTTPUnitPlans(name string, plans *httpunit.Plans) {
+func HTTPUnitPlans(name string, plans *httpunit.Plans, freq time.Duration) {
+	if freq < time.Second {
+		freq = time.Minute * 5
+	}
 	collectors = append(collectors, &IntervalCollector{
 		F: func() (opentsdb.MultiDataPoint, error) {
 			return cHTTPUnit(plans)
 		},
 		name:     fmt.Sprintf("c_httpunit_%s", name),
-		Interval: time.Minute * 5,
+		Interval: freq,
 	})
 }
 
@@ -53,8 +54,10 @@ func cHTTPUnit(plans *httpunit.Plans) (opentsdb.MultiDataPoint, error) {
 			"url_host":     r.Case.URL.Host,
 			"hc_test_case": r.Plan.Label,
 		}
+		ms := r.Result.TimeTotal / time.Millisecond
 		Add(&md, "hu.error", r.Result.Result != nil, tags, metadata.Gauge, metadata.Bool, descHTTPUnitError)
 		Add(&md, "hu.socket_connected", r.Result.Connected, tags, metadata.Gauge, metadata.Bool, descHTTPUnitSocketConnected)
+		Add(&md, "hu.time_total", ms, tags, metadata.Gauge, metadata.MilliSecond, descHTTPUnitTotalTime)
 		switch r.Case.URL.Scheme {
 		case "http", "https":
 			Add(&md, "hu.http.got_expected_code", r.Result.GotCode, tags, metadata.Gauge, metadata.Bool, descHTTPUnitExpectedCode)
@@ -79,4 +82,5 @@ const (
 	descHTTPUnitExpectedRegex   = "1 if the response matched expected regex, else 0."
 	descHTTPUnitCertValid       = "1 if the SSL certificate is valid, else 0."
 	descHTTPUnitCertExpires     = "Unix epoch time of the certificate expiration."
+	descHTTPUnitTotalTime       = "Total time consumed by test case."
 )

--- a/cmd/scollector/conf/conf.go
+++ b/cmd/scollector/conf/conf.go
@@ -150,6 +150,7 @@ type ProcessDotNet struct {
 type HTTPUnit struct {
 	TOML  string
 	Hiera string
+	Freq  int
 }
 
 type Riak struct {

--- a/cmd/scollector/doc.go
+++ b/cmd/scollector/doc.go
@@ -211,13 +211,14 @@ ProcessDotNet.
 HTTPUnit (array of table, keys are TOML, Hiera): httpunit TOML and Hiera
 files to read and monitor. See https://github.com/StackExchange/httpunit
 for documentation about the toml file. TOML and Hiera may both be specified,
-or just one.
+or just one. Freq is collector frequency in seconds.
 
 	[[HTTPUnit]]
 	  TOML = "/path/to/httpunit.toml"
 	  Hiera = "/path/to/listeners.json"
 	[[HTTPUnit]]
 	  TOML = "/some/other.toml"
+	  Freq = 15
 
 Riak (array of table, keys are URL): Riak hosts to poll.
 

--- a/cmd/scollector/main.go
+++ b/cmd/scollector/main.go
@@ -124,11 +124,12 @@ func main() {
 		check(collectors.AddProcessDotNetConfig(p))
 	}
 	for _, h := range conf.HTTPUnit {
+		freq := time.Second * time.Duration(h.Freq)
 		if h.TOML != "" {
-			check(collectors.HTTPUnitTOML(h.TOML))
+			check(collectors.HTTPUnitTOML(h.TOML, freq))
 		}
 		if h.Hiera != "" {
-			check(collectors.HTTPUnitHiera(h.Hiera))
+			check(collectors.HTTPUnitHiera(h.Hiera, freq))
 		}
 	}
 	for _, r := range conf.ElasticIndexFilters {


### PR DESCRIPTION
Can now disable collectors using filter patterns prefixed by "-", eg. scollector-windows-amd64.exe -p -d -l -f="network_windows,-tcp" on my dev. machine prints:
bosun.org/cmd/scollector/collectors.c_network_windows

(excluding c_network_windows_tcp)


I needed this specifically for disabling c_network_windows_tcp while keeping c_network_windows enabled, trying to find performance issues caused by one of the two collectors, or both. High CPU usage by WmiPrvSE.exe and blocked collectors seems to be the symptoms (have not solved the issue or confirmed the offending collector yet)
Edit: It was not one of the network collectors. Could be some WMI related issue. It seems like the issue mostly occurs when the machines are under heavy load.
