### PR TITLE
bosun: Only giving the dashboard the most recent action.

### DIFF
--- a/cmd/bosun/sched/sched.go
+++ b/cmd/bosun/sched/sched.go
@@ -375,6 +375,9 @@ func (s *Schedule) MarshalGroups(T miniprofiler.Timer, filter string) (*StateGro
 						if len(st.History) > 1 {
 							st.History = st.History[len(st.History)-1:]
 						}
+						if len(st.Actions) > 1 {
+							st.Actions = st.Actions[len(st.Actions)-1:]
+						}
 
 						g.Children = append(g.Children, &StateGroup{
 							Active:   tuple.Active,


### PR DESCRIPTION
Fixes #1156.

The dashboard was showing Actions[0] as the last, but we append to the right. If we only give the dashboard the most recent, everything should work.