### PR TITLE
WIP: new udp listener for sporadic counter events.

### DIFF
--- a/cmd/scollector/collectors/redis_counters.go
+++ b/cmd/scollector/collectors/redis_counters.go
@@ -1,0 +1,81 @@
+package collectors
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"bosun.org/_third_party/github.com/garyburd/redigo/redis"
+	"bosun.org/cmd/scollector/conf"
+	"bosun.org/collect"
+	"bosun.org/metadata"
+	"bosun.org/opentsdb"
+	"bosun.org/slog"
+)
+
+func init() {
+	registerInit(func(c *conf.Conf) {
+		for _, red := range c.RedisCounters {
+			collectors = append(collectors,
+				&IntervalCollector{
+					name: "redisCounters_" + red.Server,
+					F: func() (opentsdb.MultiDataPoint, error) {
+						return c_redis_counters(red.Server, red.Database)
+					},
+				})
+		}
+	})
+}
+
+func c_redis_counters(server string, db int) (opentsdb.MultiDataPoint, error) {
+	var md opentsdb.MultiDataPoint
+	conn, err := redis.Dial("tcp", server, redis.DialDatabase(db))
+	if err != nil {
+		return md, err
+	}
+	defer conn.Close()
+	if _, err := conn.Do("CLIENT", "SETNAME", "scollector"); err != nil {
+		return md, err
+	}
+	cursor := 0
+	for {
+		vals, err := redis.Values(conn.Do("HSCAN", collect.RedisCountersKey, cursor))
+		if err != nil {
+			return md, err
+		}
+		if len(vals) != 2 {
+			return md, fmt.Errorf("Unexpected number of values")
+		}
+		cursor, err = redis.Int(vals[0], nil)
+		if err != nil {
+			return md, err
+		}
+		pairs, err := redis.StringMap(vals[1], nil)
+		if err != nil {
+			return md, err
+		}
+		for mts, val := range pairs {
+			parts := strings.Split(mts, ":")
+			if len(parts) != 2 {
+				slog.Errorf("Invalid metric tag set counter: %s", mts)
+				continue
+			}
+			metric := parts[0]
+			tags, err := opentsdb.ParseTags(parts[1])
+			if err != nil {
+				slog.Errorf("Invalid tags: %s", parts[1])
+				continue
+			}
+			v, err := strconv.Atoi(val)
+			if err != nil {
+				slog.Errorf("Invalid counter value: %s", val)
+				continue
+			}
+			Add(&md, metric, v, tags, metadata.Counter, metadata.Count, "")
+		}
+		if cursor == 0 {
+			break
+		}
+	}
+	return md, nil
+}

