### PR TITLE
Add metricFilters to filter only the metrics we want to send

### DIFF
--- a/cmd/scollector/collectors/collectors.go
+++ b/cmd/scollector/collectors/collectors.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -95,6 +96,8 @@ var (
 	tlock     sync.Mutex
 	AddTags   opentsdb.TagSet
 
+	metricFilters = make([]*regexp.Regexp, 0)
+
 	AddProcessDotNetConfig = func(params conf.ProcessDotNet) error {
 		return fmt.Errorf("process_dotnet watching not implemented on this platform")
 	}
@@ -174,6 +177,10 @@ type MetricMeta struct {
 
 // AddTS is the same as Add but lets you specify the timestamp
 func AddTS(md *opentsdb.MultiDataPoint, name string, ts int64, value interface{}, t opentsdb.TagSet, rate metadata.RateType, unit metadata.Unit, desc string) {
+	// Check if we really want that metric
+	if skipMetric(name) {
+		return
+	}
 	if b, ok := value.(bool); ok {
 		if b {
 			value = 1
@@ -291,4 +298,28 @@ func metaIfaces(f func(iface net.Interface, tags opentsdb.TagSet)) {
 			f(iface, tags)
 		}
 	}
+}
+
+// AddMetricFilters adds metric filters provided by the conf
+func AddMetricFilters(s string) error {
+	re, err := regexp.Compile(s)
+	if err != nil {
+		return err
+	}
+	metricFilters = append(metricFilters, re)
+	return nil
+}
+
+// skipMetric will return true if we need to skip this metric
+func skipMetric(index string) bool {
+	// If no filters provided, we skip nothing
+	if len(metricFilters) == 0 {
+		return false
+	}
+	for _, re := range metricFilters {
+		if re.MatchString(index) {
+			return false
+		}
+	}
+	return true
 }

--- a/cmd/scollector/conf/conf.go
+++ b/cmd/scollector/conf/conf.go
@@ -28,6 +28,9 @@ type Conf struct {
 	// PProf is an IP:Port binding to be used for debugging with pprof package.
 	// Examples: localhost:6060 for loopback or :6060 for all IP addresses.
 	PProf string
+	// MetricFilters takes regular expressions and includes only indicies that
+	// match those filters from being monitored
+	MetricFilters []string
 
 	// KeepalivedCommunity, if not empty, enables the Keepalived collector with
 	// the specified community.

--- a/cmd/scollector/doc.go
+++ b/cmd/scollector/doc.go
@@ -101,6 +101,9 @@ Default is 500.
 
 Filter (array of string): filters collectors matching these terms.
 
+MetricFilters (array of string): filters metrics matching these regular
+expressions.
+
 PProf (string): optional IP:Port binding to be used for debugging with pprof.
 Examples: localhost:6060 for loopback or :6060 for all IP addresses.
 

--- a/cmd/scollector/main.go
+++ b/cmd/scollector/main.go
@@ -99,6 +99,9 @@ func main() {
 		}
 	}
 	collectors.Init(conf)
+	for _, r := range conf.MetricFilters {
+		check(collectors.AddMetricFilters(r))
+	}
 	for _, rmq := range conf.RabbitMQ {
 		check(collectors.RabbitMQ(rmq.URL))
 	}


### PR DESCRIPTION
Add metricFilters to filter only the metrics we want to send
If no filters are specified, nothing is filtered to keep
current behaviour