### PR TITLE
cmd/scollector: Propagate FullHost setting

### DIFF
--- a/cmd/scollector/main.go
+++ b/cmd/scollector/main.go
@@ -84,9 +84,9 @@ func main() {
 	util.Set()
 	if conf.Hostname != "" {
 		util.Hostname = conf.Hostname
-		if err := collect.SetHostname(conf.Hostname); err != nil {
-			slog.Fatal(err)
-		}
+	}
+	if err := collect.SetHostname(util.Hostname); err != nil {
+		slog.Fatal(err)
 	}
 	if conf.ColDir != "" {
 		collectors.InitPrograms(conf.ColDir)


### PR DESCRIPTION
I noticed our scollectors reported different host tags for internal metrics.