### PR TITLE
cmd/scollector: Extend cfstats collector to consume sstables level info

### DIFF
--- a/cmd/scollector/collectors/cassandra_unix.go
+++ b/cmd/scollector/collectors/cassandra_unix.go
@@ -3,12 +3,15 @@
 package collectors
 
 import (
+	"strconv"
 	"strings"
 
 	"bosun.org/metadata"
 	"bosun.org/opentsdb"
 	"bosun.org/util"
 )
+
+type MetricSet map[string]string
 
 func init() {
 	collectors = append(collectors, &IntervalCollector{F: c_nodestats_cfstats_linux})
@@ -31,22 +34,59 @@ func c_nodestats_cfstats_linux() (opentsdb.MultiDataPoint, error) {
 			table = fields[1]
 			return nil
 		}
+
+		tagset := make(opentsdb.TagSet)
+		metricset := make(MetricSet)
+
+		if table != "" {
+			tagset["table"] = table
+		}
+		if keyspace != "" {
+			tagset["keyspace"] = keyspace
+		}
+
 		metric := strings.Replace(fields[0], " ", "_", -1)
 		metric = strings.Replace(metric, "(", "", -1)
 		metric = strings.Replace(metric, ")", "", -1)
 		metric = strings.Replace(metric, ",", "", -1)
 		metric = strings.ToLower(metric)
+
+		/*  This is to handle lines like "SSTables in each level: [31/4, 0, 0, 0, 0, 0, 0, 0]"
+		sstables_in_each_level format (BNF):
+		     <count>         ::= <integer>
+		     <max_threshold> ::= <integer>
+		     <exceeded>      ::= <count> "/" <max_threshold>
+		     <level_item>    ::= <count>|<exceeded>
+		     <list_item>     ::= <level_item> "," " " | <level_item>
+		     <list>          ::= <list_item> | <list_item> <list>
+		     <per_level>     ::= "[" <list> "]"
+		*/
+		if metric == "sstables_in_each_level" {
+			fields[1] = strings.Replace(fields[1], "[", "", -1)
+			fields[1] = strings.Replace(fields[1], "]", "", -1)
+			per_level := strings.Split(fields[1], ", ")
+			for index, count := range per_level {
+				metricset["cassandra.tables.sstables_in_level_"+strconv.Itoa(index)] = strings.Split(count, "/")[0]
+			}
+			submitMetrics(&md, metricset, tagset)
+			return nil
+		}
+
+		// every other value is simpler, and we only want the first word
 		values := strings.Fields(fields[1])
 		if values[0] == "NaN" {
 			return nil
 		}
-		value := values[0]
-		if table == "" {
-			Add(&md, "cassandra.tables."+metric, value, opentsdb.TagSet{"keyspace": keyspace}, metadata.Unknown, metadata.None, "")
-		} else {
-			Add(&md, "cassandra.tables."+metric, value, opentsdb.TagSet{"keyspace": keyspace, "table": table}, metadata.Unknown, metadata.None, "")
-		}
+		metricset["cassandra.tables."+metric] = values[0]
+
+		submitMetrics(&md, metricset, tagset)
 		return nil
 	}, "nodetool", "cfstats")
 	return md, nil
+}
+
+func submitMetrics(md *opentsdb.MultiDataPoint, metricset MetricSet, tagset opentsdb.TagSet) {
+	for m, v := range metricset {
+		Add(md, m, v, tagset, metadata.Unknown, metadata.None, "")
+	}
 }


### PR DESCRIPTION
Fixes bosun-monitor/bosun#1547

This also refactors the logic to permit maps of metrics when handling multiple values in a single line (as the "SSTables in each level" line does).