### PR TITLE
Add more info to Clean() err message.

### DIFF
--- a/opentsdb/tsdb.go
+++ b/opentsdb/tsdb.go
@@ -244,7 +244,7 @@ func (t TagSet) Valid() bool {
 
 func (d *DataPoint) clean() error {
 	if err := d.Tags.Clean(); err != nil {
-		return err
+		return fmt.Errorf("cleaning tags for metric %s: %s", d.Metric, err)
 	}
 	m, err := Clean(d.Metric)
 	if err != nil {
@@ -288,7 +288,7 @@ func (t TagSet) Clean() error {
 		}
 		vc, err := Clean(v)
 		if err != nil {
-			return fmt.Errorf("cleaning key %s: %s", v, err)
+			return fmt.Errorf("cleaning value %s for tag %s: %s", v, k, err)
 		}
 		if kc != k || vc != v {
 			delete(t, k)


### PR DESCRIPTION
The usage of 'key' was erroneous. Corrected it and added the tag which the value was from.

Also added the metric to the error message when a tag failed to clean.

:eyeglasses: @kylebrandt @captncraig 