### PR TITLE
cmd/scollector: Send a hi metric with a value of 1

### DIFF
--- a/cmd/scollector/collectors/hi.go
+++ b/cmd/scollector/collectors/hi.go
@@ -1,0 +1,20 @@
+package collectors
+
+import (
+	"bosun.org/metadata"
+	"bosun.org/opentsdb"
+)
+
+func init() {
+	collectors = append(collectors, &IntervalCollector{F: c_scollector_hi})
+}
+
+const (
+	hiDesc = "Scollector sends a 1 every DefaultFreq. This is so you can alert on scollector being down."
+)
+
+func c_scollector_hi() (opentsdb.MultiDataPoint, error) {
+	var md opentsdb.MultiDataPoint
+	Add(&md, "scollector.hi", 1, nil, metadata.Gauge, metadata.Ok, hiDesc)
+	return md, nil
+}


### PR DESCRIPTION
This can be used to create an alert for scollector being alive and then used as a dependency.