### PR TITLE
scollector: vSphere collector with performance counters

### DIFF
--- a/cmd/scollector/conf/conf.go
+++ b/cmd/scollector/conf/conf.go
@@ -142,9 +142,10 @@ type ICMP struct {
 }
 
 type Vsphere struct {
-	Host     string
-	User     string
-	Password string
+	Host               string
+	User               string
+	Password           string
+	PerformanceMetrics []string // Additional performance metrics to collect, like vsphere.perf.cpu.ready
 }
 
 type AWS struct {

--- a/cmd/scollector/doc.go
+++ b/cmd/scollector/doc.go
@@ -203,6 +203,9 @@ Vsphere (array of table, keys are Host, User, Password): vSphere hosts to poll.
 	  Host = "vsphere01"
 	  User = "vuser"
 	  Password = "pass"
+	  # Additional performance metrics to collect, like vsphere.perf.cpu.ready. Use PerformanceMetrics = ['.*'] to collect all additional metrics.
+	  # If PerformanceMetrics parameter is not set, you will still get a basic subset of vSphere metrics.
+	  PerformanceMetrics = ['\.cpu\.ready$', '^vsphere(\.guest)?\.perf\.(cpu|mem|net|power)\.', '^vsphere(\.guest)?\.perf\.mem\.(de)?compression']
 
 AWS (array of table, keys are AccessKey, SecretKey, Region, BillingProductCodesRegex,
 BillingBucketName, BillingBucketPath, BillingPurgeDays): AWS hosts to poll, and associated

--- a/cmd/scollector/main.go
+++ b/cmd/scollector/main.go
@@ -162,7 +162,7 @@ func main() {
 		check(collectors.AzureEABilling(ea.EANumber, ea.APIKey, ea.LogBillingDetails))
 	}
 	for _, v := range conf.Vsphere {
-		check(collectors.Vsphere(v.User, v.Password, v.Host))
+		check(collectors.Vsphere(v.User, v.Password, v.Host, v.PerformanceMetrics))
 	}
 	for _, p := range conf.Process {
 		check(collectors.AddProcessConfig(p))

--- a/vsphere/vsphere.go
+++ b/vsphere/vsphere.go
@@ -11,6 +11,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"bosun.org/util"
 )
 
 // Vsphere holds connection state for a vSphere session.
@@ -19,6 +21,33 @@ type Vsphere struct {
 	header  http.Header
 	cookies http.CookieJar
 	client  *http.Client
+	service *ServiceContent
+}
+
+// ServiceContent partial structure to hold basic vSphere info, including Performance Manager name.
+type ServiceContent struct {
+	RootFolder  string    `xml:"rootFolder"`
+	ViewManager string    `xml:"viewManager,omitempty"`
+	About       AboutInfo `xml:"about"`
+	PerfManager string    `xml:"perfManager,omitempty"`
+}
+
+// AboutInfo holds more basic vSphere info.
+type AboutInfo struct {
+	Name                  string `xml:"name"`
+	FullName              string `xml:"fullName"`
+	Vendor                string `xml:"vendor"`
+	Version               string `xml:"version"`
+	Build                 string `xml:"build"`
+	LocaleVersion         string `xml:"localeVersion,omitempty"`
+	LocaleBuild           string `xml:"localeBuild,omitempty"`
+	OsType                string `xml:"osType"`
+	ProductLineId         string `xml:"productLineId"`
+	ApiType               string `xml:"apiType"`
+	ApiVersion            string `xml:"apiVersion"`
+	InstanceUuid          string `xml:"instanceUuid,omitempty"`
+	LicenseProductName    string `xml:"licenseProductName,omitempty"`
+	LicenseProductVersion string `xml:"licenseProductVersion,omitempty"`
 }
 
 // Connect connects and logs in to a vSphere host.
@@ -46,15 +75,16 @@ func Connect(host, user, pwd string) (*Vsphere, error) {
 		},
 		cookies: jar,
 	}
