### PR TITLE
add support for the OpenTSDB 'regexp' filter function.

### DIFF
--- a/cmd/bosun/search/search.go
+++ b/cmd/bosun/search/search.go
@@ -218,7 +218,7 @@ func (s *Search) Expand(q *opentsdb.Query) error {
 		var nvs []string
 		for _, v := range strings.Split(ov, "|") {
 			v = strings.TrimSpace(v)
-			if v == "*" || !strings.Contains(v, "*") {
+			if v == "*" || strings.HasPrefix(v, "regexp") || !strings.Contains(v, "*") {
 				nvs = append(nvs, v)
 			} else {
 				vs := s.TagValuesByMetricTagKey(q.Metric, k, 0)

--- a/opentsdb/tsdb.go
+++ b/opentsdb/tsdb.go
@@ -378,7 +378,7 @@ func ParseRequest(req string) (*Request, error) {
 	return &r, nil
 }
 
-var qRE = regexp.MustCompile(`^(\w+):(?:(\w+-\w+):)?(?:(rate.*):)?([\w./-]+)(?:\{([\w./,=*-|]+)\})?$`)
+var qRE = regexp.MustCompile(`^(\w+):(?:(\w+-\w+):)?(?:(rate.*):)?([\w./-]+)(?:\{([\w./,=\(\)\[\]*-|]+)\})?$`)
 
 // ParseQuery parses OpenTSDB queries of the form: avg:rate:cpu{k=v}. Validation
 // errors will be returned along with a valid Query.


### PR DESCRIPTION
The changes only support the OpenTSDB 'regexp' filter function.

Example:

       avg(q("avg:rate:os.cpu{host=regexp(s[wl]73*)}", "5m", "")) > 80