### PR TITLE
cmd/bosun: pprof for bosun

### DIFF
--- a/cmd/bosun/conf/conf.go
+++ b/cmd/bosun/conf/conf.go
@@ -42,6 +42,7 @@ type Conf struct {
 	Ping            bool
 	PingDuration    time.Duration // Duration from now to stop pinging hosts based on time since the host tag was touched
 	EmailFrom       string
+	PProf           string // PProf is an IP:Port binding to be used for debugging with pprof package.
 	StateFile       string
 	LedisDir        string
 
@@ -358,6 +359,7 @@ func New(name, text string) (c *Conf, err error) {
 		CheckFrequency:   time.Minute * 5,
 		DefaultRunEvery:  1,
 		HTTPListen:       ":8070",
+		PProf:            "",
 		StateFile:        "bosun.state",
 		LedisDir:         "ledis_data",
 		MinGroupSize:     5,
@@ -555,6 +557,8 @@ func (c *Conf) loadGlobal(p *parse.PairNode) {
 		if err := c.Squelch.Add(v); err != nil {
 			c.error(err)
 		}
+	case "pprof":
+		c.PProf = v
 	case "shortURLKey":
 		c.ShortURLKey = v
 	case "internetProxy":

--- a/cmd/bosun/main.go
+++ b/cmd/bosun/main.go
@@ -90,6 +90,12 @@ func main() {
 	if *flagTest {
 		os.Exit(0)
 	}
+	if c.PProf != "" {
+		go func() {
+			slog.Infof("Starting pprof at http://%s/debug/pprof/", c.PProf)
+			slog.Fatal(http.ListenAndServe(c.PProf, nil))
+		}()
+	}
 	httpListen := &url.URL{
 		Scheme: "http",
 		Host:   c.HTTPListen,


### PR DESCRIPTION
Option to enable a pprof http endpoint for bosun. Essentially the same code as the one in scollector.