--- a/cmd/scollector/conf/conf.go
+++ b/cmd/scollector/conf/conf.go
@@ -59,6 +59,7 @@ type Conf struct {
 	Nexpose             []Nexpose
 	GoogleAnalytics     []GoogleAnalytics
 	Cadvisor            []Cadvisor
+	RedisCounters       []RedisCounters
 }
 
 type HAProxy struct {
@@ -167,4 +168,9 @@ type Github struct {
 
 type Cadvisor struct {
 	URL string
+}
+
+type RedisCounters struct {
+	Server   string
+	Database int
 }

--- a/cmd/scollector/doc.go
+++ b/cmd/scollector/doc.go
@@ -231,11 +231,6 @@ management plugin on http://guest:guest@127.0.0.1:15672/ .
 	[[RabbitMQ]]
 	  URL = "https://user:password@hostname:15671"
 
-Windows
-
-scollector has full Windows support. It can be run standalone, or installed as a
-service (see -winsvc). The Event Log is used when installed as a service.
-
 Cadvisor: Cadvisor endpoints to poll.
 Cadvisor collects system statistics about running containers.
 See https://github.com/google/cadvisor/ for documentation about configuring
@@ -243,6 +238,21 @@ cadvisor.
 
 	[[Cadvisor]]
 		URL = "http://localhost:8080"
+
+RedisCounters: Reads a hash of metric/counters from a redis database.
+
+    [[RedisCounters]]
+        Server = "localhost:6379"
+        Database = 2
+
+Expects data populated via bosun's udp listener in the "scollectorCounters" hash.
+
+
+Windows
+
+scollector has full Windows support. It can be run standalone, or installed as a
+service (see -winsvc). The Event Log is used when installed as a service.
+
 
 */
 package main

--- a/collect/eventListener.go
+++ b/collect/eventListener.go
@@ -1,0 +1,99 @@
+package collect
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"time"
+
+	"bosun.org/_third_party/github.com/garyburd/redigo/redis"
+	"bosun.org/opentsdb"
+	"bosun.org/slog"
+)
+
+/*
+ Listen on the specified udp port for events.
+ This provides long term aggrigation for sparse events.
+ wire format: opcode(1 byte) | data
+
+Opcodes:
+ 1: increment - increments a redis counter for the specified metric/tag set
+     data: count(4 bytes signed int) | metric:tag1=foo,tag2=bar
+*/
+func ListenUdp(port int, redisHost string, redisDb int) error {
+	addr := net.UDPAddr{
+		Port: port,
+		IP:   net.ParseIP("127.0.0.1"),
+	}
+	conn, err := net.ListenUDP("udp", &addr)
+	if err != nil {
+		return err
+	}
+	pool := newRedisPool(redisHost, redisDb)
+	for {
+		buf := make([]byte, 1025)
+		n, addr, err := conn.ReadFromUDP(buf)
+		if err != nil {
+			slog.Error(err)
+			continue
+		}
+		if n == len(buf) { // if we get a full buffer, assume some was truncated.
+			slog.Errorf("Too large a udp packet received from: %s. Skipping.", addr.String())
+			continue
+		}
+		Add("udp.packets", opentsdb.TagSet{}, 1)
+		go func(data []byte, addr string) {
+			c := pool.Get()
+			defer c.Close()
+			if len(data) == 0 {
+				slog.Errorf("Empty packet received from %s.", addr)
+			}
+			switch data[0] {
+			case 1:
+				incrementRedisCounter(data[1:], addr, c)
+			default:
+				slog.Errorf("Unknown opcode %d from %s.", data[0], addr)
+			}
+		}(buf[:n], addr.String())
+	}
+}
+
+func incrementRedisCounter(data []byte, addr string, conn redis.Conn) {
+	if len(data) < 5 {
+		slog.Errorf("Insufficient data for increment from %s.", addr)
+		return
+	}
+	r := bytes.NewReader(data)
+	var i int32
+	err := binary.Read(r, binary.BigEndian, &i)
+	if err != nil {
+		slog.Error(err)
+		return
+	}
+	mts := string(data[4:])
+	if _, err = conn.Do("HINCRBY", RedisCountersKey, mts, i); err != nil {
+		slog.Errorf("Error incrementing counter %s by %d. From %s. %s", mts, i, addr, err)
+	}
+}
+
+const RedisCountersKey = "scollectorCounters"
+
+func newRedisPool(server string, database int) *redis.Pool {
+	return &redis.Pool{
+		MaxIdle:     10,
+		MaxActive:   10,
+		Wait:        true,
+		IdleTimeout: 240 * time.Second,
+		Dial: func() (redis.Conn, error) {
+			c, err := redis.Dial("tcp", server, redis.DialDatabase(database))
+			if err != nil {
+				return nil, err
+			}
+			if _, err := c.Do("CLIENT", "SETNAME", metricRoot+"UDP"); err != nil {
+				c.Close()
+				return nil, err
+			}
+			return c, err
+		},
+	}
+}


### PR DESCRIPTION
This is the base implementation of a udp collector. I put it in the collect package because it is not in a `cmd/*` package and it seemed logical. 

We have a couple of options for deploying it:

1) scollector listens locally, stores things in redis master. Less udp traffic on network.
2) bosun listens. 
3) tsdbrelay listens. I don't like this a ton.

My vote is for 2. Any or all of them can be implemented fairly easily. 

@gbrayut @kylebrandt @bretcope 