### PR TITLE
Update the ifstat regexp to match all the linux interfaces

### DIFF
--- a/cmd/scollector/collectors/ifstat_linux.go
+++ b/cmd/scollector/collectors/ifstat_linux.go
@@ -43,8 +43,7 @@ var netFields = []struct {
 	{"compressed", metadata.Counter, metadata.Count},
 }
 
-var ifstatRE = regexp.MustCompile(`\s+(eth\d+|em\d+_\d+/\d+|em\d+_\d+|em\d+|` +
-	`bond\d+|team\d+|` + `p\d+p\d+_\d+/\d+|p\d+p\d+_\d+|p\d+p\d+):(.*)`)
+var ifstatRE = regexp.MustCompile(`(?:\s+)?([^:]+):(.*)`)
 
 func c_ipcount_linux() (opentsdb.MultiDataPoint, error) {
 	var md opentsdb.MultiDataPoint


### PR DESCRIPTION
Related to https://github.com/bosun-monitor/bosun/pull/1353

I'm not sure why the regexp was limited to some interfaces in the first place. Should scollector match some network interfaces or _all_ the network interfaces ??

What do you think ?
