### PR TITLE
cmd/scollector: c_procstats_linux: Add buffered and cached memory usage to os.mem.free.

### DIFF
--- a/cmd/scollector/collectors/procstats_linux.go
+++ b/cmd/scollector/collectors/procstats_linux.go
@@ -68,7 +68,7 @@ func c_procstats_linux() (opentsdb.MultiDataPoint, error) {
 		Error = err
 	}
 	Add(&md, osMemTotal, int(mem["MemTotal"])*1024, nil, metadata.Gauge, metadata.Bytes, osMemTotalDesc)
-	Add(&md, osMemFree, int(mem["MemFree"])*1024, nil, metadata.Gauge, metadata.Bytes, osMemFreeDesc)
+	Add(&md, osMemFree, (int(mem["MemFree"])+int(mem["Buffers"])+int(mem["Cached"]))*1024, nil, metadata.Gauge, metadata.Bytes, osMemFreeDesc)
 	Add(&md, osMemUsed, (int(mem["MemTotal"])-(int(mem["MemFree"])+int(mem["Buffers"])+int(mem["Cached"])))*1024, nil, metadata.Gauge, metadata.Bytes, osMemUsedDesc)
 	if mem["MemTotal"] != 0 {
 		Add(&md, osMemPctFree, (mem["MemFree"]+mem["Buffers"]+mem["Cached"])/mem["MemTotal"]*100, nil, metadata.Gauge, metadata.Pct, osMemFreeDesc)


### PR DESCRIPTION

This makes os.mem.free match how os.mem.percent_free works for linux.

:eyeglasses: @kylebrandt  @gbrayut 