### PR TITLE
scollector: generic tag override by collector

### DIFF
--- a/cmd/scollector/collectors/interval.go
+++ b/cmd/scollector/collectors/interval.go
@@ -26,6 +26,8 @@ type IntervalCollector struct {
 	// internal use
 	sync.Mutex
 	enabled bool
+
+	TagOverride
 }
 
 func (c *IntervalCollector) Init() {
@@ -68,6 +70,7 @@ func (c *IntervalCollector) Run(dpchan chan<- *opentsdb.DataPoint, quit <-chan s
 				Add(&md, "scollector.collector.error", result, tags, metadata.Gauge, metadata.Ok, "Status of collector run. 1=Error, 0=Success.")
 			}
 			for _, dp := range md {
+				c.ApplyTagOverrides(dp.Tags)
 				dpchan <- dp
 			}
 		}

--- a/cmd/scollector/collectors/program.go
+++ b/cmd/scollector/collectors/program.go
@@ -22,6 +22,8 @@ import (
 type ProgramCollector struct {
 	Path     string
 	Interval time.Duration
+
+	TagOverride
 }
 
 func InitPrograms(cpath string) {
@@ -152,6 +154,7 @@ func (c *ProgramCollector) runProgram(dpchan chan<- *opentsdb.DataPoint) (progEr
 				dp.Tags = opentsdb.TagSet{}
 			}
 			setExternalTags(dp.Tags)
+			c.ApplyTagOverrides(dp.Tags)
 			dpchan <- &dp
 			continue
 		} else {

--- a/cmd/scollector/collectors/stream.go
+++ b/cmd/scollector/collectors/stream.go
@@ -18,6 +18,8 @@ type StreamCollector struct {
 	F    func() <-chan *opentsdb.MultiDataPoint
 	name string
 	init func()
+
+	TagOverride
 }
 
 func (s *StreamCollector) Init() {
@@ -41,6 +43,7 @@ func (s *StreamCollector) Run(dpchan chan<- *opentsdb.DataPoint, quit <-chan str
 				if _, found := dp.Tags["host"]; !found {
 					dp.Tags["host"] = util.Hostname
 				}
+				s.ApplyTagOverrides(dp.Tags)
 				dpchan <- dp
 				count++
 			}

--- a/cmd/scollector/collectors/tag_override.go
+++ b/cmd/scollector/collectors/tag_override.go
@@ -1,0 +1,64 @@
+package collectors
+
+import (
+	"fmt"
+	"regexp"
+
+	"bosun.org/opentsdb"
+)
+
+type TagOverride struct {
+	matchedTags map[string]*regexp.Regexp
+	tags        opentsdb.TagSet
+}
+
+func (to *TagOverride) AddTagOverrides(sources map[string]string, t opentsdb.TagSet) error {
+	if to.matchedTags == nil {
+		to.matchedTags = make(map[string]*regexp.Regexp)
+	}
+	var err error
+	for tag, re := range sources {
+		to.matchedTags[tag], err = regexp.Compile(re)
+		if err != nil {
+			return fmt.Errorf("invalid regexp: %s error: %s", re, err)
+		}
+	}
+
+	if to.tags == nil {
+		to.tags = t.Copy()
+	} else {
+		to.tags = to.tags.Merge(t)
+	}
+
+	return nil
+}
+
+func (to *TagOverride) ApplyTagOverrides(t opentsdb.TagSet) {
+	namedMatchGroup := make(map[string]string)
+	for tag, re := range to.matchedTags {
+		if v, ok := t[tag]; ok {
+			matches := re.FindStringSubmatch(v)
+
+			if len(matches) > 1 {
+				for i, match := range matches[1:] {
+					matchedTag := re.SubexpNames()[i+1]
+					if match != "" && matchedTag != "" {
+						namedMatchGroup[matchedTag] = match
+					}
+				}
+			}
+		}
+	}
+
+	for tag, v := range namedMatchGroup {
+		t[tag] = v
+	}
+
+	for tag, v := range to.tags {
+		if v == "" {
+			delete(t, tag)
+		} else {
+			t[tag] = v
+		}
+	}
+}

--- a/cmd/scollector/conf/conf.go
+++ b/cmd/scollector/conf/conf.go
@@ -62,6 +62,7 @@ type Conf struct {
 	RedisCounters       []RedisCounters
 	ExtraHop            []ExtraHop
 	LocalListener       string
+	TagOverride         []TagOverride
 }
 
 type HAProxy struct {
@@ -182,4 +183,10 @@ type ExtraHop struct {
 	APIKey        string
 	FilterBy      string
 	FilterPercent int
+}
+
+type TagOverride struct {
+	CollectorExpr string
+	MatchedTags   map[string]string
+	Tags          map[string]string
 }

--- a/cmd/scollector/doc.go
+++ b/cmd/scollector/doc.go
@@ -275,6 +275,22 @@ metrics.
 
 	LocalListener = "localhost:4242"
 
+TagOverride (array of tables, key are CollectorExpr, MatchedTags and Tags): if a collector
+name matches CollectorExpr MatchedTags and Tags will be merged to all outgoing message
+produced by the collector, in that order. MatchedTags will apply a regexp to the tag
+defined by the key name and add tags based on the named match groups defined in the
+regexp. After tags defined in Tags will be merged, defining a tag as empty string
+will deletes it.
+
+	[[TagOverride]]
+	  CollectorExpr = 'cadvisor'
+	  [TagOverride.MatchedTags]
+	    docker_name = 'k8s_(?P<container_name>[^\.]+)\.[0-9a-z]+_(?P<pod_name>[^-]+)'
+	    docker_id = '^(?P<docker_id>.{12})'
+	  [TagOverride.Tags]
+	    docker_name = ''
+	    source = 'kubelet'
+
 Windows
 
 scollector has full Windows support. It can be run standalone, or installed as a

--- a/cmd/scollector/main.go
+++ b/cmd/scollector/main.go
@@ -160,6 +160,10 @@ func main() {
 	for _, col := range c {
 		col.Init()
 	}
+	err = collectors.AddTagOverrides(c, conf.TagOverride)
+	if err != nil {
+		slog.Fatalf("Error adding tag overrides: %s", err)
+	}
 	u, err := parseHost(conf.Host)
 	if *flagList {
 		list(c)


### PR DESCRIPTION
This is a feature to extract/overwrite/delete tags produced by a collector. In most collectors there isn't much value in this but when we do not have full control of that data within scollector or if it the wanted behavior might change between organizations I think this is useful. We use this internally on both the snmp collector and cadvisor which I'll use as example.

In the case of the snmp collectors, using collector name matching we add equipment type and datacenter as tag. snmp collector names follow the snmp-<hostname> pattern which makes it pretty easy to achieve (assuming sane hostnames).

For cadvisor we extract container, podname and container id from the encoded kubernetes name which makes aggregated data actually usable. From doc.go:

```
TagOverride (array of tables, key are CollectorExpr, MatchedTags and Tags): if a collector
name matches CollectorExpr MatchedTags and Tags will be merged to all outgoing message
produced by the collector, in that order. MatchedTags will apply a regexp to the tag
defined by the key name and add tags based on the named match groups defined in the
regexp. After that tags defined in Tags will be merged. Defining a tag as empty string
will delete it.

[[TagOverride]]
	  CollectorExpr = 'cadvisor'
	  [[MatchedTags]]
	    docker_name = 'k8s_(?P<container_name>[^\.]+)\.[0-9a-z]+_(?P<pod_name>[^-]+)'
	    docker_id = '^(?P<docker_id>.{12})'
	  [[Tags]]
	    docker_name = ''
	    source = 'kubelet'
```

Let me know what you think