### PR TITLE
cmd/bosun: Allow to query graphite with Auth informations

### DIFF
--- a/graphite/graphite.go
+++ b/graphite/graphite.go
@@ -62,6 +62,7 @@ func (r *Request) Query(host string, header http.Header) (Response, error) {
 		if u.Path != "" {
 			r.URL.Path = u.Path
 		}
+		r.URL.User = u.User
 	}
 	req, err := http.NewRequest("GET", r.URL.String(), nil)
 	if err != nil {


### PR DESCRIPTION
a small patch to resolve #1349