### PR TITLE
cmd/scollector: Change Linux process monitoring to use regex for Comm…

### DIFF
--- a/cmd/scollector/collectors/processes_linux.go
+++ b/cmd/scollector/collectors/processes_linux.go
@@ -280,7 +280,7 @@ func NewWatchedProc(params conf.ProcessParams) (*WatchedProc, error) {
 		return nil, fmt.Errorf("bad process name: %v", params.Name)
 	}
 	return &WatchedProc{
-		Command:      params.Command,
+		Command:      regexp.MustCompile(params.Command),
 		Name:         params.Name,
 		IncludeCount: params.IncludeCount,
 		Processes:    make(map[string]int),
@@ -290,7 +290,7 @@ func NewWatchedProc(params conf.ProcessParams) (*WatchedProc, error) {
 }
 
 type WatchedProc struct {
-	Command      string
+	Command      *regexp.Regexp
 	Name         string
 	IncludeCount bool
 	Processes    map[string]int
@@ -304,7 +304,7 @@ func (w *WatchedProc) Check(procs []*Process) {
 		if _, ok := w.Processes[l.Pid]; ok {
 			continue
 		}
-		if !strings.Contains(l.Command, w.Command) {
+		if !w.Command.MatchString(l.Command) {
 			continue
 		}
 		if !w.ArgMatch.MatchString(l.Arguments) {

--- a/cmd/scollector/collectors/systemd_linux.go
+++ b/cmd/scollector/collectors/systemd_linux.go
@@ -112,7 +112,7 @@ func watchSystemdServiceProc(md *opentsdb.MultiDataPoint, conn *dbus.Conn, unit 
 	}
 
 	wp := WatchedProc{
-		Command:   cmdline[0],
+		Command:   regexp.MustCompile("^" + regexp.QuoteMeta(cmdline[0]) + "$"),
 		Name:      strings.TrimSuffix(unit.Name, ".service"),
 		Processes: make(map[string]int),
 		ArgMatch:  regexp.MustCompile(""),


### PR DESCRIPTION
…and argument

This may impact anyone monitoring a process where the command includes a regex reserved character.
In that case you should change your toml config to use ' instead of " and escape the character using \
Example:

[[Process]]
  Command = "/usr/bin/redis-server *:16389"
  Name = "redis-bosun-dev"

needs to escape the * since that is a regex reserved character

[[Process]]
  Command = '/usr/bin/redis-server \\*:16389'
  Name = "redis-bosun-dev"

if you use " instead of ' the escape would be "redis-server \\\\*:16389"