### PR TITLE
cmd/bosun: Shorten-only http proxy

### DIFF
--- a/cmd/bosun/conf/conf.go
+++ b/cmd/bosun/conf/conf.go
@@ -64,6 +64,7 @@ type Conf struct {
 	Quiet            bool
 	NoSleep          bool
 	ShortURLKey      string
+	InternetProxy    string
 	MinGroupSize     int
 
 	TSDBHost             string                    // OpenTSDB relay and query destination: ny-devtsdb04:4242
@@ -549,6 +550,8 @@ func (c *Conf) loadGlobal(p *parse.PairNode) {
 		}
 	case "shortURLKey":
 		c.ShortURLKey = v
+	case "internetProxy":
+		c.InternetProxy = v
 	case "ledisDir":
 		c.LedisDir = v
 	case "redisHost":

--- a/cmd/bosun/main.go
+++ b/cmd/bosun/main.go
@@ -136,6 +136,12 @@ func main() {
 			c.TSDBHost = tsdbHost.Host
 		}
 	}
+	if c.InternetProxy != "" {
+		web.InternetProxy, err = url.Parse(c.InternetProxy)
+		if err != nil {
+			slog.Fatalf("InternetProxy error: %s", err)
+		}
+	}
 	if *flagQuiet {
 		c.Quiet = true
 	}


### PR DESCRIPTION
This adds shortenProxy as option in bosun.toml to add a proxy only to requests out to googleapis' shortener api. The alternative is making use of the default http client's http.ProxyFromEnvironment but it results in all http calls to use it. That includes calls to OpenTSDB which isn't a something we want.