### PR TITLE
More readable ifstat regexp + more interfaces matched

### DIFF
--- a/cmd/scollector/collectors/ifstat_linux.go
+++ b/cmd/scollector/collectors/ifstat_linux.go
@@ -2,6 +2,7 @@ package collectors
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"regexp"
@@ -13,11 +14,49 @@ import (
 	"bosun.org/util"
 )
 
+var ifstatRE *regexp.Regexp
+
 func init() {
 	collectors = append(collectors, &IntervalCollector{F: c_ifstat_linux})
 	collectors = append(collectors, &IntervalCollector{F: c_ipcount_linux})
 	collectors = append(collectors, &IntervalCollector{F: c_if_team_linux})
 	collectors = append(collectors, &IntervalCollector{F: c_if_bond_linux})
+
+	// Interfaces to match with ifstat
+	ifstatInterfaces := []string{
+		// e.g. eth0
+		`eth\d+`,
+		// e.g. em10_5/10
+		`em\d+_\d+/\d+`,
+		// e.g. em10_5
+		`em\d+_\d+`,
+		// e.g. em0
+		`em\d+`,
+		// e.g. bond0
+		`bond\d+`,
+		// e.g. team0
+		`team\d+`,
+		// e.g. p10p5_19/2
+		`p\d+p\d+_\d+/\d+`,
+		// e.g. p10p5_19
+		`p\d+p\d+_\d+`,
+		// e.g. p19p10
+		`p\d+p\d+`,
+		// e.g. if0
+		`if\d+`,
+		// e.g. lan
+		`lan\d*`,
+		// e.g. tun0
+		`tun\d+`,
+		// e.g. br0
+		`br\d+`,
+		// e.g. docker0
+		`docker\d+`,
+		// e.g. vet09d6143 / veth1pl6143 / veth2e23fca
+		`veth?(?:[\d\w]+)`,
+	}
+	combined := strings.Join(ifstatInterfaces, "|")
+	ifstatRE = regexp.MustCompile(fmt.Sprintf(`\s*(%s):(.*)`, combined))
 }
 
 var netFields = []struct {
@@ -42,9 +81,6 @@ var netFields = []struct {
 	{"carrier.errs", metadata.Counter, metadata.Count},
 	{"compressed", metadata.Counter, metadata.Count},
 }
-
-var ifstatRE = regexp.MustCompile(`\s+(eth\d+|em\d+_\d+/\d+|em\d+_\d+|em\d+|` +
-	`bond\d+|team\d+|` + `p\d+p\d+_\d+/\d+|p\d+p\d+_\d+|p\d+p\d+):(.*)`)
 
 func c_ipcount_linux() (opentsdb.MultiDataPoint, error) {
 	var md opentsdb.MultiDataPoint

--- a/cmd/scollector/collectors/ifstat_linux_test.go
+++ b/cmd/scollector/collectors/ifstat_linux_test.go
@@ -1,0 +1,55 @@
+package collectors
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestIfstatRE(t *testing.T) {
+	// Expected values
+	expectedValues := []string{"1", "2", "3", "4"}
+	valuesStr := strings.Join(expectedValues, " ")
+
+	// Interfaces that should match the regexp
+	expectedInterfaces := []string{
+		"eth0",
+		"em10_5/10",
+		"em10_5",
+		"em0",
+		"bond0",
+		"p10p5_19/2",
+		"p10p5_19",
+		"p19p10",
+		"if0",
+		"lan",
+		"tun0",
+		"br0",
+		"docker0",
+		"vet09d6143",
+		"veth1pl6143",
+		"veth2e23fca",
+	}
+
+	for _, iface := range expectedInterfaces {
+		str := fmt.Sprintf(" %s:%s", iface, valuesStr)
+
+		m := ifstatRE.FindStringSubmatch(str)
+		if len(m) != 3 {
+			t.Errorf("interface %q not matched", iface)
+			continue
+		}
+
+		gotInterface := m[1]
+		gotValues := strings.Fields(m[2])
+
+		if gotInterface != iface {
+			t.Errorf("expected interface %q, got %q", iface, gotInterface)
+		}
+
+		if !reflect.DeepEqual(gotValues, expectedValues) {
+			t.Errorf("expected values %+v, got %+v", expectedValues, gotValues)
+		}
+	}
+}


### PR DESCRIPTION
This improves the ifstat regexp readability by splitting the interfaces into simple regexp. It also allows comments above each regexp for better understanding.

I added some regexp testing to ensure the proper interfaces are matched.
