### PR TITLE
c_elasticsearch: Refactor collector.

### DIFF
--- a/cmd/scollector/collectors/elasticsearch.go
+++ b/cmd/scollector/collectors/elasticsearch.go
@@ -2,32 +2,38 @@ package collectors
 
 import (
 	"encoding/json"
-	"errors"
-	"math"
 	"net/http"
 	"net/url"
+	"reflect"
 	"regexp"
-	"time"
+	"strings"
 
+	"bosun.org/cmd/scollector/conf"
 	"bosun.org/metadata"
 	"bosun.org/opentsdb"
+	"bosun.org/slog"
 )
 
 func init() {
-	collectors = append(collectors, &IntervalCollector{F: c_elasticsearch, Enable: enableURL(esURL)})
-	collectors = append(collectors, &IntervalCollector{F: c_elasticsearch_indices, Interval: time.Minute * 2, Enable: enableURL(esURL)})
+	registerInit(func(c *conf.Conf) {
+		for _, filter := range c.ElasticIndexFilters {
+			err := AddElasticIndexFilter(filter)
+			if err != nil {
+				slog.Errorf("Error processing ElasticIndexFilter: %s", err)
+			}
+		}
+		collectors = append(collectors, &IntervalCollector{F: c_elasticsearch, Enable: enableURL("http://localhost:9200/")})
+	})
 }
 
