### PR TITLE
cmd/scollector: count running linux processes from linux.proc collector

### DIFF
--- a/cmd/scollector/conf/conf_linux.go
+++ b/cmd/scollector/conf/conf_linux.go
@@ -1,7 +1,8 @@
 package conf
 
 type ProcessParams struct {
-	Command string
-	Name    string
-	Args    string
+	Command      string
+	Name         string
+	Args         string
+	IncludeCount bool
 }


### PR DESCRIPTION
Kind of fixes #1079 . The goal is to have something to track if there are no running processes matching from [[Process]] entry and not use `since()`.