### PR TITLE
cmd/bosun: fixing empty email body, and handling absence better

### DIFF
--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -302,8 +302,13 @@ func (s *Schedule) executeTemplates(state *models.IncidentState, event *models.E
 		}
 		state.Subject = string(subject)
 		state.Body = string(body)
-		state.EmailBody = emailbody
-		state.EmailSubject = emailsubject
+		//don't save email seperately if they are identical
+		if string(state.EmailBody) != state.Body {
+			state.EmailBody = emailbody
+		}
+		if string(state.EmailSubject) != state.Subject {
+			state.EmailSubject = emailsubject
+		}
 		state.Attachments = attachments
 	}
 }

--- a/cmd/bosun/sched/notify.go
+++ b/cmd/bosun/sched/notify.go
@@ -183,6 +183,12 @@ var unknownMultiGroup = ttemplate.Must(ttemplate.New("unknownMultiGroup").Parse(
 	`))
 
 func (s *Schedule) notify(st *models.IncidentState, n *conf.Notification) {
+	if len(st.EmailSubject) == 0 {
+		st.EmailSubject = []byte(st.Subject)
+	}
+	if len(st.EmailBody) == 0 {
+		st.EmailBody = []byte(st.Body)
+	}
 	n.Notify(st.Subject, st.Body, st.EmailSubject, st.EmailBody, s.Conf, string(st.AlertKey), st.Attachments...)
 }
 

--- a/models/incidents.go
+++ b/models/incidents.go
@@ -24,9 +24,9 @@ type IncidentState struct {
 
 	Subject      string
 	Body         string
-	EmailBody    []byte        `json:"-"`
-	EmailSubject []byte        `json:"-"`
-	Attachments  []*Attachment `json:"-"`
+	EmailBody    []byte
+	EmailSubject []byte
+	Attachments  []*Attachment
 
 	NeedAck bool
 	Open    bool


### PR DESCRIPTION
Not even storing email body and email subject if identical to regular. If empty when we want to notify we use the regular body. Will be stored if different.