### PR TITLE
cmd/bosun: Auto-Closing open alerts if alert doesn't exist anymore.

### DIFF
--- a/cmd/bosun/sched/sched.go
+++ b/cmd/bosun/sched/sched.go
@@ -386,7 +386,10 @@ func (s *Schedule) MarshalGroups(T miniprofiler.Timer, filter string) (*StateGro
 		for k, v := range status2 {
 			a := s.Conf.Alerts[k.Name()]
 			if a == nil {
-				slog.Errorf("unknown alert %s", k.Name())
+				slog.Errorf("unknown alert %s. Force closing.", k.Name())
+				if err2 = s.Action("bosun", "closing because alert doesn't exist.", models.ActionForceClose, k); err2 != nil {
+					slog.Error(err2)
+				}
 				continue
 			}
 			if matches(s.Conf, a, v) {


### PR DESCRIPTION
We used to remove open alerts with no corresponding alert in conf when we restored the state file. That is't possible in redis now, so there are a lot of warnings from the dashboard when alerts are left open after the alert is removed from the conf. 

This will force close those so the warnings stop, but will not delete history.