### PR TITLE
cmd/Bosun: Metadata checking in alert expressions

### DIFF
--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -499,7 +499,7 @@ func (s *Schedule) executeExpr(T miniprofiler.Timer, rh *RunHistory, a *conf.Ale
 	if e == nil {
 		return nil, nil
 	}
-	results, _, err := e.Execute(rh.Context, rh.GraphiteContext, rh.Logstash, rh.Cache, T, rh.Start, 0, a.UnjoinedOK, s.Search, s.Conf.AlertSquelched(a), rh)
+	results, _, err := e.Execute(rh.Context, rh.GraphiteContext, rh.Logstash, rh.Cache, T, rh.Start, 0, a.UnjoinedOK, s.Search, s.Conf.AlertSquelched(a), rh, s)
 	if err != nil {
 		ak := expr.NewAlertKey(a.Name, nil)
 		rh.Events[ak] = &Event{

--- a/cmd/bosun/sched/template.go
+++ b/cmd/bosun/sched/template.go
@@ -202,7 +202,7 @@ func (c *Context) evalExpr(e *expr.Expr, filter bool, series bool, autods int) (
 	if series && e.Root.Return() != parse.TypeSeriesSet {
 		return nil, "", fmt.Errorf("need a series, got %T (%v)", e, e)
 	}
-	res, _, err := e.Execute(c.runHistory.Context, c.runHistory.GraphiteContext, c.runHistory.Logstash, c.runHistory.Cache, nil, c.runHistory.Start, autods, c.Alert.UnjoinedOK, c.schedule.Search, c.schedule.Conf.AlertSquelched(c.Alert), c.runHistory)
+	res, _, err := e.Execute(c.runHistory.Context, c.runHistory.GraphiteContext, c.runHistory.Logstash, c.runHistory.Cache, nil, c.runHistory.Start, autods, c.Alert.UnjoinedOK, c.schedule.Search, c.schedule.Conf.AlertSquelched(c.Alert), c.runHistory, c.schedule)
 	if err != nil {
 		return nil, "", fmt.Errorf("%s: %v", e, err)
 	}

--- a/cmd/bosun/web/chart.go
+++ b/cmd/bosun/web/chart.go
@@ -211,7 +211,7 @@ func ExprGraph(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (in
 	tsdbContext := schedule.Conf.TSDBContext()
 	graphiteContext := schedule.Conf.GraphiteContext()
 	ls := schedule.Conf.LogstashElasticHosts
-	res, _, err := e.Execute(tsdbContext, graphiteContext, ls, cacheObj, t, now, autods, false, schedule.Search, nil, nil)
+	res, _, err := e.Execute(tsdbContext, graphiteContext, ls, cacheObj, t, now, autods, false, schedule.Search, nil, nil, schedule)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/bosun/web/expr.go
+++ b/cmd/bosun/web/expr.go
@@ -74,7 +74,7 @@ func Expr(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (v inter
 	tsdbContext := schedule.Conf.TSDBContext()
 	graphiteContext := schedule.Conf.GraphiteContext()
 	ls := schedule.Conf.LogstashElasticHosts
-	res, queries, err := e.Execute(tsdbContext, graphiteContext, ls, cacheObj, t, now, 0, false, schedule.Search, nil, nil)
+	res, queries, err := e.Execute(tsdbContext, graphiteContext, ls, cacheObj, t, now, 0, false, schedule.Search, nil, nil, schedule)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This adds metaMatch, which does a metadata lookup for the tagset, and returns if any of the strings returned for that key match the regex
