### PR TITLE
cmd/tsdbrelay: accept responses with 2xx code

### DIFF
--- a/cmd/tsdbrelay/main.go
+++ b/cmd/tsdbrelay/main.go
@@ -174,8 +174,8 @@ func (rp *relayProxy) relayPut(responseWriter http.ResponseWriter, r *http.Reque
 	r.Body = reader
 	w := &relayWriter{ResponseWriter: responseWriter}
 	rp.TSDBProxy.ServeHTTP(w, r)
-	if w.code != 204 {
-		verbose("got status", w.code)
+	if w.code/100 != 2 {
+		verbose("got status %d", w.code)
 		return
 	}
 	verbose("relayed to tsdb")


### PR DESCRIPTION
opentsdb may return 204 or 200 on successful PUTs to /api/put. 204 indicates success with no response body, but when the details parameter is specified, a 200 is returned along with a simple response document. tsdbrelay should relay all successful PUTs to bosun.

I am explicitly not changing relayMetadata, since bosun itself appears to only return a 204.

(Also fix a missing format specifier in the verbose() call.)