### PR TITLE
scollector generic SNMP documentation syntax and typo fix

### DIFF
--- a/cmd/scollector/doc.go
+++ b/cmd/scollector/doc.go
@@ -144,7 +144,7 @@ to at a 5 minute poll interval.
 
 MIBs (map of string to table): Allows user-specified, custom SNMP configurations.
 
-    [[MIBs]]
+    [MIBs]
       [MIBs.cisco] #can name anything you want
         BaseOid = "1.3.6.1.4.1.9.9" # common base for all metrics in this mib
 
@@ -157,7 +157,7 @@ MIBs (map of string to table): Allows user-specified, custom SNMP configurations
           Description = "cpu percent used by this device"
 
         # can also iterate over snmp tables
-        [[MIBSs.cisco.Trees]]
+        [[MIBs.cisco.Trees]]
           BaseOid = ".48.1.1.1" #common base oid for this tree
 
           # tags to apply to metrics in this tree. Can come from another oid, or specify "idx" to use


### PR DESCRIPTION
`MIBs` needs to be a toml "table" (parsed as a go `map[string]interface{}`) instead of a toml "array of tables" (parsed as a go `[]map[string]interface{}`).  Also fix a minor typo.