-const esURL = "http://localhost:9200/"
-
 var (
-	esPreV1     = regexp.MustCompile(`^0\.`)
-	esStatusMap = map[string]int{
+	elasticPreV1     = regexp.MustCompile(`^0\.`)
+	elasticStatusMap = map[string]int{
 		"green":  0,
 		"yellow": 1,
 		"red":    2,
 	}
-	esIndexFilters = make([]*regexp.Regexp, 0)
+	elasticIndexFilters = make([]*regexp.Regexp, 0)
 )
 
 func AddElasticIndexFilter(s string) error {
@@ -35,491 +41,170 @@ func AddElasticIndexFilter(s string) error {
 	if err != nil {
 		return err
 	}
-	esIndexFilters = append(esIndexFilters, re)
+	elasticIndexFilters = append(elasticIndexFilters, re)
 	return nil
 }
 
+type structProcessor struct {
+	elasticVersion string
+	md             *opentsdb.MultiDataPoint
+}
+
+// structProcessor.add() takes in a metric name prefix, an arbitrary struct, and a tagset.
+// The processor recurses through the struct and builds metrics. The field tags direct how
+// the field should be processed, as well as the metadata for the resulting metric.
+//
+// The field tags used are described as follows:
+//
+// version: typically set to '1' or '2'.
+//	This is compared against the elastic cluster version. If the version from the tag
+//      does not match the version in production, the metric will not be sent for this field.
+//
+// exclude:
+//      If this tag is set to 'true', a metric will not be sent for this field.
+//
+// rate: one of 'gauge', 'counter', 'rate'
+//	This tag dictates the metadata.RateType we send.
+//
+// unit: 'bytes', 'pages', etc
+//	This tag dictates the metadata.Unit we send.
+//
+// metric:
+//      This is the metric name which will be sent. If not present, the 'json'
+//      tag is sent as the metric name.
+//
+// Special handling:
+//
+// Metrics having the json tag suffix of 'in_milliseconds' are automagically
+// divided by 1000 and sent as seconds. The suffix is stripped from the name.
+//
+// Metrics having the json tag suffix of 'in_bytes' are automatically sent as
+// gauge bytes. The suffix is stripped from the metric name.
+func (s *structProcessor) add(prefix string, st interface{}, ts opentsdb.TagSet) {
+	t := reflect.TypeOf(st)
+	valueOf := reflect.ValueOf(st)
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		value := valueOf.Field(i).Interface()
+		if field.Tag.Get("exclude") == "true" {
+			continue
+		}
+		var (
+			jsonTag    = field.Tag.Get("json")
+			metricTag  = field.Tag.Get("metric")
+			versionTag = field.Tag.Get("version")
+			rateTag    = field.Tag.Get("rate")
+			unitTag    = field.Tag.Get("unit")
+		)
+		metricName := jsonTag
+		if metricTag != "" {
+			metricName = metricTag
+		}
+		if metricName == "" {
+			slog.Errorf("Unable to determine metric name for field %s. Skipping.", field.Name)
+			continue
+		}
+		if versionTag == "" || strings.HasPrefix(s.elasticVersion, versionTag) {
+			switch value := value.(type) {
+			case int, float64: // Number types in our structs are only ints and float64s.
+				// Turn all millisecond metrics into seconds
+				if strings.HasSuffix(metricName, "_in_millis") {
+					switch value.(type) {
+					case int:
+						value = float64(value.(int)) / 1000
+					case float64:
+						value = value.(float64) / 1000
+					}
+					unitTag = "seconds"
+					metricName = strings.TrimSuffix(metricName, "_in_millis")
+				}
+				// Set rate and unit for all "_in_bytes" metrics, and strip the "_in_bytes"
+				if strings.HasSuffix(metricName, "_in_bytes") {
+					if rateTag == "" {
+						rateTag = "gauge"
+					}
+					unitTag = "bytes"
+					metricName = strings.TrimSuffix(metricName, "_in_bytes")
+				}
+				Add(s.md, prefix+"."+metricName, value, ts, metadata.RateType(rateTag), metadata.Unit(unitTag), field.Tag.Get("desc"))
+			case string:
+				// The json data has a lot of strings, and we don't care about em.
+			default:
+				// If we hit another struct, recurse
+				if reflect.ValueOf(value).Kind() == reflect.Struct {
+					s.add(prefix+"."+metricName, value, ts)
+				} else {
+					slog.Errorf("Field %s for metric %s is non-numeric type. Cannot record as a metric.\n", field.Name, prefix+"."+metricName)
+				}
+			}
+		}
+	}
+}
+
 func c_elasticsearch() (opentsdb.MultiDataPoint, error) {
-	var status esStatus
+	var status ElasticStatus
 	if err := esReq("/", "", &status); err != nil {
 		return nil, err
 	}
-	var stats esStats
-	if err := esReq(esStatsURL(status.Version.Number), "", &stats); err != nil {
+	var clusterStats ElasticClusterStats
+	if err := esReq(esStatsURL(status.Version.Number), "", &clusterStats); err != nil {
 		return nil, err
 	}
-	var clusterState esClusterState
-	if err := esReq("/_cluster/state", "?filter_routing_table=true&filter_metadata=true&filter_blocks=true", &clusterState); err != nil {
+	var clusterState ElasticClusterState
+	if err := esReq("/_cluster/state/master_node", "", &clusterState); err != nil {
+		return nil, err
+	}
+	var clusterHealth ElasticHealth
+	if err := esReq("/_cluster/health", "level=indices", &clusterHealth); err != nil {
 		return nil, err
 	}
 	var md opentsdb.MultiDataPoint
-	add := func(name string, val interface{}, ts opentsdb.TagSet) {
-		tags := opentsdb.TagSet{"cluster": stats.ClusterName}
-		for k, v := range ts {
-			tags[k] = v
-		}
-		Add(&md, "elastic."+name, val, tags, metadata.Unknown, metadata.None, "")
-	}
-	for nodeid, nstats := range stats.Nodes {
-		isMaster := nodeid == clusterState.MasterNode
+	s := structProcessor{elasticVersion: status.Version.Number, md: &md}
+	ts := opentsdb.TagSet{"cluster": clusterStats.ClusterName}
+	for nodeID, nodeStats := range clusterStats.Nodes {
+		isMaster := nodeID == clusterState.MasterNode
 		if isMaster {
-			cstats := make(map[string]interface{})
-			if err := esReq("/_cluster/health", "", &cstats); err != nil {
-				return nil, err
-			}
-			for k, v := range cstats {
-				switch t := v.(type) {
-				case string:
-					if k != "status" {
-						continue
-					}
-					var present bool
-					if v, present = esStatusMap[t]; !present {
-						v = -1
-					}
-				case float64:
-					// break
-				default:
-					continue
-				}
-				add("cluster."+k, v, nil)
+			s.add("elastic.health", clusterHealth, nil)
+			if statusCode, ok := elasticStatusMap[clusterHealth.Status]; ok {
+				Add(&md, "elastic.health.status", statusCode, ts, metadata.Gauge, metadata.StatusCode, "The current status of the cluster. Zero for green, one for yellow, two for red.")
 			}
 		}
-		for k, v := range nstats.Indices {
-			switch k {
-			case "docs":
-				add("num_docs", v["count"], nil)
-			case "store":
-				add("indices.size", v["size_in_bytes"], nil)
-			case "indexing":
-				add("indexing.index_total", v["index_total"], nil)
-				add("indexing.index_time", v["index_time_in_millis"], nil)
-				if f, err := divInterfaceFlt(v["index_time_in_millis"], v["index_total"]); err == nil {
-					add("indexing.time_per_index", f, nil)
-				}
-				add("indexing.index_current", v["index_current"], nil)
-				add("indexing.delete_total", v["delete_total"], nil)
-				add("indexing.delete_time", v["delete_time_in_millis"], nil)
-				add("indexing.delete_current", v["delete_current"], nil)
-				if f, err := divInterfaceFlt(v["delete_time_in_millis"], v["delete_total"]); err == nil {
-					add("indexing.time_per_delete", f, nil)
-				}
-			case "get":
-				add("get.total", v["total"], nil)
-				add("get.time", v["time_in_millis"], nil)
-				if f, err := divInterfaceFlt(v["time_in_millis"], v["total"]); err == nil {
-					add("get.time_per_get", f, nil)
-				}
-				add("get.exists_total", v["exists_total"], nil)
-				add("get.exists_time", v["exists_time_in_millis"], nil)
-				if f, err := divInterfaceFlt(v["exists_time_in_millis"], v["exists_total"]); err == nil {
-					add("get.time_per_get_exists", f, nil)
-				}
-				add("get.missing_total", v["missing_total"], nil)
-				add("get.missing_time", v["missing_time_in_millis"], nil)
-				if f, err := divInterfaceFlt(v["missing_time_in_millis"], v["missing_total"]); err == nil {
-					add("get.time_per_get_missing", f, nil)
-				}
-			case "search":
-				add("search.query_total", v["query_total"], nil)
-				add("search.query_time", v["query_time_in_millis"], nil)
-				if f, err := divInterfaceFlt(v["query_time_in_millis"], v["query_total"]); err == nil {
-					add("search.time_per_query", f, nil)
-				}
-				add("search.query_current", v["query_current"], nil)
-				add("search.fetch_total", v["fetch_total"], nil)
-				add("search.fetch_time", v["fetch_time_in_millis"], nil)
-				if f, err := divInterfaceFlt(v["fetch_time_in_millis"], v["fetch_total"]); err == nil {
-					add("search.time_per_fetch", f, nil)
-				}
-				add("search.fetch_current", v["fetch_current"], nil)
-			case "cache":
-				add("cache.field.evictions", v["field_evictions"], nil)
-				add("cache.field.size", v["field_size_in_bytes"], nil)
-				add("cache.filter.count", v["filter_count"], nil)
-				add("cache.filter.evictions", v["filter_evictions"], nil)
-				add("cache.filter.size", v["filter_size_in_bytes"], nil)
-			case "merges":
-				add("merges.current", v["current"], nil)
-				add("merges.total", v["total"], nil)
-				add("merges.total_time", v["total_time_in_millis"], nil)
-				if f, err := divInterfaceFlt(v["total_time_in_millis"], v["total"]); err == nil {
-					add("merges.time_per_merge", f, nil)
-				}
-			}
+		s.add("elastic", nodeStats, ts)
+		s.add("elastic.indices.local", nodeStats.Indices, ts)
+		s.add("elastic.jvm.gc", nodeStats.JVM.GC.Collectors.Old, opentsdb.TagSet{"gc": "old"}.Merge(ts))
+		s.add("elastic.jvm.gc", nodeStats.JVM.GC.Collectors.Young, opentsdb.TagSet{"gc": "young"}.Merge(ts))
+	}
+	var indexStats ElasticIndexStats
+	if err := esReq("/_stats", "", &indexStats); err != nil {
+		return nil, err
+	}
+	for k, index := range clusterHealth.Indices {
+		if esSkipIndex(k) {
+			continue
 		}
-		for k, v := range nstats.Process {
-			switch k {
-			case "open_file_descriptors": // ES 0.17
-				add("process.open_file_descriptors", v, nil)
-			case "fd": // ES 0.16
-				if t, present := nstats.Process["total"]; present {
-					add("process.open_file_descriptors", t, nil)
-				}
-			case "cpu":
-				v := v.(map[string]interface{})
-				add("process.cpu.percent", v["percent"], nil)
-				add("process.cpu.sys", v["sys_in_millis"].(float64)/1000., nil)
-				add("process.cpu.user", v["user_in_millis"].(float64)/1000., nil)
-			case "mem":
-				v := v.(map[string]interface{})
-				add("process.mem.resident", v["resident_in_bytes"], nil)
-				add("process.mem.shared", v["share_in_bytes"], nil)
-				add("process.mem.total_virtual", v["total_virtual_in_bytes"], nil)
-			}
+		ts := opentsdb.TagSet{"index_name": k, "cluster": clusterStats.ClusterName}
+		s.add("elastic.health.indices", index, ts)
+		if status, ok := elasticStatusMap[index.Status]; ok {
+			Add(&md, "elastic.health.indices.status", status, ts, metadata.Gauge, metadata.StatusCode, "The current status of the index. Zero for green, one for yellow, two for red.")
 		}
-		for k, v := range nstats.JVM {
-			switch k {
-			case "mem":
-				v := v.(map[string]interface{})
-				add("jvm.mem.heap_used", v["heap_used_in_bytes"], nil)
-				add("jvm.mem.heap_committed", v["heap_committed_in_bytes"], nil)
-				add("jvm.mem.non_heap_used", v["non_heap_used_in_bytes"], nil)
-				add("jvm.mem.non_heap_committed", v["non_heap_committed_in_bytes"], nil)
-			case "threads":
-				v := v.(map[string]interface{})
-				add("jvm.threads.count", v["count"], nil)
-				add("jvm.threads.peak_count", v["peak_count"], nil)
-			case "gc":
-				v := v.(map[string]interface{})
-				c := v["collectors"].(map[string]interface{})
-				for k, v := range c {
-					v := v.(map[string]interface{})
-					ts := opentsdb.TagSet{"gc": k}
-					add("jvm.gc.collection_count", v["collection_count"], ts)
-					add("jvm.gc.collection_time", v["collection_time_in_millis"].(float64)/1000, ts)
-				}
-			}
+	}
+	for k, index := range indexStats.Indices {
+		if esSkipIndex(k) {
+			continue
 		}
-		for k, v := range nstats.Network {
-			switch k {
-			case "tcp":
-				for k, v := range v.(map[string]interface{}) {
-					switch v.(type) {
-					case float64:
-						add("network.tcp."+k, v, nil)
-					}
-				}
-			}
-		}
-		for k, v := range nstats.Transport {
-			switch v.(type) {
-			case float64:
-				add("transport."+k, v, nil)
-			}
-		}
-		for k, v := range nstats.HTTP {
-			switch v.(type) {
-			case float64:
-				add("http."+k, v, nil)
-			}
-		}
+		ts := opentsdb.TagSet{"index_name": k, "cluster": clusterStats.ClusterName}
+		s.add("elastic.indices.cluster", index.Primaries, ts)
 	}
 	return md, nil
 }
 
-type ElasticIndexStats struct {
-	All    ElasticIndex `json:"_all"`
-	Shards struct {
-		Failed     float64 `json:"failed"`
-		Successful float64 `json:"successful"`
-		Total      float64 `json:"total"`
-	} `json:"_shards"`
-	Indices map[string]ElasticIndex `json:"indices"`
-}
-
-type ElasticIndex struct {
-	Primaries ElasticIndexDetails `json:"primaries"`
-	Total     ElasticIndexDetails `json:"total"`
-}
-
-type ElasticIndexDetails struct {
-	Completion struct {
-		SizeInBytes float64 `json:"size_in_bytes"`
-	} `json:"completion"`
-	Docs struct {
-		Count   float64 `json:"count"`
-		Deleted float64 `json:"deleted"`
-	} `json:"docs"`
-	Fielddata struct {
-		Evictions         float64 `json:"evictions"`
-		MemorySizeInBytes float64 `json:"memory_size_in_bytes"`
-	} `json:"fielddata"`
-	FilterCache struct {
-		Evictions         float64 `json:"evictions"`
-		MemorySizeInBytes float64 `json:"memory_size_in_bytes"`
-	} `json:"filter_cache"`
-	Flush struct {
-		Total             float64 `json:"total"`
-		TotalTimeInMillis float64 `json:"total_time_in_millis"`
-	} `json:"flush"`
-	Get struct {
-		Current             float64 `json:"current"`
-		ExistsTimeInMillis  float64 `json:"exists_time_in_millis"`
-		ExistsTotal         float64 `json:"exists_total"`
-		MissingTimeInMillis float64 `json:"missing_time_in_millis"`
-		MissingTotal        float64 `json:"missing_total"`
-		TimeInMillis        float64 `json:"time_in_millis"`
-		Total               float64 `json:"total"`
-	} `json:"get"`
-	IDCache struct {
-		MemorySizeInBytes float64 `json:"memory_size_in_bytes"`
-	} `json:"id_cache"`
-	Indexing struct {
-		DeleteCurrent      float64 `json:"delete_current"`
-		DeleteTimeInMillis float64 `json:"delete_time_in_millis"`
-		DeleteTotal        float64 `json:"delete_total"`
-		IndexCurrent       float64 `json:"index_current"`
-		IndexTimeInMillis  float64 `json:"index_time_in_millis"`
-		IndexTotal         float64 `json:"index_total"`
-	} `json:"indexing"`
-	Merges struct {
-		Current            float64 `json:"current"`
-		CurrentDocs        float64 `json:"current_docs"`
-		CurrentSizeInBytes float64 `json:"current_size_in_bytes"`
-		Total              float64 `json:"total"`
-		TotalDocs          float64 `json:"total_docs"`
-		TotalSizeInBytes   float64 `json:"total_size_in_bytes"`
-		TotalTimeInMillis  float64 `json:"total_time_in_millis"`
-	} `json:"merges"`
-	Percolate struct {
-		Current           float64 `json:"current"`
-		MemorySize        string  `json:"memory_size"`
-		MemorySizeInBytes float64 `json:"memory_size_in_bytes"`
-		Queries           float64 `json:"queries"`
-		TimeInMillis      float64 `json:"time_in_millis"`
-		Total             float64 `json:"total"`
-	} `json:"percolate"`
-	Refresh struct {
-		Total             float64 `json:"total"`
-		TotalTimeInMillis float64 `json:"total_time_in_millis"`
-	} `json:"refresh"`
-	Search struct {
-		FetchCurrent      float64 `json:"fetch_current"`
-		FetchTimeInMillis float64 `json:"fetch_time_in_millis"`
-		FetchTotal        float64 `json:"fetch_total"`
-		OpenContexts      float64 `json:"open_contexts"`
-		QueryCurrent      float64 `json:"query_current"`
-		QueryTimeInMillis float64 `json:"query_time_in_millis"`
-		QueryTotal        float64 `json:"query_total"`
-	} `json:"search"`
-	Segments struct {
-		Count         float64 `json:"count"`
-		MemoryInBytes float64 `json:"memory_in_bytes"`
-	} `json:"segments"`
-	Store struct {
-		SizeInBytes          float64 `json:"size_in_bytes"`
-		ThrottleTimeInMillis float64 `json:"throttle_time_in_millis"`
-	} `json:"store"`
-	Suggest struct {
-		Current      float64 `json:"current"`
-		TimeInMillis float64 `json:"time_in_millis"`
-		Total        float64 `json:"total"`
-	} `json:"suggest"`
-	Translog struct {
-		Operations  float64 `json:"operations"`
-		SizeInBytes float64 `json:"size_in_bytes"`
-	} `json:"translog"`
-	Warmer struct {
-		Current           float64 `json:"current"`
-		Total             float64 `json:"total"`
-		TotalTimeInMillis float64 `json:"total_time_in_millis"`
-	} `json:"warmer"`
-}
-
-const (
-	descCompletionSizeInBytes        = "Size of the completion index (used for auto-complete functionallity)."
-	descDocsCount                    = "The number of documents in the index."
-	descDocsDeleted                  = "The number of deleted documents in the index."
-	descFielddataEvictions           = "The number of cache evictions for field data."
-	descFielddataMemorySizeInBytes   = "The amount of memory used for field data."
-	descFilterCacheEvictions         = "The number of cache evictions for filter data."
-	descFilterCacheMemorySizeInBytes = "The amount of memory used for filter data."
-	descFlushTotal                   = "The number of flush operations. The flush process of an index basically frees memory from the index by flushing data to the index storage and clearing the internal transaction log."
-	descFlushTotalTimeInMillis       = "The total amount of time spent on flush operations. The flush process of an index basically frees memory from the index by flushing data to the index storage and clearing the internal transaction log."
-	descGetCurrent                   = "The current number of get operations. Gets get a typed JSON document from the index based on its id."
-	descGetTimeInMillis              = "The total amount of time spent on get operations. Gets get a typed JSON document from the index based on its id."
-	descGetTotal                     = "The total number of get operations. Gets get a typed JSON document from the index based on its id."
-	descGetMissingTimeInMillis       = "The total amount of time spent trying to get documents that turned out to be missing."
-	descGetMissingTotal              = "The total number of operations that tried to get a document that turned out to be missing."
-	descGetExistsTimeInMillis        = "The total amount of time spent on get exists operations. Gets exists sees if a document exists."
-	descGetExistsTotal               = "The total number of get exists operations. Gets exists sees if a document exists."
-	descIDCacheMemorySizeInBytes     = "The size of the id cache."
-	descIndexingDeleteCurrent        = "The current number of documents being deleted via indexing commands (such as a delete query)."
-	descIndexingDeleteTimeInMillis   = "The time spent deleting documents."
-	descIndexingDeleteTotal          = "The total number of documents deleted."
-	descIndexingIndexCurrent         = "The current number of documents being indexed."
-	descIndexingIndexTimeInMillis    = "The total amount of time spent indexing documents."
-	descIndexingIndexTotal           = "The total number of documents indexed."
-	descMergesCurrent                = "The current number of merge operations. In elastic Lucene segments are merged behind the scenes. It is possible these can impact search performance."
-	descMergesCurrentDocs            = "The current number of documents that have an underlying merge operation going on. In elastic Lucene segments are merged behind the scenes. It is possible these can impact search performance."
-	descMergesCurrentSizeInBytes     = "The current number of bytes being merged. In elastic Lucene segments are merged behind the scenes. It is possible these can impact search performance."
-	descMergesTotal                  = "The total number of merges. In elastic Lucene segments are merged behind the scenes. It is possible these can impact search performance."
-	descMergesTotalDocs              = "The total number of documents that have had an underlying merge operation. In elastic Lucene segments are merged behind the scenes. It is possible these can impact search performance."
-	descMergesTotalSizeInBytes       = "The total number of bytes merged. In elastic Lucene segments are merged behind the scenes. It is possible these can impact search performance."
-	descMergesTotalTimeInMillis      = "The total amount of time spent on merge operations. In elastic Lucene segments are merged behind the scenes. It is possible these can impact search performance."
-	descPercolateCurrent             = "The current number of percolate operations."
-	descPercolateMemorySizeInBytes   = "The amount of memory used for the percolate index. Percolate is a reverse query to document operation."
-	descPercolateQueries             = "The total number of percolate queries. Percolate is a reverse query to document operation."
-	descPercolateTimeInMillis        = "The total amount of time spent on percolating. Percolate is a reverse query to document operation."
-	descPercolateTotal               = "The total number of percolate operations. Percolate is a reverse query to document operation."
-	descRefreshTotal                 = "The total number of refreshes. Refreshing makes all operations performed since the last search available."
-	descRefreshTotalTimeInMillis     = "The total amount of time spent on refreshes. Refreshing makes all operations performed since the last search available."
-	descSearchFetchCurrent           = "The current number of documents being fetched. Fetching is a phase of querying in a distributed search."
-	descSearchFetchTimeInMillis      = "The total time spent fetching documents. Fetching is a phase of querying in a distributed search."
-	descSearchFetchTotal             = "The total number of documents fetched. Fetching is a phase of querying in a distributed search."
-	descSearchOpenContexts           = "The current number of open contexts. A search is left open when srolling (i.e. pagination)."
-	descSearchQueryCurrent           = "The current number of queries."
-	descSearchQueryTimeInMillis      = "The total amount of time spent querying."
-	descSearchQueryTotal             = "The total number of queries."
-	descSegmentsMemoryInBytes        = "The total amount of memory used for Lucene segments."
-	descSegmentsCount                = "The number of segments that make up the index."
-	descStoreSizeInBytes             = "The current size of the store."
-	descStoreThrottleTimeInMillis    = "The amount of time that merges where throttled."
-	descSuggestCurrent               = "The current number of suggest operations."
-	descSuggestTimeInMillis          = "The total amount of time spent on suggest operations."
-	descSuggestTotal                 = "The total number of suggest operations."
-	descTranslogOperations           = "The total number of translog operations. The transaction logs (or write ahead logs) ensure atomicity of operations."
-	descTranslogSizeInBytes          = "The current size of transaction log. The transaction log (or write ahead log) ensure atomicity of operations."
-	descWarmerCurrent                = "The current number of warmer operations. Warming registers search requests in the background to speed up actual search requests."
-	descWarmerTotal                  = "The total number of warmer operations. Warming registers search requests in the background to speed up actual search requests."
-	descWarmerTotalTimeInMillis      = "The total time spent on warmer operations. Warming registers search requests in the background to speed up actual search requests."
-)
-
-type ElasticIndicesHealth struct {
-	ActivePrimaryShards float64                       `json:"active_primary_shards"`
-	ActiveShards        float64                       `json:"active_shards"`
-	ClusterName         string                        `json:"cluster_name"`
-	Indices             map[string]ElasticIndexHealth `json:"indices"`
-	InitializingShards  float64                       `json:"initializing_shards"`
-	NumberOfDataNodes   float64                       `json:"number_of_data_nodes"`
-	NumberOfNodes       float64                       `json:"number_of_nodes"`
-	RelocatingShards    float64                       `json:"relocating_shards"`
-	Status              string                        `json:"status"`
-	TimedOut            bool                          `json:"timed_out"`
-	UnassignedShards    float64                       `json:"unassigned_shards"`
-}
-
-type ElasticIndexHealth struct {
-	ActivePrimaryShards float64 `json:"active_primary_shards"`
-	ActiveShards        float64 `json:"active_shards"`
-	InitializingShards  float64 `json:"initializing_shards"`
-	NumberOfReplicas    float64 `json:"number_of_replicas"`
-	NumberOfShards      float64 `json:"number_of_shards"`
-	RelocatingShards    float64 `json:"relocating_shards"`
-	Status              string  `json:"status"`
-	UnassignedShards    float64 `json:"unassigned_shards"`
-}
-
-const (
-	descStatus              = "The current status of the index. Zero for green, one for yellow, two for red."
-	descActivePrimaryShards = "The number of active primary shards. Each document is stored in a single primary shard and then when it is indexed it is copied the replicas of that shard."
-	descActiveShards        = "The number of active shards."
-	descInitializingShards  = "The number of initalizing shards."
-	descNumberOfShards      = "The number of shards."
-	descRelocatingShards    = "The number of shards relocating."
-	descNumberOfReplicas    = "The number of replicas."
-)
-
 func esSkipIndex(index string) bool {
-	for _, re := range esIndexFilters {
+	for _, re := range elasticIndexFilters {
 		if re.MatchString(index) {
 			return true
 		}
 	}
 	return false
-}
-
-func c_elasticsearch_indices() (opentsdb.MultiDataPoint, error) {
-	var stats ElasticIndexStats
-	var health ElasticIndicesHealth
-	if err := esReq("/_cluster/health", "level=indices", &health); err != nil {
-		return nil, err
-	}
-	cluster := health.ClusterName
-	var md opentsdb.MultiDataPoint
-	for k, v := range health.Indices {
-		if esSkipIndex(k) {
-			continue
-		}
-		ts := opentsdb.TagSet{"index_name": k, "cluster": cluster}
-		if status, ok := esStatusMap[v.Status]; ok {
-			Add(&md, "elastic.indices.status", status, ts, metadata.Gauge, metadata.StatusCode, descStatus)
-		}
-		Add(&md, "elastic.indices.shards.active_primary", v.ActivePrimaryShards, ts, metadata.Gauge, metadata.Shard, descActivePrimaryShards)
-		Add(&md, "elastic.indices.shards.active", v.ActiveShards, ts, metadata.Gauge, metadata.Shard, descActiveShards)
-		Add(&md, "elastic.indices.shards.initalizing", v.InitializingShards, ts, metadata.Gauge, metadata.Shard, descInitializingShards)
-		Add(&md, "elastic.indices.shards.number", v.NumberOfShards, ts, metadata.Gauge, metadata.Shard, descNumberOfShards)
-		Add(&md, "elastic.indices.shards.relocating", v.RelocatingShards, ts, metadata.Gauge, metadata.Shard, descRelocatingShards)
-		Add(&md, "elastic.indices.replicas", v.NumberOfReplicas, ts, metadata.Gauge, metadata.Replica, descNumberOfReplicas)
-
-	}
-	if err := esReq("/_stats", "", &stats); err != nil {
-		return nil, err
-	}
-	for k, v := range stats.Indices {
-		if esSkipIndex(k) {
-			continue
-		}
-		ts := opentsdb.TagSet{"index_name": k, "cluster": cluster}
-		Add(&md, "elastic.indices.completion.size", v.Primaries.Completion.SizeInBytes, ts, metadata.Gauge, metadata.Bytes, descCompletionSizeInBytes)
-		Add(&md, "elastic.indices.docs.count", v.Primaries.Docs.Count, ts, metadata.Gauge, metadata.Document, descDocsCount)
-		Add(&md, "elastic.indices.docs.deleted", v.Primaries.Docs.Deleted, ts, metadata.Gauge, metadata.Document, descDocsDeleted)
-		Add(&md, "elastic.indices.fielddata.evictions", v.Primaries.Fielddata.Evictions, ts, metadata.Counter, metadata.Eviction, descFielddataEvictions)
-		Add(&md, "elastic.indices.fielddata.memory_size", v.Primaries.Fielddata.MemorySizeInBytes, ts, metadata.Gauge, metadata.Bytes, descFielddataMemorySizeInBytes)
-		Add(&md, "elastic.indices.filter_cache.evictions", v.Primaries.FilterCache.Evictions, ts, metadata.Counter, metadata.Eviction, descFilterCacheEvictions)
-		Add(&md, "elastic.indices.filter_cache.memory_size", v.Primaries.FilterCache.MemorySizeInBytes, ts, metadata.Counter, metadata.Bytes, descFilterCacheMemorySizeInBytes)
-		Add(&md, "elastic.indices.flush.total", v.Primaries.Flush.Total, ts, metadata.Counter, metadata.Flush, descFlushTotal)
-		Add(&md, "elastic.indices.flush.total_time", v.Primaries.Flush.TotalTimeInMillis, ts, metadata.Counter, metadata.MilliSecond, descFlushTotalTimeInMillis)
-		Add(&md, "elastic.indices.get.current", v.Primaries.Get.Current, ts, metadata.Gauge, metadata.Get, descGetCurrent)
-		Add(&md, "elastic.indices.get.exists_time", v.Primaries.Get.ExistsTimeInMillis, ts, metadata.Counter, metadata.GetExists, descGetExistsTimeInMillis)
-		Add(&md, "elastic.indices.get.exists_total", v.Primaries.Get.ExistsTotal, ts, metadata.Counter, metadata.GetExists, descGetExistsTotal)
-		Add(&md, "elastic.indices.get.missing_time", v.Primaries.Get.MissingTimeInMillis, ts, metadata.Counter, metadata.MilliSecond, descGetMissingTimeInMillis)
-		Add(&md, "elastic.indices.get.missing_total", v.Primaries.Get.MissingTotal, ts, metadata.Counter, metadata.Operation, descGetMissingTotal)
-		Add(&md, "elastic.indices.get.time", v.Primaries.Get.TimeInMillis, ts, metadata.Counter, metadata.MilliSecond, descGetTimeInMillis)
-		Add(&md, "elastic.indices.get.total", v.Primaries.Get.Total, ts, metadata.Counter, metadata.Get, descGetTotal)
-		Add(&md, "elastic.indices.id_cache.memory_size", v.Primaries.IDCache.MemorySizeInBytes, ts, metadata.Gauge, metadata.Bytes, descIDCacheMemorySizeInBytes)
-		Add(&md, "elastic.indices.indexing.delete_current", v.Primaries.Indexing.DeleteCurrent, ts, metadata.Gauge, metadata.Document, descIndexingDeleteCurrent)
-		Add(&md, "elastic.indices.indexing.delete_time", v.Primaries.Indexing.DeleteTimeInMillis, ts, metadata.Counter, metadata.MilliSecond, descIndexingDeleteTimeInMillis)
-		Add(&md, "elastic.indices.indexing.delete_total", v.Primaries.Indexing.DeleteTotal, ts, metadata.Counter, metadata.Document, descIndexingDeleteTotal)
-		Add(&md, "elastic.indices.indexing.index_current", v.Primaries.Indexing.IndexCurrent, ts, metadata.Gauge, metadata.Document, descIndexingIndexCurrent)
-		Add(&md, "elastic.indices.indexing.index_time", v.Primaries.Indexing.IndexTimeInMillis, ts, metadata.Counter, metadata.MilliSecond, descIndexingIndexTimeInMillis)
-		Add(&md, "elastic.indices.indexing.index_total", v.Primaries.Indexing.IndexTotal, ts, metadata.Counter, metadata.Document, descIndexingIndexTotal)
-		Add(&md, "elastic.indices.merges.current", v.Primaries.Merges.Current, ts, metadata.Gauge, metadata.Merge, descMergesCurrent)
-		Add(&md, "elastic.indices.merges.current_docs", v.Primaries.Merges.CurrentDocs, ts, metadata.Gauge, metadata.Document, descMergesCurrentDocs)
-		Add(&md, "elastic.indices.merges.current_size", v.Primaries.Merges.CurrentSizeInBytes, ts, metadata.Gauge, metadata.Document, descMergesCurrentSizeInBytes)
-		Add(&md, "elastic.indices.merges.total", v.Primaries.Merges.Total, ts, metadata.Counter, metadata.Merge, descMergesTotal)
-		Add(&md, "elastic.indices.merges.total_docs", v.Primaries.Merges.TotalDocs, ts, metadata.Counter, metadata.Document, descMergesTotalDocs)
-		Add(&md, "elastic.indices.merges.total_size", v.Primaries.Merges.TotalSizeInBytes, ts, metadata.Counter, metadata.Bytes, descMergesTotalSizeInBytes)
-		Add(&md, "elastic.indices.merges.total_time", v.Primaries.Merges.TotalTimeInMillis, ts, metadata.Counter, metadata.MilliSecond, descMergesTotalTimeInMillis)
-		Add(&md, "elastic.indices.percolate.current", v.Primaries.Percolate.Current, ts, metadata.Gauge, "", descPercolateCurrent)
-		Add(&md, "elastic.indices.percolate.memory_size", v.Primaries.Percolate.MemorySizeInBytes, ts, metadata.Gauge, metadata.Bytes, descPercolateMemorySizeInBytes)
-		Add(&md, "elastic.indices.percolate.queries", v.Primaries.Percolate.Queries, ts, metadata.Counter, metadata.Query, descPercolateQueries)
-		Add(&md, "elastic.indices.percolate.time", v.Primaries.Percolate.TimeInMillis, ts, metadata.Counter, metadata.MilliSecond, descPercolateTimeInMillis)
-		Add(&md, "elastic.indices.percolate.total", v.Primaries.Percolate.Total, ts, metadata.Gauge, metadata.Operation, descPercolateTotal)
-		Add(&md, "elastic.indices.refresh.total", v.Primaries.Refresh.Total, ts, metadata.Counter, metadata.Refresh, descRefreshTotal)
-		Add(&md, "elastic.indices.refresh.total_time", v.Primaries.Refresh.TotalTimeInMillis, ts, metadata.Counter, metadata.MilliSecond, descRefreshTotalTimeInMillis)
-		Add(&md, "elastic.indices.search.fetch_current", v.Primaries.Search.FetchCurrent, ts, metadata.Gauge, metadata.Document, descSearchFetchCurrent)
-		Add(&md, "elastic.indices.search.fetch_time", v.Primaries.Search.FetchTimeInMillis, ts, metadata.Counter, metadata.MilliSecond, descSearchFetchTimeInMillis)
-		Add(&md, "elastic.indices.search.fetch_total", v.Primaries.Search.FetchTotal, ts, metadata.Counter, metadata.Document, descSearchFetchTotal)
-		Add(&md, "elastic.indices.search.open_contexts", v.Primaries.Search.OpenContexts, ts, metadata.Gauge, metadata.Context, descSearchOpenContexts)
-		Add(&md, "elastic.indices.search.query_current", v.Primaries.Search.QueryCurrent, ts, metadata.Gauge, metadata.Query, descSearchQueryCurrent)
-		Add(&md, "elastic.indices.search.query_time", v.Primaries.Search.QueryTimeInMillis, ts, metadata.Counter, metadata.MilliSecond, descSearchQueryTimeInMillis)
-		Add(&md, "elastic.indices.search.query_total", v.Primaries.Search.QueryTotal, ts, metadata.Counter, metadata.Query, descSearchQueryTotal)
-		Add(&md, "elastic.indices.segments.count", v.Primaries.Segments.Count, ts, metadata.Counter, metadata.Segment, descSegmentsCount)
-		Add(&md, "elastic.indices.segments.memory", v.Primaries.Segments.MemoryInBytes, ts, metadata.Gauge, metadata.Bytes, descSegmentsMemoryInBytes)
-		Add(&md, "elastic.indices.store.size_in_bytes", v.Primaries.Store.SizeInBytes, ts, metadata.Gauge, metadata.Bytes, descStoreSizeInBytes)
-		Add(&md, "elastic.indices.store.throttle_time", v.Primaries.Store.ThrottleTimeInMillis, ts, metadata.Gauge, metadata.MilliSecond, descStoreThrottleTimeInMillis)
-		Add(&md, "elastic.indices.suggest.current", v.Primaries.Suggest.Current, ts, metadata.Gauge, metadata.Suggest, descSuggestCurrent)
-		Add(&md, "elastic.indices.suggest.time", v.Primaries.Suggest.TimeInMillis, ts, metadata.Counter, metadata.MilliSecond, descSuggestTimeInMillis)
-		Add(&md, "elastic.indices.suggest.total", v.Primaries.Suggest.Total, ts, metadata.Counter, metadata.Suggest, descSuggestTotal)
-		Add(&md, "elastic.indices.translog.operations", v.Primaries.Translog.Operations, ts, metadata.Counter, metadata.Operation, descTranslogOperations)
-		Add(&md, "elastic.indices.translog.size_in_bytes", v.Primaries.Translog.SizeInBytes, ts, metadata.Gauge, metadata.Bytes, descTranslogSizeInBytes)
-		Add(&md, "elastic.indices.warmer.current", v.Primaries.Warmer.Current, ts, metadata.Gauge, metadata.Operation, descWarmerCurrent)
-		Add(&md, "elastic.indices.warmer.total", v.Primaries.Warmer.Total, ts, metadata.Counter, metadata.Operation, descWarmerTotal)
-		Add(&md, "elastic.indices.warmer.total_time", v.Primaries.Warmer.TotalTimeInMillis, ts, metadata.Counter, metadata.MilliSecond, descWarmerTotalTimeInMillis)
-	}
-	return md, nil
 }
 
 func esReq(path, query string, v interface{}) error {
@@ -542,13 +227,190 @@ func esReq(path, query string, v interface{}) error {
 }
 
 func esStatsURL(version string) string {
-	if esPreV1.MatchString(version) {
+	if elasticPreV1.MatchString(version) {
 		return "/_cluster/nodes/_local/stats"
 	}
 	return "/_nodes/_local/stats"
 }
 
-type esStatus struct {
+type ElasticHealth struct {
+	ActivePrimaryShards         int                           `json:"active_primary_shards" desc:"The number of active primary shards. Each document is stored in a single primary shard and then when it is indexed it is copied the replicas of that shard."`
+	ActiveShards                int                           `json:"active_shards" desc:"The number of active shards."`
+	ActiveShardsPercentAsNumber int                           `json:"active_shards_percent_as_number" version:"2"` // 2.0 only
+	ClusterName                 string                        `json:"cluster_name"`
+	DelayedUnassignedShards     int                           `json:"delayed_unassigned_shards" version:"2"` // 2.0 only
+	Indices                     map[string]ElasticIndexHealth `json:"indices" exclude:"true"`
+	InitializingShards          int                           `json:"initializing_shards" desc:"The number of initalizing shards."`
+	NumberOfDataNodes           int                           `json:"number_of_data_nodes"`
+	NumberOfInFlightFetch       int                           `json:"number_of_in_flight_fetch" version:"2"` // 2.0 only
+	NumberOfNodes               int                           `json:"number_of_nodes"`
+	NumberOfPendingTasks        int                           `json:"number_of_pending_tasks"`
+	RelocatingShards            int                           `json:"relocating_shards" desc:"The number of shards relocating."`
+	Status                      string                        `json:"status" desc:"The current status of the cluster. 0: green, 1: yellow, 2: red."`
+	TaskMaxWaitingInQueueMillis int                           `json:"task_max_waiting_in_queue_millis" version:"2"` // 2.0 only
+	TimedOut                    bool                          `json:"timed_out" exclude:"true"`
+	UnassignedShards            int                           `json:"unassigned_shards" version:"2"` // 2.0 only
+}
+
+type ElasticIndexHealth struct {
+	ActivePrimaryShards int    `json:"active_primary_shards" desc:"The number of active primary shards. Each document is stored in a single primary shard and then when it is indexed it is copied the replicas of that shard."`
+	ActiveShards        int    `json:"active_shards" desc:"The number of active shards."`
+	InitializingShards  int    `json:"initializing_shards" desc:"The number of initalizing shards."`
+	NumberOfReplicas    int    `json:"number_of_replicas" desc:"The number of replicas."`
+	NumberOfShards      int    `json:"number_of_shards" desc:"The number of shards."`
+	RelocatingShards    int    `json:"relocating_shards" desc:"The number of shards relocating."`
+	Status              string `json:"status" desc:"The current status of the index. 0: green, 1: yellow, 2: red."`
+	UnassignedShards    int    `json:"unassigned_shards"`
+}
+
+type ElasticIndexStats struct {
+	All    ElasticIndex `json:"_all"`
+	Shards struct {
+		Failed     float64 `json:"failed"`
+		Successful float64 `json:"successful"`
+		Total      float64 `json:"total"`
+	} `json:"_shards"`
+	Indices map[string]ElasticIndex `json:"indices"`
+}
+
+type ElasticIndex struct {
+	Primaries ElasticIndexDetails `json:"primaries"`
+	Total     ElasticIndexDetails `json:"total"`
+}
+
+type ElasticIndexDetails struct {
+	Completion struct {
+		SizeInBytes int `json:"size_in_bytes" desc:"Size of the completion index (used for auto-complete functionallity)."`
+	} `json:"completion"`
+	Docs struct {
+		Count   int `json:"count" rate:"gauge" rate:"gauge" unit:"documents" desc:"The number of documents in the index."`
+		Deleted int `json:"deleted" rate:"gauge" unit:"documents" desc:"The number of deleted documents in the index."`
+	} `json:"docs"`
+	Fielddata struct {
+		Evictions         int `json:"evictions" rate:"counter" unit:"evictions" desc:"The number of cache evictions for field data."`
+		MemorySizeInBytes int `json:"memory_size_in_bytes" desc:"The amount of memory used for field data."`
+	} `json:"fielddata"`
+	FilterCache struct { // 1.0 only
+		Evictions         int `json:"evictions" version:"1" rate:"counter" unit:"evictions" desc:"The number of cache evictions for filter data."` // 1.0 only
+		MemorySizeInBytes int `json:"memory_size_in_bytes" version:"1" desc:"The amount of memory used for filter data."`                          // 1.0 only
+	} `json:"filter_cache"`
+	Flush struct {
+		Total             int `json:"total" rate:"counter" unit:"flushes" desc:"The number of flush operations. The flush process of an index basically frees memory from the index by flushing data to the index storage and clearing the internal transaction log."`
+		TotalTimeInMillis int `json:"total_time_in_millis" rate:"counter" unit:"seconds" desc:"The total amount of time spent on flush operations. The flush process of an index basically frees memory from the index by flushing data to the index storage and clearing the internal transaction log."`
+	} `json:"flush"`
+	Get struct {
+		Current             int `json:"current" rate:"gauge" unit:"gets" desc:"The current number of get operations. Gets get a typed JSON document from the index based on its id."`
+		ExistsTimeInMillis  int `json:"exists_time_in_millis" rate:"counter" unit:"seconds" desc:"The total amount of time spent on get exists operations. Gets exists sees if a document exists."`
+		ExistsTotal         int `json:"exists_total" rate:"counter" unit:"get exists" desc:"The total number of get exists operations. Gets exists sees if a document exists."`
+		MissingTimeInMillis int `json:"missing_time_in_millis" rate:"counter" unit:"seconds" desc:"The total amount of time spent trying to get documents that turned out to be missing."`
+		MissingTotal        int `json:"missing_total" rate:"counter" unit:"operations" desc:"The total number of operations that tried to get a document that turned out to be missing."`
+		TimeInMillis        int `json:"time_in_millis" rate:"counter" unit:"seconds" desc:"The total amount of time spent on get operations. Gets get a typed JSON document from the index based on its id."`
+		Total               int `json:"total" rate:"counter" unit:"operations" desc:"The total number of get operations. Gets get a typed JSON document from the index based on its id."`
+	} `json:"get"`
+	IDCache struct { // 1.0 only
+		MemorySizeInBytes int `json:"memory_size_in_bytes" version:"1" desc:"The size of the id cache."` // 1.0 only
+	} `json:"id_cache"`
+	Indexing struct {
+		DeleteCurrent        int  `json:"delete_current" rate:"gauge" unit:"documents" desc:"The current number of documents being deleted via indexing commands (such as a delete query)."`
+		DeleteTimeInMillis   int  `json:"delete_time_in_millis" rate:"counter" unit:"seconds" desc:"The time spent deleting documents."`
+		DeleteTotal          int  `json:"delete_total" rate:"counter" unit:"documents" desc:"The total number of documents deleted."`
+		IndexCurrent         int  `json:"index_current" rate:"gauge" unit:"documents" desc:"The current number of documents being indexed."`
+		IndexTimeInMillis    int  `json:"index_time_in_millis" rate:"counter" unit:"seconds" desc:"The total amount of time spent indexing documents."`
+		IndexTotal           int  `json:"index_total" rate:"counter" unit:"documents" desc:"The total number of documents indexed."`
+		IsThrottled          bool `json:"is_throttled" exclude:"true"`
+		NoopUpdateTotal      int  `json:"noop_update_total"`
+		ThrottleTimeInMillis int  `json:"throttle_time_in_millis"`
+	} `json:"indexing"`
+	Merges struct {
+		Current                    int `json:"current" rate:"gauge" unit:"merges" desc:"The current number of merge operations. In elastic Lucene segments are merged behind the scenes. It is possible these can impact search performance."`
+		CurrentDocs                int `json:"current_docs" rate:"gauge" unit:"documents" desc:"The current number of documents that have an underlying merge operation going on. In elastic Lucene segments are merged behind the scenes. It is possible these can impact search performance."`
+		CurrentSizeInBytes         int `json:"current_size_in_bytes" desc:"The current number of bytes being merged. In elastic Lucene segments are merged behind the scenes. It is possible these can impact search performance."`
+		Total                      int `json:"total" rate:"counter" unit:"merges" desc:"The total number of merges. In elastic Lucene segments are merged behind the scenes. It is possible these can impact search performance."`
+		TotalAutoThrottleInBytes   int `json:"total_auto_throttle_in_bytes" version:"2"` // 2.0 only
+		TotalDocs                  int `json:"total_docs" rate:"counter" unit:"documents" desc:"The total number of documents that have had an underlying merge operation. In elastic Lucene segments are merged behind the scenes. It is possible these can impact search performance."`
+		TotalSizeInBytes           int `json:"total_size_in_bytes" desc:"The total number of bytes merged. In elastic Lucene segments are merged behind the scenes. It is possible these can impact search performance."`
+		TotalStoppedTimeInMillis   int `json:"total_stopped_time_in_millis" version:"2"`   // 2.0 only
+		TotalThrottledTimeInMillis int `json:"total_throttled_time_in_millis" version:"2"` // 2.0 only
+		TotalTimeInMillis          int `json:"total_time_in_millis" rate:"counter" unit:"seconds" desc:"The total amount of time spent on merge operations. In elastic Lucene segments are merged behind the scenes. It is possible these can impact search performance."`
+	} `json:"merges"`
+	Percolate struct {
+		Current           int    `json:"current" rate:"gauge" unit:"operations" desc:"The current number of percolate operations."`
+		MemorySize        string `json:"memory_size"`
+		MemorySizeInBytes int    `json:"memory_size_in_bytes" desc:"The amount of memory used for the percolate index. Percolate is a reverse query to document operation."`
+		Queries           int    `json:"queries" rate:"counter" unit:"queries" desc:"The total number of percolate queries. Percolate is a reverse query to document operation."`
+		TimeInMillis      int    `json:"time_in_millis" rate:"counter" unit:"seconds" desc:"The total amount of time spent on percolating. Percolate is a reverse query to document operation."`
+		Total             int    `json:"total" rate:"gauge" unit:"operations" desc:"The total number of percolate operations. Percolate is a reverse query to document operation."`
+	} `json:"percolate"`
+	QueryCache struct {
+		CacheCount        int `json:"cache_count" version:"2"` // 2.0 only
+		CacheSize         int `json:"cache_size" version:"2"`  // 2.0 only
+		Evictions         int `json:"evictions"`
+		HitCount          int `json:"hit_count"`
+		MemorySizeInBytes int `json:"memory_size_in_bytes"`
+		MissCount         int `json:"miss_count"`
+		TotalCount        int `json:"total_count" version:"2"` // 2.0 only
+	} `json:"query_cache"`
+	Recovery struct {
+		CurrentAsSource      int `json:"current_as_source"`
+		CurrentAsTarget      int `json:"current_as_target"`
+		ThrottleTimeInMillis int `json:"throttle_time_in_millis"`
+	} `json:"recovery"`
+	Refresh struct {
+		Total             int `json:"total" rate:"counter" unit:"refresh" desc:"The total number of refreshes. Refreshing makes all operations performed since the last search available."`
+		TotalTimeInMillis int `json:"total_time_in_millis" rate:"counter" unit:"seconds" desc:"The total amount of time spent on refreshes. Refreshing makes all operations performed since the last search available."`
+	} `json:"refresh"`
+	RequestCache struct { // 2.0 only
+		Evictions         int `json:"evictions" version:"2"`            // 2.0 only
+		HitCount          int `json:"hit_count" version:"2"`            // 2.0 only
+		MemorySizeInBytes int `json:"memory_size_in_bytes" version:"2"` // 2.0 only
+		MissCount         int `json:"miss_count" version:"2"`           // 2.0 only
+	} `json:"request_cache"`
+	Search struct {
+		FetchCurrent       int `json:"fetch_current" rate:"gauge" unit:"documents" desc:"The current number of documents being fetched. Fetching is a phase of querying in a distributed search."`
+		FetchTimeInMillis  int `json:"fetch_time_in_millis" rate:"counter" unit:"seconds" desc:"The total time spent fetching documents. Fetching is a phase of querying in a distributed search."`
+		FetchTotal         int `json:"fetch_total" rate:"counter" unit:"documents" desc:"The total number of documents fetched. Fetching is a phase of querying in a distributed search."`
+		OpenContexts       int `json:"open_contexts" rate:"gauge" unit:"contexts" desc:"The current number of open contexts. A search is left open when srolling (i.e. pagination)."`
+		QueryCurrent       int `json:"query_current" rate:"gauge" unit:"queries" desc:"The current number of queries."`
+		QueryTimeInMillis  int `json:"query_time_in_millis" rate:"counter" unit:"seconds" desc:"The total amount of time spent querying."`
+		QueryTotal         int `json:"query_total" rate:"counter" unit:"queries" desc:"The total number of queries."`
+		ScrollCurrent      int `json:"scroll_current" version:"2"`        // 2.0 only
+		ScrollTimeInMillis int `json:"scroll_time_in_millis" version:"2"` // 2.0 only
+		ScrollTotal        int `json:"scroll_total" version:"2"`          // 2.0 only
+	} `json:"search"`
+	Segments struct {
+		Count                       int `json:"count" rate:"counter" unit:"segments" desc:"The number of segments that make up the index."`
+		DocValuesMemoryInBytes      int `json:"doc_values_memory_in_bytes" version:"2"` // 2.0 only
+		FixedBitSetMemoryInBytes    int `json:"fixed_bit_set_memory_in_bytes"`
+		IndexWriterMaxMemoryInBytes int `json:"index_writer_max_memory_in_bytes"`
+		IndexWriterMemoryInBytes    int `json:"index_writer_memory_in_bytes"`
+		MemoryInBytes               int `json:"memory_in_bytes" desc:"The total amount of memory used for Lucene segments."`
+		NormsMemoryInBytes          int `json:"norms_memory_in_bytes" version:"2"`         // 2.0 only
+		StoredFieldsMemoryInBytes   int `json:"stored_fields_memory_in_bytes" version:"2"` // 2.0 only
+		TermVectorsMemoryInBytes    int `json:"term_vectors_memory_in_bytes" version:"2"`  // 2.0 only
+		TermsMemoryInBytes          int `json:"terms_memory_in_bytes" version:"2"`         // 2.0 only
+		VersionMapMemoryInBytes     int `json:"version_map_memory_in_bytes"`
+	} `json:"segments"`
+	Store struct {
+		SizeInBytes          int `json:"size_in_bytes" unit:"bytes" desc:"The current size of the store."`
+		ThrottleTimeInMillis int `json:"throttle_time_in_millis" rate:"gauge" unit:"seconds" desc:"The amount of time that merges where throttled."`
+	} `json:"store"`
+	Suggest struct {
+		Current      int `json:"current" rate:"gauge" unit:"suggests" desc:"The current number of suggest operations."`
+		TimeInMillis int `json:"time_in_millis" rate:"gauge" unit:"seconds" desc:"The total amount of time spent on suggest operations."`
+		Total        int `json:"total" rate:"gauge" unit:"suggests" desc:"The total number of suggest operations."`
+	} `json:"suggest"`
+	Translog struct {
+		Operations  int `json:"operations" rate:"gauge" unit:"operations" desc:"The total number of translog operations. The transaction logs (or write ahead logs) ensure atomicity of operations."`
+		SizeInBytes int `json:"size_in_bytes" desc:"The current size of transaction log. The transaction log (or write ahead log) ensure atomicity of operations."`
+	} `json:"translog"`
+	Warmer struct {
+		Current           int `json:"current" rate:"gauge" unit:"operations" desc:"The current number of warmer operations. Warming registers search requests in the background to speed up actual search requests."`
+		Total             int `json:"total" rate:"gauge" unit:"operations" desc:"The total number of warmer operations. Warming registers search requests in the background to speed up actual search requests."`
+		TotalTimeInMillis int `json:"total_time_in_millis" rate:"gauge" unit:"seconds" desc:"The total time spent on warmer operations. Warming registers search requests in the background to speed up actual search requests."`
+	} `json:"warmer"`
+}
+
+type ElasticStatus struct {
 	Status  int    `json:"status"`
 	Name    string `json:"name"`
 	Version struct {
@@ -556,36 +418,233 @@ type esStatus struct {
 	} `json:"version"`
 }
 
-type esStats struct {
+type ElasticClusterStats struct {
 	ClusterName string `json:"cluster_name"`
 	Nodes       map[string]struct {
-		Indices   map[string]map[string]interface{} `json:"indices"`
-		Process   map[string]interface{}            `json:"process"`
-		JVM       map[string]interface{}            `json:"jvm"`
-		Network   map[string]interface{}            `json:"network"`
-		Transport map[string]interface{}            `json:"transport"`
-		HTTP      map[string]interface{}            `json:"http"`
+		Attributes struct {
+			Master string `json:"master"`
+		} `json:"attributes"`
+		Breakers struct {
+			Fielddata ElasticBreakersStat `json:"fielddata"`
+			Parent    ElasticBreakersStat `json:"parent"`
+			Request   ElasticBreakersStat `json:"request"`
+		} `json:"breakers" exclude:"true"`
+		FS struct {
+			Data []struct {
+				AvailableInBytes     int    `json:"available_in_bytes"`
+				Dev                  string `json:"dev" version:"1"`                      // 1.0 only
+				DiskIoOp             int    `json:"disk_io_op" version:"1"`               // 1.0 only
+				DiskIoSizeInBytes    int    `json:"disk_io_size_in_bytes" version:"1"`    // 1.0 only
+				DiskQueue            string `json:"disk_queue" version:"1"`               // 1.0 only
+				DiskReadSizeInBytes  int    `json:"disk_read_size_in_bytes" version:"1"`  // 1.0 only
+				DiskReads            int    `json:"disk_reads" version:"1"`               // 1.0 only
+				DiskServiceTime      string `json:"disk_service_time" version:"1"`        // 1.0 only
+				DiskWriteSizeInBytes int    `json:"disk_write_size_in_bytes" version:"1"` // 1.0 only
+				DiskWrites           int    `json:"disk_writes" version:"1"`              // 1.0 only
+				FreeInBytes          int    `json:"free_in_bytes"`
+				Mount                string `json:"mount"`
+				Path                 string `json:"path"`
+				TotalInBytes         int    `json:"total_in_bytes"`
+				Type                 string `json:"type" version:"2"` // 2.0 only
+			} `json:"data"`
+			Timestamp int `json:"timestamp"`
+			Total     struct {
+				AvailableInBytes     int    `json:"available_in_bytes"`
+				DiskIoOp             int    `json:"disk_io_op" version:"1"`               // 1.0 only
+				DiskIoSizeInBytes    int    `json:"disk_io_size_in_bytes" version:"1"`    // 1.0 only
+				DiskQueue            string `json:"disk_queue" version:"1"`               // 1.0 only
+				DiskReadSizeInBytes  int    `json:"disk_read_size_in_bytes" version:"1"`  // 1.0 only
+				DiskReads            int    `json:"disk_reads" version:"1"`               // 1.0 only
+				DiskServiceTime      string `json:"disk_service_time" version:"1"`        // 1.0 only
+				DiskWriteSizeInBytes int    `json:"disk_write_size_in_bytes" version:"1"` // 1.0 only
+				DiskWrites           int    `json:"disk_writes" version:"1"`              // 1.0 only
+				FreeInBytes          int    `json:"free_in_bytes"`
+				TotalInBytes         int    `json:"total_in_bytes"`
+			} `json:"total"`
+		} `json:"fs" exclude:"true"`
+		Host string `json:"host"`
+		HTTP struct {
+			CurrentOpen int `json:"current_open"`
+			TotalOpened int `json:"total_opened"`
+		} `json:"http"`
+		Indices ElasticIndexDetails `json:"indices" exclude:"true"` // Stored under elastic.indices.local namespace.
+		IP      []string            `json:"ip" exclude:"true"`
+		JVM     struct {
+			BufferPools struct {
+				Direct struct {
+					Count                int `json:"count"`
+					TotalCapacityInBytes int `json:"total_capacity_in_bytes"`
+					UsedInBytes          int `json:"used_in_bytes"`
+				} `json:"direct"`
+				Mapped struct {
+					Count                int `json:"count"`
+					TotalCapacityInBytes int `json:"total_capacity_in_bytes"`
+					UsedInBytes          int `json:"used_in_bytes"`
+				} `json:"mapped"`
+			} `json:"buffer_pools"`
+			Classes struct { // 2.0 only
+				CurrentLoadedCount int `json:"current_loaded_count" version:"2"` // 2.0 only
+				TotalLoadedCount   int `json:"total_loaded_count" version:"2"`   // 2.0 only
+				TotalUnloadedCount int `json:"total_unloaded_count" version:"2"` // 2.0 only
+			} `json:"classes"`
+			GC struct {
+				Collectors struct {
+					Old struct {
+						CollectionCount        int `json:"collection_count"`
+						CollectionTimeInMillis int `json:"collection_time_in_millis"`
+					} `json:"old"`
+					Young struct {
+						CollectionCount        int `json:"collection_count"`
+						CollectionTimeInMillis int `json:"collection_time_in_millis"`
+					} `json:"young"`
+				} `json:"collectors"`
+			} `json:"gc" exclude:"true"` // This is recorded manually so we can tag the GC collector type.
+			Mem struct {
+				HeapCommittedInBytes    int `json:"heap_committed_in_bytes" metric:"heap_committed"`
+				HeapMaxInBytes          int `json:"heap_max_in_bytes"`
+				HeapUsedInBytes         int `json:"heap_used_in_bytes" metric:"heap_used"`
+				HeapUsedPercent         int `json:"heap_used_percent"`
+				NonHeapCommittedInBytes int `json:"non_heap_committed_in_bytes"`
+				NonHeapUsedInBytes      int `json:"non_heap_used_in_bytes"`
+				Pools                   struct {
+					Old struct {
+						MaxInBytes      int `json:"max_in_bytes"`
+						PeakMaxInBytes  int `json:"peak_max_in_bytes"`
+						PeakUsedInBytes int `json:"peak_used_in_bytes"`
+						UsedInBytes     int `json:"used_in_bytes"`
+					} `json:"old"`
+					Survivor struct {
+						MaxInBytes      int `json:"max_in_bytes"`
+						PeakMaxInBytes  int `json:"peak_max_in_bytes"`
+						PeakUsedInBytes int `json:"peak_used_in_bytes"`
+						UsedInBytes     int `json:"used_in_bytes"`
+					} `json:"survivor"`
+					Young struct {
+						MaxInBytes      int `json:"max_in_bytes"`
+						PeakMaxInBytes  int `json:"peak_max_in_bytes"`
+						PeakUsedInBytes int `json:"peak_used_in_bytes"`
+						UsedInBytes     int `json:"used_in_bytes"`
+					} `json:"young"`
+				} `json:"pools" exclude:"true"`
+			} `json:"mem"`
+			Threads struct {
+				Count     int `json:"count"`
+				PeakCount int `json:"peak_count"`
+			} `json:"threads"`
+			Timestamp      int `json:"timestamp"`
+			UptimeInMillis int `json:"uptime_in_millis"`
+		} `json:"jvm"`
+		Name    string   `json:"name"`
+		Network struct { // 1.0 only
+			TCP struct { // 1.0 only
+				ActiveOpens  int `json:"active_opens" version:"1"`  // 1.0 only
+				AttemptFails int `json:"attempt_fails" version:"1"` // 1.0 only
+				CurrEstab    int `json:"curr_estab" version:"1"`    // 1.0 only
+				EstabResets  int `json:"estab_resets" version:"1"`  // 1.0 only
+				InErrs       int `json:"in_errs" version:"1"`       // 1.0 only
+				InSegs       int `json:"in_segs" version:"1"`       // 1.0 only
+				OutRsts      int `json:"out_rsts" version:"1"`      // 1.0 only
+				OutSegs      int `json:"out_segs" version:"1"`      // 1.0 only
+				PassiveOpens int `json:"passive_opens" version:"1"` // 1.0 only
+				RetransSegs  int `json:"retrans_segs" version:"1"`  // 1.0 only
+			} `json:"tcp"`
+		} `json:"network"`
+		OS struct {
+			CPU struct { // 1.0 only
+				Idle   int `json:"idle" version:"1"`   // 1.0 only
+				Stolen int `json:"stolen" version:"1"` // 1.0 only
+				Sys    int `json:"sys" version:"1"`    // 1.0 only
+				Usage  int `json:"usage" version:"1"`  // 1.0 only
+				User   int `json:"user" version:"1"`   // 1.0 only
+			} `json:"cpu"`
+			//			LoadAverage []float64 `json:"load_average"` // 1.0 only
+			//			LoadAverage float64 `json:"load_average"` // 2.0 only
+			Mem struct {
+				ActualFreeInBytes int `json:"actual_free_in_bytes" version:"1"` // 1.0 only
+				ActualUsedInBytes int `json:"actual_used_in_bytes" version:"1"` // 1.0 only
+				FreeInBytes       int `json:"free_in_bytes"`
+				FreePercent       int `json:"free_percent"`
+				TotalInBytes      int `json:"total_in_bytes" version:"2"` // 2.0 only
+				UsedInBytes       int `json:"used_in_bytes"`
+				UsedPercent       int `json:"used_percent"`
+			} `json:"mem"`
+			Swap struct {
+				FreeInBytes  int `json:"free_in_bytes"`
+				TotalInBytes int `json:"total_in_bytes" version:"2"` // 2.0 only
+				UsedInBytes  int `json:"used_in_bytes"`
+			} `json:"swap"`
+			Timestamp      int `json:"timestamp"`
+			UptimeInMillis int `json:"uptime_in_millis"`
+		} `json:"os" exclude:"true"` // These are OS-wide stats, and are already gathered by other collectors.
+		Process struct {
+			CPU struct {
+				Percent       int `json:"percent" exclude:"true"`
+				SysInMillis   int `json:"sys_in_millis" version:"1"` // 1.0 only
+				TotalInMillis int `json:"total_in_millis"`
+				UserInMillis  int `json:"user_in_millis" version:"1"` // 1.0 only
+			} `json:"cpu"`
+			MaxFileDescriptors int `json:"max_file_descriptors" version:"2"` // 2.0 only
+			Mem                struct {
+				ResidentInBytes     int `json:"resident_in_bytes" metric:"resident" version:"1"` // 1.0 only
+				ShareInBytes        int `json:"share_in_bytes" metric:"shared" version:"1"`      // 1.0 only
+				TotalVirtualInBytes int `json:"total_virtual_in_bytes" metric:"total_virtual"`
+			} `json:"mem"`
+			OpenFileDescriptors int `json:"open_file_descriptors"`
+			Timestamp           int `json:"timestamp" exclude:"true"`
+		} `json:"process"`
+		Script struct { // 2.0 only
+			CacheEvictions int `json:"cache_evictions" version:"2"` // 2.0 only
+			Compilations   int `json:"compilations" version:"2"`    // 2.0 only
+		} `json:"script"`
+		ThreadPool struct {
+			Bulk              ElasticThreadPoolStat `json:"bulk"`
+			FetchShardStarted ElasticThreadPoolStat `json:"fetch_shard_started" version:"2"` // 2.0 only
+			FetchShardStore   ElasticThreadPoolStat `json:"fetch_shard_store" version:"2"`   // 2.0 only
+			Flush             ElasticThreadPoolStat `json:"flush"`
+			Generic           ElasticThreadPoolStat `json:"generic"`
+			Get               ElasticThreadPoolStat `json:"get"`
+			Index             ElasticThreadPoolStat `json:"index"`
+			Listener          ElasticThreadPoolStat `json:"listener"`
+			Management        ElasticThreadPoolStat `json:"management"`
+			Merge             ElasticThreadPoolStat `json:"merge" version:"1"` // 1.0 only
+			Optimize          ElasticThreadPoolStat `json:"optimize"`
+			Percolate         ElasticThreadPoolStat `json:"percolate"`
+			Refresh           ElasticThreadPoolStat `json:"refresh"`
+			Search            ElasticThreadPoolStat `json:"search"`
+			Snapshot          ElasticThreadPoolStat `json:"snapshot"`
+			Suggest           ElasticThreadPoolStat `json:"suggest"`
+			Warmer            ElasticThreadPoolStat `json:"warmer"`
+		} `json:"thread_pool" exclude:"true"`
+		Timestamp int `json:"timestamp"`
+		Transport struct {
+			RxCount       int `json:"rx_count"`
+			RxSizeInBytes int `json:"rx_size_in_bytes"`
+			ServerOpen    int `json:"server_open"`
+			TxCount       int `json:"tx_count"`
+			TxSizeInBytes int `json:"tx_size_in_bytes"`
+		} `json:"transport"`
+		TransportAddress string `json:"transport_address"`
 	} `json:"nodes"`
 }
 
-type esClusterState struct {
-	MasterNode string `json:"master_node"`
+type ElasticThreadPoolStat struct {
+	Active    int `json:"active"`
+	Completed int `json:"completed"`
+	Largest   int `json:"largest"`
+	Queue     int `json:"queue"`
+	Rejected  int `json:"rejected"`
+	Threads   int `json:"threads"`
 }
 
-func divInterfaceFlt(a, b interface{}) (float64, error) {
-	af, ok := a.(float64)
-	if !ok {
-		return 0, errors.New("elasticsearch: expected float64")
-	}
-	bf, ok := b.(float64)
-	if !ok {
-		return 0, errors.New("elasticsearch: expected float64")
-	}
-	r := af / bf
-	if math.IsNaN(r) {
-		return 0, errors.New("elasticsearch: got NaN")
-	} else if math.IsInf(r, 0) {
-		return 0, errors.New("elasticsearch: got Inf")
-	}
-	return r, nil
+type ElasticBreakersStat struct {
+	EstimatedSize        string  `json:"estimated_size"`
+	EstimatedSizeInBytes int     `json:"estimated_size_in_bytes"`
+	LimitSize            string  `json:"limit_size"`
+	LimitSizeInBytes     int     `json:"limit_size_in_bytes"`
+	Overhead             float64 `json:"overhead"`
+	Tripped              int     `json:"tripped"`
+}
+
+type ElasticClusterState struct {
+	MasterNode string `json:"master_node"`
 }

--- a/cmd/scollector/main.go
+++ b/cmd/scollector/main.go
@@ -131,9 +131,6 @@ func main() {
 			check(collectors.HTTPUnitHiera(h.Hiera))
 		}
 	}
-	for _, r := range conf.ElasticIndexFilters {
-		check(collectors.AddElasticIndexFilter(r))
-	}
 	for _, r := range conf.Riak {
 		check(collectors.Riak(r.URL))
 	}


### PR DESCRIPTION
This change refactors much of the collector, and also makes it compatible with ElasticSearch 2.

Notable changes:
* All of the JSON we use has been struct-ified.
* Metric metadata and descriptions have been placed into the struct field tags.
* Metrics which are version-specific have been denoted in field tags, and are conditionally sent based on those tags and what version of Elastic we're hitting.
* Namespaces of the metrics have been rearranged to make more intuitive sense.
    * Previously local-node index stats were stuck right on `elastic.`, while cluster-white index stats were stuck in `elastic.indices.`. These have been moved to `elastic.indices.local` and `elastic.indices.cluster`, respectively.
    * Health-related stats have been moved into `elastic.health`.
* Previously we had a mix of millisecond and second metric values. All metric values are now consistently in seconds.

:eyeglasses: @captncraig @gbrayut 