### PR TITLE
cmd/scollector: fix error: interval.go:64: c_google_analytics:

### DIFF
--- a/cmd/scollector/collectors/google_analytics.go
+++ b/cmd/scollector/collectors/google_analytics.go
@@ -73,7 +73,11 @@ func c_google_analytics(clientid string, secret string, tokenstr string, sites [
 		}
 	}
 
-	return md, mErr
+	if len(mErr) == 0 {
+		return md, nil
+	} else {
+		return md, mErr
+	}
 }
 
 func getActiveUsersByDimension(md *opentsdb.MultiDataPoint, svc *analytics.Service, site conf.GoogleAnalyticsSite, dimension string) error {

--- a/cmd/scollector/collectors/redis_linux.go
+++ b/cmd/scollector/collectors/redis_linux.go
@@ -1,5 +1,3 @@
-// +build darwin linux
-
 package collectors
 
 import (


### PR DESCRIPTION
There may be a better way to do this, but we see the following error every time the collector runs:

Mar  4 00:25:57 ny-bosun01 scollector[23960]: error: interval.go:64: c_google_analytics:

@captncraig @alienth 