### PR TITLE
Really kill a process when we say we kill it.

### DIFF
--- a/util/command.go
+++ b/util/command.go
@@ -48,7 +48,7 @@ func Command(timeout time.Duration, stdin io.Reader, name string, arg ...string)
 	})
 	killTimer := time.AfterFunc(timeout, func() {
 		slog.Errorf("Process taking too long. Killing: %s %s", name, strings.Join(arg, " "))
-		c.Process.Signal(os.Interrupt)
+		c.Process.Kill()
 		timedOut = true
 	})
 	err := c.Wait()


### PR DESCRIPTION
BTW, looking at the previous code, it seems odd to randomly kill() or int(). It would be better to signal first, and terminate after a moment (say 5 * time.Millisecond). I would also use SIGTERM signal instead of SIGINT, since SIGINT means: "interrupted from the keyboard".
