### PR TITLE
Sort data to prevent arbitrary metadata changes.

### DIFF
--- a/cmd/scollector/collectors/snmp_bridge.go
+++ b/cmd/scollector/collectors/snmp_bridge.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -93,6 +94,7 @@ func c_snmp_bridge(community, host string) (opentsdb.MultiDataPoint, error) {
 		}
 	}
 	for iface, macs := range ifMacs {
+		sort.Strings(macs)
 		j, err := json.Marshal(macs)
 		if err != nil {
 			return md, nil

--- a/cmd/scollector/collectors/snmp_ips.go
+++ b/cmd/scollector/collectors/snmp_ips.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"sort"
 	"strings"
 	"time"
 
@@ -72,6 +73,7 @@ func c_snmp_ips(community, host string) (opentsdb.MultiDataPoint, error) {
 		for _, ipNet := range ipNets {
 			ips = append(ips, ipNet.String())
 		}
+		sort.Strings(ips)
 		j, err := json.Marshal(ips)
 		if err != nil {
 			slog.Errorf("error marshaling ips for host %v: %v", host, err)


### PR DESCRIPTION
The `macs` and `ips` data from snmp don't come in ordered. As a result, metadata gets rewritten whenever their order is changed. This should prevent that.

:eyeglasses:  @gbrayut @captncraig 