### PR TITLE
cmd/scollector: Fix for unset MaxQueueLen

### DIFF
--- a/cmd/scollector/main.go
+++ b/cmd/scollector/main.go
@@ -216,10 +216,10 @@ func main() {
 		collect.BatchSize = *flagBatchSize
 	}
 
-	if conf.MaxQueueLen < collect.BatchSize {
-		slog.Fatalf("MaxQueueLen must be >= %d (BatchSize)", collect.BatchSize)
-	}
 	if conf.MaxQueueLen != 0 {
+		if conf.MaxQueueLen < collect.BatchSize {
+			slog.Fatalf("MaxQueueLen must be >= %d (BatchSize)", collect.BatchSize)
+		}
 		collect.MaxQueueLen = conf.MaxQueueLen
 	}
 


### PR DESCRIPTION
This fixes scollector complaining about MaxQueueLen smaller than the batchsize when it's unset. 