### PR TITLE
smd/scollector: Allowing multipart snmp keys in subtrees.

### DIFF
--- a/cmd/scollector/collectors/snmp_ifaces.go
+++ b/cmd/scollector/collectors/snmp_ifaces.go
@@ -114,7 +114,7 @@ func c_snmp_ifaces(community, host string) (opentsdb.MultiDataPoint, error) {
 		for k, v := range m {
 			tags := opentsdb.TagSet{
 				"host":  host,
-				"iface": fmt.Sprintf("%d", k),
+				"iface": fmt.Sprintf("%s", k),
 				"iname": ifNames[k],
 			}
 			if sA.dir != "" {


### PR DESCRIPTION
Snmp is horrible. Some trees index keys

```
.8.1
.8.2
.8.3
...
```

Others index them:
```
.8.1.1
.8.1.2
.8.1.3
...
```

Scollector would previously reject trees of the second form if present in a MIB. This patch makes all subtree paths strings and if a multipart key is  found simply converts it to `.1.3` style string.