### PR TITLE
cmd/scollector: Configurable MaxQueueLen

### DIFF
--- a/cmd/scollector/conf/conf.go
+++ b/cmd/scollector/conf/conf.go
@@ -23,6 +23,8 @@ type Conf struct {
 	Freq int
 	// BatchSize is the number of metrics that will be sent in each batch.
 	BatchSize int
+	// MaxQueueLen is the number of metrics keept internally.
+	MaxQueueLen int
 	// Filter filters collectors matching these terms.
 	Filter []string
 	// PProf is an IP:Port binding to be used for debugging with pprof package.

--- a/cmd/scollector/doc.go
+++ b/cmd/scollector/doc.go
@@ -99,6 +99,9 @@ Freq (integer): is the default frequency in seconds for most collectors.
 BatchSize (integer): is the number of metrics that will be sent in each batch.
 Default is 500.
 
+MaxQueueLen (integer): is the number of metrics keept internally.
+Default is 200000.
+
 Filter (array of string): filters collectors matching these terms.
 
 MetricFilters (array of string): filters metrics matching these regular

--- a/cmd/scollector/main.go
+++ b/cmd/scollector/main.go
@@ -215,6 +215,14 @@ func main() {
 	if *flagBatchSize > 0 {
 		collect.BatchSize = *flagBatchSize
 	}
+
+	if conf.MaxQueueLen < collect.BatchSize {
+		slog.Fatalf("MaxQueueLen must be >= %d (BatchSize)", collect.BatchSize)
+	}
+	if conf.MaxQueueLen != 0 {
+		collect.MaxQueueLen = conf.MaxQueueLen
+	}
+
 	go func() {
 		const maxMem = 500 * 1024 * 1024 // 500MB
 		var m runtime.MemStats


### PR DESCRIPTION
This adds MaxQueueLen as option in the config file. If undefined it keeps the current default of 200000. If defined it must be greater or equal than the batch size.