### PR TITLE
cmd/scollector: configurable network interface name regexp

### DIFF
--- a/cmd/scollector/collectors/ifstat_linux.go
+++ b/cmd/scollector/collectors/ifstat_linux.go
@@ -2,22 +2,30 @@ package collectors
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
 
+	"bosun.org/cmd/scollector/conf"
 	"bosun.org/metadata"
 	"bosun.org/opentsdb"
 	"bosun.org/util"
 )
 
 func init() {
-	collectors = append(collectors, &IntervalCollector{F: c_ifstat_linux})
-	collectors = append(collectors, &IntervalCollector{F: c_ipcount_linux})
-	collectors = append(collectors, &IntervalCollector{F: c_if_team_linux})
-	collectors = append(collectors, &IntervalCollector{F: c_if_bond_linux})
+	registerInit(func(c *conf.Conf) {
+		if c.IfaceExpr != "" {
+			ifstatRE = regexp.MustCompile(fmt.Sprintf("(%s):(.*)", c.IfaceExpr))
+		}
+
+		collectors = append(collectors, &IntervalCollector{F: c_ifstat_linux})
+		collectors = append(collectors, &IntervalCollector{F: c_ipcount_linux})
+		collectors = append(collectors, &IntervalCollector{F: c_if_team_linux})
+		collectors = append(collectors, &IntervalCollector{F: c_if_bond_linux})
+	})
 }
 
 var netFields = []struct {

--- a/cmd/scollector/conf/conf.go
+++ b/cmd/scollector/conf/conf.go
@@ -36,6 +36,9 @@ type Conf struct {
 	// the specified community.
 	KeepalivedCommunity string
 
+	//Override default network interface expression
+	IfaceExpr string
+
 	HAProxy        []HAProxy
 	SNMP           []SNMP
 	MIBS           map[string]MIB

--- a/cmd/scollector/doc.go
+++ b/cmd/scollector/doc.go
@@ -104,6 +104,9 @@ Filter (array of string): filters collectors matching these terms.
 MetricFilters (array of string): filters metrics matching these regular
 expressions.
 
+IfaceExpr (string): Replaces the default regular expression for interface name
+matching on Linux.
+
 PProf (string): optional IP:Port binding to be used for debugging with pprof.
 Examples: localhost:6060 for loopback or :6060 for all IP addresses.
 


### PR DESCRIPTION
This adds config to replace the default interface name regexp used in ifstat_linux.go. We use custom interface names internally hence this PR. I think this should also fill the need expressed in  https://github.com/bosun-monitor/bosun/pull/1366.