### PR TITLE
cmd/scollector: cassandra collector value validation

### DIFF
--- a/cmd/scollector/collectors/cassandra_unix.go
+++ b/cmd/scollector/collectors/cassandra_unix.go
@@ -74,9 +74,10 @@ func c_nodestats_cfstats_linux() (opentsdb.MultiDataPoint, error) {
 
 		// every other value is simpler, and we only want the first word
 		values := strings.Fields(fields[1])
-		if values[0] == "NaN" {
+		if _, err := strconv.ParseFloat(values[0], 64); err != nil || values[0] == "NaN" {
 			return nil
 		}
+
 		metricset["cassandra.tables."+metric] = values[0]
 
 		submitMetrics(&md, metricset, tagset)


### PR DESCRIPTION
Small bugfix on the nodetool cfstats output parsing. We can get this kind of output:
```
Keyspace: MyKeyspace
	Read Count: 0
	Read Latency: NaN ms.
	Write Count: 11119269
	Write Latency: 0.03063775793174893 ms.
	Pending Flushes: 0
		Table (index): MyKeyspace.my_idx
		SSTable count: 3
		Space used (live): 16584359
		Space used (total): 16584359
...
```
As the collector currently is it will pass "MyKeyspace.my_idx" as a datapoint value which doesn't work so well. It then fails in the json encoder down the line since it's not a float nor an integer.