### PR TITLE
cmd/scollector collector: local listener

### DIFF
--- a/cmd/scollector/collectors/local_listener.go
+++ b/cmd/scollector/collectors/local_listener.go
@@ -1,0 +1,108 @@
+package collectors
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"bosun.org/cmd/scollector/conf"
+	"bosun.org/metadata"
+	"bosun.org/opentsdb"
+)
+
+func init() {
+	registerInit(func(c *conf.Conf) {
+		if c.LocalListener != "" {
+			collectors = append(collectors, &StreamCollector{F: func() <-chan *opentsdb.MultiDataPoint {
+				return c_local_listener(c.LocalListener)
+			},
+				name: fmt.Sprintf("local_listener-%s", c.LocalListener),
+			})
+		}
+	})
+}
+
+func c_local_listener(listenAddr string) <-chan *opentsdb.MultiDataPoint {
+	pm := &putMetric{}
+	pm.localMetrics = make(chan *opentsdb.MultiDataPoint, 1)
+
+	mux := http.NewServeMux()
+	mux.Handle("/api/put", pm)
+	mux.HandleFunc("/api/metadata/put", putMetadata)
+	go http.ListenAndServe(listenAddr, mux)
+
+	return pm.localMetrics
+}
+
+type putMetric struct {
+	localMetrics chan *opentsdb.MultiDataPoint
+}
+
+func (pm *putMetric) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var (
+		bodyReader io.ReadCloser
+		err        error
+	)
+	defer r.Body.Close()
+
+	if r.Method != "POST" {
+		w.WriteHeader(405)
+		return
+	}
+
+	if r.Header.Get("Content-Encoding") == "gzip" {
+		if bodyReader, err = gzip.NewReader(r.Body); err != nil {
+			w.WriteHeader(500)
+			w.Write([]byte(fmt.Sprintf("Unable to decompress: %s\n", err)))
+			return
+		}
+	} else {
+		bodyReader = r.Body
+	}
+
+	if body, err := ioutil.ReadAll(bodyReader); err != nil {
+		w.WriteHeader(500)
+		return
+	} else {
+		bodyReader.Close()
+
+		var (
+			dp  *opentsdb.DataPoint
+			mdp opentsdb.MultiDataPoint
+		)
+
+		if err := json.Unmarshal(body, &mdp); err == nil {
+		} else if err = json.Unmarshal(body, &dp); err == nil {
+			mdp = opentsdb.MultiDataPoint{dp}
+		} else {
+			w.WriteHeader(500)
+			w.Write([]byte(fmt.Sprintf("Unable to decode OpenTSDB json: %s\n", err)))
+			return
+		}
+
+		for _, dp := range mdp {
+			dp.Tags = AddTags.Copy().Merge(dp.Tags)
+		}
+
+		pm.localMetrics <- &mdp
+
+		w.WriteHeader(204)
+	}
+}
+
+func putMetadata(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	d := json.NewDecoder(r.Body)
+	var ms []metadata.Metasend
+	if err := d.Decode(&ms); err != nil {
+		w.WriteHeader(500)
+		return
+	}
+	for _, m := range ms {
+		metadata.AddMeta(m.Metric, m.Tags.Copy(), m.Name, m.Value, true)
+	}
+	w.WriteHeader(204)
+}

--- a/cmd/scollector/collectors/stream.go
+++ b/cmd/scollector/collectors/stream.go
@@ -1,0 +1,64 @@
+package collectors
+
+import (
+	"reflect"
+	"runtime"
+
+	"bosun.org/collect"
+	"bosun.org/metadata"
+	"bosun.org/opentsdb"
+	"bosun.org/util"
+)
+
+/* StreamCollector is useful for collectors that do not produces metrics at a
+   preset interval. Instead it consummes directly from a channel provided by
+   the collector and forwards it internally. */
+
+type StreamCollector struct {
+	F    func() <-chan *opentsdb.MultiDataPoint
+	name string
+	init func()
+}
+
+func (s *StreamCollector) Init() {
+	if s.init != nil {
+		s.init()
+	}
+}
+
+func (s *StreamCollector) Run(dpchan chan<- *opentsdb.DataPoint, quit <-chan struct{}) {
+	inputChan := s.F()
+	count := 0
+	for {
+		select {
+		case md := <-inputChan:
+			if !collect.DisableDefaultCollectors {
+				tags := opentsdb.TagSet{"collector": s.Name(), "os": runtime.GOOS}
+				Add(md, "scollector.collector.count", count, tags, metadata.Counter, metadata.Count, "Counter of metrics passed through.")
+			}
+
+			for _, dp := range *md {
+				if _, found := dp.Tags["host"]; !found {
+					dp.Tags["host"] = util.Hostname
+				}
+				dpchan <- dp
+				count++
+			}
+		case <-quit:
+			return
+		}
+	}
+}
+
+func (s *StreamCollector) Enabled() bool {
+	return true
+}
+
+func (s *StreamCollector) Name() string {
+	if s.name != "" {
+		return s.name
+	}
+	v := runtime.FuncForPC(reflect.ValueOf(s.F).Pointer())
+	return v.Name()
+
+}

--- a/cmd/scollector/conf/conf.go
+++ b/cmd/scollector/conf/conf.go
@@ -61,6 +61,7 @@ type Conf struct {
 	Cadvisor            []Cadvisor
 	RedisCounters       []RedisCounters
 	ExtraHop            []ExtraHop
+	LocalListener       string
 }
 
 type HAProxy struct {

--- a/cmd/scollector/doc.go
+++ b/cmd/scollector/doc.go
@@ -269,6 +269,12 @@ then this filtering loses its usefulness.
 	  FilterBy = "toppercent"
 	  FilterPercent = 75
 
+LocalListener (string): local_listener will listen for HTTP request and forward
+the request to the configured OpenTSDB host while adding defined tags to
+metrics.
+
+	LocalListener = "localhost:4242"
+
 Windows
 
 scollector has full Windows support. It can be run standalone, or installed as a


### PR DESCRIPTION
This adds the local_listener collector, it starts an http server locally and listens for /api/put and /api/metadata/put http requests. It ingest that data and forward it through its usual mechanism, basically acting as a proxy.