### PR TITLE
cmd/bosun: Added missing bracket in dev.sample.conf

### DIFF
--- a/cmd/bosun/dev.sample.conf
+++ b/cmd/bosun/dev.sample.conf
@@ -51,7 +51,7 @@ alert example.opentsdb.os.high.cpu {
 
 alert example.influx.os.high.cpu {
         $db = "opentsdb"
-        $q = avg(influx($db, '''select derivative(mean(value), 1s) from "os.cpu" GROUP BY host''', "2m", "", "15s")
+        $q = avg(influx($db, '''select derivative(mean(value), 1s) from "os.cpu" GROUP BY host''', "2m", "", "15s"))
         warn = $q > 20
         crit = $q >= 1
 }


### PR DESCRIPTION
Avg call in macro example.influx.os.high.cpu is missing a closing bracket. Added it. 