### PR TITLE
cmd/Bosun: support / in lookup sections

### DIFF
--- a/cmd/bosun/conf/parse/lex.go
+++ b/cmd/bosun/conf/parse/lex.go
@@ -293,5 +293,5 @@ func isEndOfLine(r rune) bool {
 }
 
 func isVarchar(r rune) bool {
-	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '.' || r == '$'
+	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '.' || r == '$' || r == '/'
 }

--- a/cmd/bosun/conf/test.conf
+++ b/cmd/bosun/conf/test.conf
@@ -95,6 +95,12 @@ lookup l2 {
 	}
 }
 
+lookup l3 {
+        entry host=one,disk=/data {
+                r = 4
+        }
+}
+
 # notification lookups
 
 notification nc1 {


### PR DESCRIPTION
With regards to the os.diskspace alert, I like to write my exceptions for disks like this:
```
lookup disk_space {
    entry host=netlog,disk=/data {
        warn_percent_free = 5
        crit_percent_free = 0
    }
    entry host=*,disk=* {
        warn_percent_free = 10
        crit_percent_free = 0
    }
}
```

Currently this gives an error: "unexpected invalid character: / in section declaration", this change should remove the bug.

Thanks,