-	uuid := struct {
-		UUID string `xml:"Body>RetrieveServiceContentResponse>returnval>about>instanceUuid"`
+	service := struct {
+		SC *ServiceContent `xml:"Body>RetrieveServiceContentResponse>returnval"`
 	}{}
-	if err := v.call(soapConnect, &uuid); err != nil {
+	if err := v.call(soapConnect, &service); err != nil {
 		return nil, err
 	}
-	if uuid.UUID == "" {
+	if service.SC.About.InstanceUuid == "" {
 		return nil, fmt.Errorf("vsphere: no UUID during connect")
 	}
+	v.service = service.SC
 	userbuf := new(bytes.Buffer)
 	pwdbuf := new(bytes.Buffer)
 	xml.EscapeText(userbuf, []byte(user))
@@ -103,6 +133,124 @@ func (v *Vsphere) Info(Type string, properties []string) ([]*Result, error) {
 	return vms.Results, nil
 }
 
+// ManagedObjectReference refers to a server-side Managed Object (made for type-value information).
+type ManagedObjectReference struct {
+	Type  string `xml:"type,attr"`
+	Value string `xml:",chardata"`
+}
+
+// PerfProviderSummary describes capabilities of a performance provider.
+type PerfProviderSummary struct {
+	Entity           ManagedObjectReference `xml:"entity"`
+	CurrentSupported bool                   `xml:"currentSupported"` // CurrentSupported True if the entity supports real-time (current) statistics.
+	SummarySupported bool                   `xml:"summarySupported"`
+	RefreshRate      int                    `xml:"refreshRate,omitempty"` // RefreshRate Specifies in seconds the interval between which the system updates performance statistics.
+}
+
+// PerformanceProvider Gets capabilities of a performance provider from a vSphere server.
+func (v *Vsphere) PerformanceProvider(entityType string, entity string) (*PerfProviderSummary, error) {
+	var pm struct {
+		ProviderSummary *PerfProviderSummary `xml:"Body>QueryPerfProviderSummaryResponse>returnval"`
+	}
+	body := fmt.Sprintf(soapPerfProviderSummary, v.service.PerfManager, entityType, entity)
+	if err := v.call(body, &pm); err != nil {
+		return nil, err
+	}
+	return pm.ProviderSummary, nil
+}
+
+// ElementDescription Static strings used for describing an object model string or enumeration.
+type ElementDescription struct {
+	Label   string `xml:"label"`
+	Summary string `xml:"summary"`
+	Key     string `xml:"key"`
+}
+
+// PerfCounterInfo contains metadata for a performance counter.
+type PerfCounterInfo struct {
+	Key            int                `xml:"key"`
+	NameInfo       ElementDescription `xml:"nameInfo,typeattr"`
+	GroupInfo      ElementDescription `xml:"groupInfo,typeattr"`
+	UnitInfo       ElementDescription `xml:"unitInfo,typeattr"`
+	RollupType     string             `xml:"rollupType"`
+	StatsType      string             `xml:"statsType"`
+	Level          int                `xml:"level,omitempty"`
+	PerDeviceLevel int                `xml:"perDeviceLevel,omitempty"`
+}
+
+// PerfCounterInfos retrieves counter information for the specified list of counter IDs.
+func (v *Vsphere) PerfCounterInfos(counters string) ([]*PerfCounterInfo, error) {
+	var pcis struct {
+		PerfCounters []*PerfCounterInfo `xml:"Body>QueryPerfCounterResponse>returnval"`
+	}
+	// counters should be prepared in form of a string of multiple <counterId>%d</counterId>
+	body := fmt.Sprintf(soapQueryPerfCounters, v.service.PerfManager, counters)
+	if err := v.call(body, &pcis); err != nil {
+		return nil, err
+	}
+	return pcis.PerfCounters, nil
+}
+
+// PerfSampleInfo describes information contained in a sample collection, its timestamp, and sampling interval.
+type PerfSampleInfo struct {
+	Timestamp time.Time `xml:"timestamp"`
+	Interval  int       `xml:"interval"`
+}
+
+// PerfMetricId describes a performance counter with a performance counter ID and an instance name.
+// The instance name identifies the instance and is derived from configuration names.
+// For host and virtual machine devices, the instance name is the device name.
+type PerfMetricId struct {
+	CounterId int    `xml:"counterId"`
+	Instance  string `xml:"instance"`
+}
+
+// PerfMetricIntSeries describes integer metric values.
+// The size of the array must match the size of sampleInfo in the EntityMetric that contains this series
+type PerfMetricIntSeries struct {
+	Id    PerfMetricId `xml:"id"`
+	Value int64        `xml:"value,omitempty"`
+}
+
+// PerfEntityMetric stores metric values for a specific entity in 'normal' format.
+type PerfEntityMetric struct {
+	Entity     ManagedObjectReference `xml:"entity"`
+	SampleInfo []PerfSampleInfo       `xml:"sampleInfo,omitempty"`
+	Value      []PerfMetricIntSeries  `xml:"value,omitempty,typeattr"` //hardcoded int64
+}
+
+// PerfCountersValues Retrieves the all performance realtime metrics for the specified entity (or entities).
+func (v *Vsphere) PerfCountersValues(entityType string, entity string, pm *PerfProviderSummary) (*PerfEntityMetric, error) {
+	var pems struct {
+		PerfCountersValues *PerfEntityMetric `xml:"Body>QueryPerfResponse>returnval"`
+	}
+	if !pm.CurrentSupported {
+		return nil, nil
+	}
+	body := fmt.Sprintf(soapQueryPerf, v.service.PerfManager, entityType, entity, pm.RefreshRate)
+	if err := v.call(body, &pems); err != nil {
+		return nil, err
+	}
+	return pems.PerfCountersValues, nil
+}
+
+// Datastores returns full datastore info for a given storeKey list.
+func (v *Vsphere) Datastores(storeKey map[string]string) ([]*Result, error) {
+	var dss struct {
+		Results []*Result `xml:"Body>RetrievePropertiesResponse>returnval"`
+	}
+
+	var stores bytes.Buffer
+	for i := range storeKey {
+		stores.WriteString(fmt.Sprintf("<objectSet><obj type=\"Datastore\">%s</obj><skip>false</skip></objectSet>", i))
+	}
+
+	if err := v.call(fmt.Sprintf(soapRetrieveDatastore, stores.String()), &dss); err != nil {
+		return nil, err
+	}
+	return dss.Results, nil
+}
+
 func (v *Vsphere) call(body string, dst interface{}) error {
 	buf := new(bytes.Buffer)
 	buf.WriteString(soapPre)
@@ -139,6 +287,16 @@ func (v *Vsphere) call(body string, dst interface{}) error {
 	return nil
 }
 
+// Vcenter returns vsphere vcenter hostname
+func (v *Vsphere) Vcenter() string {
+	if v.url == nil {
+		return ""
+	}
+	// strip port number
+	fullhostname := strings.Split(v.url.Host, ":")[0]
+	return util.Clean(fullhostname)
+}
+
 // Error can be returned from any call to a Vsphere object, including Connect.
 type Error struct {
 	Code   string `xml:"Body>Fault>faultcode"`
@@ -164,4 +322,8 @@ const (
 	soapRetrieveServiceInstance = `<RetrieveProperties xmlns="urn:vim25"><_this type="PropertyCollector">propertyCollector</_this><specSet><propSet><type>ServiceInstance</type><all>false</all><pathSet>content</pathSet></propSet><objectSet><obj type="ServiceInstance">ServiceInstance</obj><skip>false</skip></objectSet></specSet></RetrieveProperties>`
 	soapCreateContainerView     = `<CreateContainerView xmlns="urn:vim25"><_this type="ViewManager">ViewManager</_this><container type="Folder">%s</container><type>%s</type><recursive>true</recursive></CreateContainerView>`
 	soapRetrieve                = `<RetrieveProperties xmlns="urn:vim25"><_this type="PropertyCollector">propertyCollector</_this><specSet><propSet><type>%s</type>%s</propSet><objectSet><obj type="ContainerView">%s</obj><skip>true</skip><selectSet xsi:type="TraversalSpec"><name>traverseEntities</name><type>ContainerView</type><path>view</path><skip>false</skip></selectSet></objectSet></specSet></RetrieveProperties>`
+	soapRetrieveDatastore       = `<RetrieveProperties xmlns="urn:vim25"><_this type="PropertyCollector">propertyCollector</_this><specSet><propSet><type>Datastore</type><all>true</all></propSet>%s</specSet></RetrieveProperties>`
+	soapPerfProviderSummary     = `<QueryPerfProviderSummary xmlns="urn:vim25" xsi:type="QueryPerfProviderSummaryRequestType"><_this type="PerformanceManager">%s</_this><entity type="%s">%s</entity></QueryPerfProviderSummary>`
+	soapQueryPerfCounters       = `<QueryPerfCounter xmlns="urn:vim25" xsi:type="QueryPerfCounterRequestType"><_this type="PerformanceManager">%s</_this>%s</QueryPerfCounter>`
+	soapQueryPerf               = `<QueryPerf xmlns="urn:vim25" xsi:type="QueryPerfRequestType"><_this type="PerformanceManager">%s</_this><querySpec><entity type="%s">%s</entity><maxSample>1</maxSample><intervalId>%d</intervalId></querySpec></QueryPerf>`
 )


### PR DESCRIPTION
New metrics:
- vsphere.perf.\* for host stats
- vsphere.guest.perf.\* for virtual machine stats

Metrics are populated dynamically, names, units, rates and descriptions are pulled from vSphere itself.

Performance metrics are opt-in, you should set include mask in PerformanceMetrics parameter. For example:
  `PerformanceMetrics = ['\.cpu\.ready$', '^vsphere(\.guest)?\.perf\.(cpu|net|power)\.', '^vsphere(\.guest)?\.perf\.mem\.(de)?compression']`

Use PerformanceMetrics = ['.*'] to collect all additional metrics.

Host metrics:

> vsphere.perf.cpu.coreUtilization
> vsphere.perf.cpu.costop
> vsphere.perf.cpu.demand
> vsphere.perf.cpu.idle
> vsphere.perf.cpu.latency
> vsphere.perf.cpu.ready
> vsphere.perf.cpu.reservedCapacity
> vsphere.perf.cpu.swapwait
> vsphere.perf.cpu.totalCapacity
> vsphere.perf.cpu.usage
> vsphere.perf.cpu.usagemhz
> vsphere.perf.cpu.used
> vsphere.perf.cpu.utilization
> vsphere.perf.cpu.wait
> vsphere.perf.datastore.datastoreIops
> vsphere.perf.datastore.datastoreMaxQueueDepth
> vsphere.perf.datastore.datastoreNormalReadLatency
> vsphere.perf.datastore.datastoreNormalWriteLatency
> vsphere.perf.datastore.datastoreReadBytes
> vsphere.perf.datastore.datastoreReadIops
> vsphere.perf.datastore.datastoreReadLoadMetric
> vsphere.perf.datastore.datastoreReadOIO
> vsphere.perf.datastore.datastoreVMObservedLatency
> vsphere.perf.datastore.datastoreWriteBytes
> vsphere.perf.datastore.datastoreWriteIops
> vsphere.perf.datastore.datastoreWriteLoadMetric
> vsphere.perf.datastore.datastoreWriteOIO
> vsphere.perf.datastore.maxTotalLatency
> vsphere.perf.datastore.numberReadAveraged
> vsphere.perf.datastore.numberWriteAveraged
> vsphere.perf.datastore.read
> vsphere.perf.datastore.siocActiveTimePercentage
> vsphere.perf.datastore.sizeNormalizedDatastoreLatency
> vsphere.perf.datastore.totalReadLatency
> vsphere.perf.datastore.totalWriteLatency
> vsphere.perf.datastore.write
> vsphere.perf.disk.busResets
> vsphere.perf.disk.commands
> vsphere.perf.disk.commandsAborted
> vsphere.perf.disk.commandsAveraged
> vsphere.perf.disk.deviceLatency
> vsphere.perf.disk.deviceReadLatency
> vsphere.perf.disk.deviceWriteLatency
> vsphere.perf.disk.kernelLatency
> vsphere.perf.disk.kernelReadLatency
> vsphere.perf.disk.kernelWriteLatency
> vsphere.perf.disk.maxQueueDepth
> vsphere.perf.disk.maxTotalLatency
> vsphere.perf.disk.numberRead
> vsphere.perf.disk.numberReadAveraged
> vsphere.perf.disk.numberWrite
> vsphere.perf.disk.numberWriteAveraged
> vsphere.perf.disk.queueLatency
> vsphere.perf.disk.queueReadLatency
> vsphere.perf.disk.queueWriteLatency
> vsphere.perf.disk.read
> vsphere.perf.disk.totalLatency
> vsphere.perf.disk.totalReadLatency
> vsphere.perf.disk.totalWriteLatency
> vsphere.perf.disk.usage
> vsphere.perf.disk.write
> vsphere.perf.hbr.hbrNetRx
> vsphere.perf.hbr.hbrNetTx
> vsphere.perf.hbr.hbrNumVms
> vsphere.perf.mem.active
> vsphere.perf.mem.activewrite
> vsphere.perf.mem.compressed
> vsphere.perf.mem.compressionRate
> vsphere.perf.mem.consumed
> vsphere.perf.mem.decompressionRate
> vsphere.perf.mem.granted
> vsphere.perf.mem.heap
> vsphere.perf.mem.heapfree
> vsphere.perf.mem.latency
> vsphere.perf.mem.llSwapIn
> vsphere.perf.mem.llSwapInRate
> vsphere.perf.mem.llSwapOut
> vsphere.perf.mem.llSwapOutRate
> vsphere.perf.mem.llSwapUsed
> vsphere.perf.mem.lowfreethreshold
> vsphere.perf.mem.overhead
> vsphere.perf.mem.reservedCapacity
> vsphere.perf.mem.shared
> vsphere.perf.mem.sharedcommon
> vsphere.perf.mem.state
> vsphere.perf.mem.swapin
> vsphere.perf.mem.swapinRate
> vsphere.perf.mem.swapout
> vsphere.perf.mem.swapoutRate
> vsphere.perf.mem.swapused
> vsphere.perf.mem.sysUsage
> vsphere.perf.mem.totalCapacity
> vsphere.perf.mem.unreserved
> vsphere.perf.mem.usage
> vsphere.perf.mem.vmmemctl
> vsphere.perf.mem.zero
> vsphere.perf.net.broadcastRx
> vsphere.perf.net.broadcastTx
> vsphere.perf.net.bytesRx
> vsphere.perf.net.bytesTx
> vsphere.perf.net.droppedRx
> vsphere.perf.net.droppedTx
> vsphere.perf.net.errorsRx
> vsphere.perf.net.errorsTx
> vsphere.perf.net.multicastRx
> vsphere.perf.net.multicastTx
> vsphere.perf.net.packetsRx
> vsphere.perf.net.packetsTx
> vsphere.perf.net.received
> vsphere.perf.net.transmitted
> vsphere.perf.net.unknownProtos
> vsphere.perf.net.usage
> vsphere.perf.power.energy
> vsphere.perf.power.power
> vsphere.perf.power.powerCap
> vsphere.perf.rescpu.actav1
> vsphere.perf.rescpu.actav15
> vsphere.perf.rescpu.actav5
> vsphere.perf.rescpu.actpk1
> vsphere.perf.rescpu.actpk15
> vsphere.perf.rescpu.actpk5
> vsphere.perf.rescpu.maxLimited1
> vsphere.perf.rescpu.maxLimited15
> vsphere.perf.rescpu.maxLimited5
> vsphere.perf.rescpu.runav1
> vsphere.perf.rescpu.runav15
> vsphere.perf.rescpu.runav5
> vsphere.perf.rescpu.runpk1
> vsphere.perf.rescpu.runpk15
> vsphere.perf.rescpu.runpk5
> vsphere.perf.rescpu.sampleCount
> vsphere.perf.rescpu.samplePeriod
> vsphere.perf.storageAdapter.commandsAveraged
> vsphere.perf.storageAdapter.maxTotalLatency
> vsphere.perf.storageAdapter.numberReadAveraged
> vsphere.perf.storageAdapter.numberWriteAveraged
> vsphere.perf.storageAdapter.read
> vsphere.perf.storageAdapter.totalReadLatency
> vsphere.perf.storageAdapter.totalWriteLatency
> vsphere.perf.storageAdapter.write
> vsphere.perf.storagePath.commandsAveraged
> vsphere.perf.storagePath.maxTotalLatency
> vsphere.perf.storagePath.numberReadAveraged
> vsphere.perf.storagePath.numberWriteAveraged
> vsphere.perf.storagePath.read
> vsphere.perf.storagePath.totalReadLatency
> vsphere.perf.storagePath.totalWriteLatency
> vsphere.perf.storagePath.write
> vsphere.perf.sys.resourceCpuAct1
> vsphere.perf.sys.resourceCpuAct5
> vsphere.perf.sys.resourceCpuAllocMax
> vsphere.perf.sys.resourceCpuAllocMin
> vsphere.perf.sys.resourceCpuAllocShares
> vsphere.perf.sys.resourceCpuMaxLimited1
> vsphere.perf.sys.resourceCpuMaxLimited5
> vsphere.perf.sys.resourceCpuRun1
> vsphere.perf.sys.resourceCpuRun5
> vsphere.perf.sys.resourceCpuUsage
> vsphere.perf.sys.resourceFdUsage
> vsphere.perf.sys.resourceMemAllocMax
> vsphere.perf.sys.resourceMemAllocMin
> vsphere.perf.sys.resourceMemAllocShares
> vsphere.perf.sys.resourceMemConsumed
> vsphere.perf.sys.resourceMemCow
> vsphere.perf.sys.resourceMemMapped
> vsphere.perf.sys.resourceMemOverhead
> vsphere.perf.sys.resourceMemShared
> vsphere.perf.sys.resourceMemSwapped
> vsphere.perf.sys.resourceMemTouched
> vsphere.perf.sys.resourceMemZero
> vsphere.perf.sys.uptime
> vsphere.perf.vflashModule.numActiveVMDKs

Virtual machine metrics:

> vsphere.guest.perf.cpu.costop
> vsphere.guest.perf.cpu.demand
> vsphere.guest.perf.cpu.demandEntitlementRatio
> vsphere.guest.perf.cpu.entitlement
> vsphere.guest.perf.cpu.idle
> vsphere.guest.perf.cpu.latency
> vsphere.guest.perf.cpu.maxlimited
> vsphere.guest.perf.cpu.overlap
> vsphere.guest.perf.cpu.ready
> vsphere.guest.perf.cpu.run
> vsphere.guest.perf.cpu.swapwait
> vsphere.guest.perf.cpu.system
> vsphere.guest.perf.cpu.usage
> vsphere.guest.perf.cpu.usagemhz
> vsphere.guest.perf.cpu.used
> vsphere.guest.perf.cpu.wait
> vsphere.guest.perf.datastore.maxTotalLatency
> vsphere.guest.perf.datastore.numberReadAveraged
> vsphere.guest.perf.datastore.numberWriteAveraged
> vsphere.guest.perf.datastore.read
> vsphere.guest.perf.datastore.totalReadLatency
> vsphere.guest.perf.datastore.totalWriteLatency
> vsphere.guest.perf.datastore.write
> vsphere.guest.perf.disk.busResets
> vsphere.guest.perf.disk.commands
> vsphere.guest.perf.disk.commandsAborted
> vsphere.guest.perf.disk.commandsAveraged
> vsphere.guest.perf.disk.maxTotalLatency
> vsphere.guest.perf.disk.numberRead
> vsphere.guest.perf.disk.numberReadAveraged
> vsphere.guest.perf.disk.numberWrite
> vsphere.guest.perf.disk.numberWriteAveraged
> vsphere.guest.perf.disk.read
> vsphere.guest.perf.disk.usage
> vsphere.guest.perf.disk.write
> vsphere.guest.perf.mem.active
> vsphere.guest.perf.mem.activewrite
> vsphere.guest.perf.mem.compressed
> vsphere.guest.perf.mem.compressionRate
> vsphere.guest.perf.mem.consumed
> vsphere.guest.perf.mem.decompressionRate
> vsphere.guest.perf.mem.entitlement
> vsphere.guest.perf.mem.granted
> vsphere.guest.perf.mem.latency
> vsphere.guest.perf.mem.llSwapInRate
> vsphere.guest.perf.mem.llSwapOutRate
> vsphere.guest.perf.mem.llSwapUsed
> vsphere.guest.perf.mem.overhead
> vsphere.guest.perf.mem.overheadMax
> vsphere.guest.perf.mem.overheadTouched
> vsphere.guest.perf.mem.shared
> vsphere.guest.perf.mem.swapin
> vsphere.guest.perf.mem.swapinRate
> vsphere.guest.perf.mem.swapout
> vsphere.guest.perf.mem.swapoutRate
> vsphere.guest.perf.mem.swapped
> vsphere.guest.perf.mem.swaptarget
> vsphere.guest.perf.mem.usage
> vsphere.guest.perf.mem.vmmemctl
> vsphere.guest.perf.mem.vmmemctltarget
> vsphere.guest.perf.mem.zero
> vsphere.guest.perf.mem.zipSaved
> vsphere.guest.perf.mem.zipped
> vsphere.guest.perf.net.broadcastRx
> vsphere.guest.perf.net.broadcastTx
> vsphere.guest.perf.net.bytesRx
> vsphere.guest.perf.net.bytesTx
> vsphere.guest.perf.net.droppedRx
> vsphere.guest.perf.net.droppedTx
> vsphere.guest.perf.net.multicastRx
> vsphere.guest.perf.net.multicastTx
> vsphere.guest.perf.net.packetsRx
> vsphere.guest.perf.net.packetsTx
> vsphere.guest.perf.net.received
> vsphere.guest.perf.net.transmitted
> vsphere.guest.perf.net.usage
> vsphere.guest.perf.power.energy
> vsphere.guest.perf.power.power
> vsphere.guest.perf.rescpu.actav1
> vsphere.guest.perf.rescpu.actav15
> vsphere.guest.perf.rescpu.actav5
> vsphere.guest.perf.rescpu.actpk1
> vsphere.guest.perf.rescpu.actpk15
> vsphere.guest.perf.rescpu.actpk5
> vsphere.guest.perf.rescpu.maxLimited1
> vsphere.guest.perf.rescpu.maxLimited15
> vsphere.guest.perf.rescpu.maxLimited5
> vsphere.guest.perf.rescpu.runav1
> vsphere.guest.perf.rescpu.runav15
> vsphere.guest.perf.rescpu.runav5
> vsphere.guest.perf.rescpu.runpk1
> vsphere.guest.perf.rescpu.runpk15
> vsphere.guest.perf.rescpu.runpk5
> vsphere.guest.perf.rescpu.sampleCount
> vsphere.guest.perf.rescpu.samplePeriod
> vsphere.guest.perf.sys.heartbeat
> vsphere.guest.perf.sys.osUptime
> vsphere.guest.perf.sys.uptime
> vsphere.guest.perf.virtualDisk.largeSeeks
> vsphere.guest.perf.virtualDisk.mediumSeeks
> vsphere.guest.perf.virtualDisk.numberReadAveraged
> vsphere.guest.perf.virtualDisk.numberWriteAveraged
> vsphere.guest.perf.virtualDisk.read
> vsphere.guest.perf.virtualDisk.readIOSize
> vsphere.guest.perf.virtualDisk.readLatencyUS
> vsphere.guest.perf.virtualDisk.readLoadMetric
> vsphere.guest.perf.virtualDisk.readOIO
> vsphere.guest.perf.virtualDisk.smallSeeks
> vsphere.guest.perf.virtualDisk.totalReadLatency
> vsphere.guest.perf.virtualDisk.totalWriteLatency
> vsphere.guest.perf.virtualDisk.write
> vsphere.guest.perf.virtualDisk.writeIOSize
> vsphere.guest.perf.virtualDisk.writeLatencyUS
> vsphere.guest.perf.virtualDisk.writeLoadMetric
> vsphere.guest.perf.virtualDisk.writeOIO
