### PR TITLE
Using slog everywhere instead of log.

### DIFF
--- a/cmd/bosun/conf/conf.go
+++ b/cmd/bosun/conf/conf.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	htemplate "html/template"
 	"io/ioutil"
-	"log"
 	"net"
 	"net/http"
 	"net/mail"
@@ -24,6 +23,7 @@ import (
 	eparse "bosun.org/cmd/bosun/expr/parse"
 	"bosun.org/graphite"
 	"bosun.org/opentsdb"
+	"bosun.org/slog"
 )
 
 type Conf struct {
@@ -963,7 +963,7 @@ func (c *Conf) loadNotification(s *parse.SectionNode) {
 		"json": func(v interface{}) string {
 			b, err := json.Marshal(v)
 			if err != nil {
-				log.Println(err)
+				slog.Errorln(err)
 			}
 			return string(b)
 		},

--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -440,6 +440,7 @@ func (s *Schedule) CheckAlert(T miniprofiler.Timer, r *RunHistory, a *conf.Alert
 	}
 	unevalCount, unknownCount := markDependenciesUnevaluated(r.Events, deps, a.Name)
 	if err != nil {
+		slog.Errorf("Error checking alert %s: %s", a.Name, err.Error())
 		removeUnknownEvents(r.Events, a.Name)
 	}
 	collect.Put("check.duration", opentsdb.TagSet{"name": a.Name}, time.Since(start).Seconds())

--- a/cmd/bosun/sched/sched.go
+++ b/cmd/bosun/sched/sched.go
@@ -4,7 +4,6 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net"
 	"sort"
 	"sync"
@@ -22,6 +21,7 @@ import (
 	"bosun.org/collect"
 	"bosun.org/metadata"
 	"bosun.org/opentsdb"
+	"bosun.org/slog"
 )
 
 func init() {
@@ -522,7 +522,7 @@ func pingHost(host string) {
 		timeout = 0
 	}
 	if err := p.Run(); err != nil {
-		log.Print(err)
+		slog.Errorln(err)
 	}
 	collect.Put("ping.timeout", tags, timeout)
 }
@@ -686,7 +686,7 @@ func (s *Schedule) Action(user, message string, t ActionType, ak expr.AlertKey) 
 	// Would like to also track the alert group, but I believe this is impossible because any character
 	// that could be used as a delimiter could also be a valid tag key or tag value character
 	if err := collect.Add("actions", opentsdb.TagSet{"user": user, "alert": ak.Name(), "type": t.String()}, 1); err != nil {
-		log.Println(err)
+		slog.Errorln(err)
 	}
 	return nil
 }

--- a/cmd/bosun/sched/template.go
+++ b/cmd/bosun/sched/template.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"html/template"
 	"io/ioutil"
-	"log"
 	"math"
 	"net/http"
 	"net/url"
@@ -127,7 +126,7 @@ func (s *Schedule) ExecuteBody(rh *RunHistory, a *conf.Alert, st *State, isEmail
 	if inline, err := inliner.Inline(buf.String()); err == nil {
 		buf = bytes.NewBufferString(inline)
 	} else {
-		log.Println(err)
+		slog.Errorln(err)
 	}
 	return buf.Bytes(), c.Attachments, nil
 }

--- a/cmd/bosun/web/web.go
+++ b/cmd/bosun/web/web.go
@@ -8,7 +8,6 @@ import (
 	"html/template"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -24,6 +23,7 @@ import (
 	"bosun.org/collect"
 	"bosun.org/metadata"
 	"bosun.org/opentsdb"
+	"bosun.org/slog"
 	"bosun.org/version"
 )
 
@@ -57,7 +57,7 @@ func init() {
 
 func Listen(listenAddr string, devMode bool, tsdbHost string) error {
 	if devMode {
-		log.Println("using local web assets")
+		slog.Infoln("using local web assets")
 	}
 	webFS := FS(devMode)
 
@@ -65,7 +65,7 @@ func Listen(listenAddr string, devMode bool, tsdbHost string) error {
 		str := FSMustString(devMode, "/templates/index.html")
 		templates, err := template.New("").Parse(str)
 		if err != nil {
-			log.Fatal(err)
+			slog.Fatal(err)
 		}
 		return templates
 	}
@@ -117,8 +117,8 @@ func Listen(listenAddr string, devMode bool, tsdbHost string) error {
 	http.Handle("/partials/", fs)
 	http.Handle("/static/", http.StripPrefix("/static/", fs))
 	http.Handle("/favicon.ico", fs)
-	log.Println("bosun web listening on:", listenAddr)
-	log.Println("tsdb host:", tsdbHost)
+	slog.Infoln("bosun web listening on:", listenAddr)
+	slog.Infoln("tsdb host:", tsdbHost)
 	return http.ListenAndServe(listenAddr, nil)
 }
 
@@ -195,7 +195,7 @@ func indexTSDB(r *http.Request, body []byte) {
 func IndexTSDB(w http.ResponseWriter, r *http.Request) {
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		log.Println(err)
+		slog.Error(err)
 	}
 	indexTSDB(r, body)
 }
@@ -237,7 +237,7 @@ func JSON(h func(miniprofiler.Timer, http.ResponseWriter, *http.Request) (interf
 		}
 		buf := new(bytes.Buffer)
 		if err := json.NewEncoder(buf).Encode(d); err != nil {
-			log.Println(err)
+			slog.Error(err)
 			serveError(w, err)
 			return
 		}

--- a/cmd/scollector/main.go
+++ b/cmd/scollector/main.go
@@ -476,13 +476,13 @@ func toToml(fname string) {
 
 	f, err := os.Create(fname)
 	if err != nil {
-		log.Fatal(err)
+		slog.Fatal(err)
 	}
 	if err := toml.NewEncoder(f).Encode(&c); err != nil {
-		log.Fatal(err)
+		slog.Fatal(err)
 	}
 	if _, err := extra.WriteTo(f); err != nil {
-		log.Fatal(err)
+		slog.Fatal(err)
 	}
 	f.Close()
 }


### PR DESCRIPTION
Should give more consistent logs, including file names.

Also logging check errors.