### PR TITLE
cmd/scollector: validate datapoints before adding them

### DIFF
--- a/cmd/scollector/collectors/stream.go
+++ b/cmd/scollector/collectors/stream.go
@@ -7,6 +7,7 @@ import (
 	"bosun.org/collect"
 	"bosun.org/metadata"
 	"bosun.org/opentsdb"
+	"bosun.org/slog"
 	"bosun.org/util"
 )
 
@@ -44,8 +45,12 @@ func (s *StreamCollector) Run(dpchan chan<- *opentsdb.DataPoint, quit <-chan str
 					dp.Tags["host"] = util.Hostname
 				}
 				s.ApplyTagOverrides(dp.Tags)
-				dpchan <- dp
-				count++
+				if dp.Valid() {
+					dpchan <- dp
+					count++
+				} else {
+					slog.Errorf("Invalid datapoint received for: %s", dp.Metric)
+				}
 			}
 		case <-quit:
 			return


### PR DESCRIPTION
Slightly related to https://github.com/bosun-monitor/bosun/pull/1646, this will validate a datapoint before sending it off in the datapoints channel. A problem I noticed in the bug fixed in the previous PR is that if we fail to json encode a batch nothing will be sent, thus a single faulty collector can break the pipeline. 

Example of the problem in question:
```
Mar  4 05:41:02 myhost scollector[1234]: error: queue.go:105: json: error calling MarshalJSON for type *opentsdb.DataPoint: Unparseable number MyKeyspace.my_idx
Mar  4 05:41:02 myhost scollector[1234]: info: queue.go:124: restored 500, sleeping 5s
...
```