### PR TITLE
metadata: fix a goroutine and memory leak in sendMetadata()

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -241,6 +241,7 @@ func sendMetadata(ms []Metasend) {
 		slog.Error(err)
 		return
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != 204 {
 		slog.Errorln("bad metadata return:", resp.Status)
 		return


### PR DESCRIPTION
Defer close http response body in sendMetadata().

The http response body doesn't get closed after sendMetada() return,
which will cause two goroutines and quite some memory leak every hour.

Scollector on our haproxy boxs got to the internal 500 MiB memory limit and
panic crashed within a week. I analyzed the crash log and graphed memory
usage and goroutine count metrics of scollector, then found out the problem.

Metrics are really great for identifying this kind of problems, and I want to say
a big thank you for your great work building bosun and scollector.