### PR TITLE
Fixed link and Go version

### DIFF
--- a/cmd/bosun/docker/build/Dockerfile
+++ b/cmd/bosun/docker/build/Dockerfile
@@ -20,11 +20,11 @@ ENV HBASE /hbase/hbase-$HBASEVER
 ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
 
 RUN mkdir -p /hbase \
-    && curl -SL http://apache.org/dist/hbase/stable/hbase-$HBASEVER-bin.tar.gz \
+    && curl -SL http://archive.apache.org/dist/hbase/$HBASEVER/hbase-$HBASEVER-bin.tar.gz \
     | tar -xzC /hbase \
     && mv /hbase/hbase-$HBASEVER /hbase/hbase
 
-RUN curl -SL https://storage.googleapis.com/golang/go1.5.1.linux-amd64.tar.gz \
+RUN curl -SL https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz \
     | tar -xzC /usr/local
 
 COPY bosun $GOPATH/src/bosun.org/


### PR DESCRIPTION
I'm trying to use bosun with latest ElasticSearch 2.0.
I've changed Go version to 1.6 because I can't compile latest master :( 
Looks like `elastic.v3` uses Go 1.6.
```
cmd/bosun/expr/elastic.go:13:2: cannot find package "gopkg.in/olivere/elastic.v3" in any of:
	/usr/local/go/src/gopkg.in/olivere/elastic.v3 (from $GOROOT)
	/go/src/gopkg.in/olivere/elastic.v3 (from $GOPATH)
2016/02/20 22:20:40 exit status 1
exit status 1
```
Now looks like working
```
➜  docker git:(docker-0.5.0-alpha) docker run -d -p 4242:4242 -p 8070:8070 stackexchange/bosun
538abf33e180a14d4734b272a1b4824f28c8d2ec6e803617faaad4f36988990a
```
Also I see strange behavior with frontend. I understand that it's not so stable.

For smoke testing I'm using examples from https://bosun.org/quickstart
```
tsdbHost = localhost:4242
stateFile = /data/bosun.state


template test {
	subject = {{.Last.Status}}: {{.Alert.Name}} on {{.Group.host}}
	body = `<p>Alert: {{.Alert.Name}} triggered on {{.Group.host}}
	<hr>
	<p><strong>Computation</strong>
	<table>
		{{range .Computations}}
			<tr><td><a href="{{$.Expr .Text}}">{{.Text}}</a></td><td>{{.Value}}</td></tr>
		{{end}}
	</table>
	<hr>
	{{ .Graph .Alert.Vars.metric }}
	<hr>
	<p><strong>Relevant Tags</strong>
	<table>
		{{range $k, $v := .Group}}
			<tr><td>{{$k}}</td><td>{{$v}}</td></tr>
		{{end}}
	</table>`
}

alert cpu.is.too.high {
	template = test
	$metric = q("sum:rate{counter,,1}:os.cpu{host=538abf33e180}", "1h", "")
	$avgcpu = avg($metric)
	crit = $avgcpu > 80
	warn = $avgcpu > 60
}
```

Than I see error `invalid command param` or 
```
Request URL:http://192.168.99.100:8070/api/rule?alert=cpu.is.too.high&from=2016%2F02%2F20-22%3A17%3A08&to=2016%2F02%2F20-22%3A17%3A08&intervals=1&email=&template_group=
Request Method:POST
Status Code:500 Internal Server Error
Remote Address:192.168.99.100:8070
```

Response from api ` invalid command param`
any ideas?