### PR TITLE
c_keepalived: Add new SNMP entry so we work with new keepalived 1.2.19,  and fix off-by-one bug.

### DIFF
--- a/cmd/scollector/collectors/keepalived_linux.go
+++ b/cmd/scollector/collectors/keepalived_linux.go
@@ -86,7 +86,7 @@ func c_snmp_keepalived_vrrp_instances() (opentsdb.MultiDataPoint, error) {
 		}
 		s := reflect.ValueOf(entry)
 		nFields := reflect.ValueOf(*entry).NumField()
-		if id[0]+1 > nFields {
+		if id[0] > nFields {
 			return nil, fmt.Errorf("unexpected number of fields for snmp keepalived VRRPInstanceTable")
 		}
 		v := s.Elem().Field(id[0] - 1)

--- a/cmd/scollector/collectors/keepalived_linux.go
+++ b/cmd/scollector/collectors/keepalived_linux.go
@@ -38,6 +38,7 @@ type VRRPInstanceEntry struct {
 	VInstanceScriptFault       string
 	VInstanceScriptStop        string
 	VInstanceScript            string
+	VInstanceAccept            int64
 }
 
 const (


### PR DESCRIPTION
:eyeglasses:  @captncraig  @gbrayut @kylebrandt 