### PR TITLE
cmd/scollector: fix pseudo file system checking for dfstat on linux

### DIFF
--- a/cmd/scollector/collectors/disk_linux.go
+++ b/cmd/scollector/collectors/disk_linux.go
@@ -75,9 +75,9 @@ func removable_fs(name string) bool {
 
 func isPseudoFS(name string) (res bool) {
 	err := readLine("/proc/filesystems", func(s string) error {
-		if strings.Contains(s, name) && strings.Contains(s, "nodev") {
+		ss := strings.Split(s, "\t")
+		if len(ss) == 2 && ss[1] == name && ss[0] == "nodev" {
 			res = true
-			return nil
 		}
 		return nil
 	})


### PR DESCRIPTION
Use string equality testing instead of sub-string matching in the
readLine() function for /proc/filesystems in isPsenduFS(), because the
latter could produce false-positive result.

For a real example:
nodev	selinuxfs
	xfs
these two lines will make the old code think xfs is a pseudo file
system.