### PR TITLE
puppet_linux: Track puppet.run.status and fix broken error checking logic.

### DIFF
--- a/cmd/scollector/collectors/puppet_linux.go
+++ b/cmd/scollector/collectors/puppet_linux.go
@@ -96,12 +96,14 @@ func puppet_linux() (opentsdb.MultiDataPoint, error) {
 	for k, v := range m.Time {
 		metric, err := strconv.ParseFloat(v, 64)
 		if err != nil {
-			if k == "total" {
-				AddTS(&md, "puppet.run_duration_total", last_run, metric, nil, metadata.Gauge, metadata.Second, descPuppetTotalTime)
-			} else {
-				AddTS(&md, "puppet.run_duration", last_run, metric, opentsdb.TagSet{"time": k}, metadata.Gauge, metadata.Second, descPuppetModuleTime)
-			}
+			return md, fmt.Errorf("Error parsing time: %s", err)
 		}
+		if k == "total" {
+			AddTS(&md, "puppet.run_duration_total", last_run, metric, nil, metadata.Gauge, metadata.Second, descPuppetTotalTime)
+		} else {
+			AddTS(&md, "puppet.run_duration", last_run, metric, opentsdb.TagSet{"time": k}, metadata.Gauge, metadata.Second, descPuppetModuleTime)
+		}
+
 	}
 	return md, nil
 }


### PR DESCRIPTION
We have a couple hosts successfully 'running' puppet and updating the last_run timestamp, but the run has a status of 'failed'. Adding a metric to track that.

:eyeglasses: @gbrayut @captncraig 