### PR TITLE
c_google_analytics: Gather realtime metrics for browsers, trafficType, deviceCategory, and OS.

### DIFF
--- a/cmd/scollector/conf/conf.go
+++ b/cmd/scollector/conf/conf.go
@@ -83,9 +83,10 @@ type GoogleAnalytics struct {
 }
 
 type GoogleAnalyticsSite struct {
-	Name    string
-	Profile string
-	Offset  int
+	Name     string
+	Profile  string
+	Offset   int
+	Detailed bool
 }
 
 type ICMP struct {

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -35,7 +35,8 @@ type Unit string
 const (
 	// None is a not-yet documented unit.
 	None            Unit = ""
-	A                    = "A" // Amps
+	A                    = "A"            // Amps
+	ActiveUsers          = "active users" // Google Analytics
 	Alert                = "alerts"
 	Abort                = "aborts"
 	Bool                 = "bool"


### PR DESCRIPTION
If the 'Detailed' attribute is set to true for a GA site in the configuration, this will track additional realtime metrics.

The `getPageviews` function is unchanged from the original. Was simply cut out of `c_google_analytics`.

The new metrics are named as follows:

`google.analytics.realtime.activeusers.by_${DIMENSION}`

:eyeglasses: @kylebrandt @captncraig 