### PR TITLE
cmd/scollector: cadvisor collector cpu metrics review

### DIFF
--- a/cmd/scollector/collectors/cadvisor.go
+++ b/cmd/scollector/collectors/cadvisor.go
@@ -41,145 +41,136 @@ var cadvisorMeta = map[string]MetricMeta{
 		Unit:     metadata.Second,
 		Desc:     "Smoothed 10s average of number of runnable threads x 1000",
 	},
-
-	"container.diskio.io_service_bytes.async": {
+	"container.blkio.io_service_bytes.async": {
 		RateType: metadata.Counter,
 		Unit:     metadata.Bytes,
 		Desc:     "Number of bytes transferred to/from the disk by the cgroup asynchronously",
 	},
-	"container.diskio.io_service_bytes.read": {
+	"container.blkio.io_service_bytes.read": {
 		RateType: metadata.Counter,
 		Unit:     metadata.Bytes,
 		Desc:     "Number of bytes read from the disk by the cgroup",
 	},
-	"container.diskio.io_service_bytes.sync": {
+	"container.blkio.io_service_bytes.sync": {
 		RateType: metadata.Counter,
 		Unit:     metadata.Bytes,
 		Desc:     "Number of bytes transferred to/from the disk by the cgroup synchronously",
 	},
-	"container.diskio.io_service_bytes.write": {
+	"container.blkio.io_service_bytes.write": {
 		RateType: metadata.Counter,
 		Unit:     metadata.Bytes,
 		Desc:     "Number of bytes written to the disk by the cgroup",
 	},
-
-	"container.diskio.io_serviced.async": {
+	"container.blkio.io_serviced.async": {
 		RateType: metadata.Counter,
 		Unit:     metadata.Operation,
 		Desc:     "Number of async IOs issued to the disk by the cgroup",
 	},
-	"container.diskio.io_serviced.read": {
+	"container.blkio.io_serviced.read": {
 		RateType: metadata.Counter,
 		Unit:     metadata.Operation,
 		Desc:     "Number of read issued to the disk by the group",
 	},
-	"container.diskio.io_serviced.sync": {
+	"container.blkio.io_serviced.sync": {
 		RateType: metadata.Counter,
 		Unit:     metadata.Operation,
 		Desc:     "Number of sync IOs issued to the disk by the cgroup",
 	},
-	"container.diskio.io_serviced.write": {
+	"container.blkio.io_serviced.write": {
 		RateType: metadata.Counter,
 		Unit:     metadata.Operation,
 		Desc:     "Number of write issued to the disk by the group",
 	},
-
-	"container.diskio.io_queued.async": {
+	"container.blkio.io_queued.async": {
 		RateType: metadata.Gauge,
 		Unit:     metadata.Operation,
 		Desc:     "Total number of async requests queued up at any given instant for this cgroup",
 	},
-	"container.diskio.io_queued.read": {
+	"container.blkio.io_queued.read": {
 		RateType: metadata.Gauge,
 		Unit:     metadata.Operation,
 		Desc:     "Total number of read requests queued up at any given instant for this cgroup",
 	},
-	"container.diskio.io_queued.sync": {
+	"container.blkio.io_queued.sync": {
 		RateType: metadata.Gauge,
 		Unit:     metadata.Operation,
 		Desc:     "Total number of sync requests queued up at any given instant for this cgroup",
 	},
-	"container.diskio.io_queued.write": {
+	"container.blkio.io_queued.write": {
 		RateType: metadata.Gauge,
 		Unit:     metadata.Operation,
 		Desc:     "Total number of write requests queued up at any given instant for this cgroup",
 	},
-
-	"container.diskio.sectors.count": {
+	"container.blkio.sectors.count": {
 		RateType: metadata.Counter,
 		Unit:     metadata.Sector,
 		Desc:     "Number of sectors transferred to/from disk by the group",
 	},
-
-	"container.diskio.io_service_time.async": {
+	"container.blkio.io_service_time.async": {
 		RateType: metadata.Counter,
 		Unit:     metadata.Nanosecond,
 		Desc:     "Total amount of time between async request dispatch and request completion for the IOs done by this cgroup",
 	},
-	"container.diskio.io_service_time.read": {
+	"container.blkio.io_service_time.read": {
 		RateType: metadata.Counter,
 		Unit:     metadata.Nanosecond,
 		Desc:     "Total amount of time between read request dispatch and request completion for the IOs done by this cgroup",
 	},
-	"container.diskio.io_service_time.sync": {
+	"container.blkio.io_service_time.sync": {
 		RateType: metadata.Counter,
 		Unit:     metadata.Nanosecond,
 		Desc:     "Total amount of time between sync request dispatch and request completion for the IOs done by this cgroup",
 	},
-	"container.diskio.io_service_time.write": {
+	"container.blkio.io_service_time.write": {
 		RateType: metadata.Counter,
 		Unit:     metadata.Nanosecond,
 		Desc:     "Total amount of time between write request dispatch and request completion for the IOs done by this cgroup",
 	},
-
-	"container.diskio.io_wait_time.async": {
+	"container.blkio.io_wait_time.async": {
 		RateType: metadata.Counter,
 		Unit:     metadata.Nanosecond,
 		Desc:     "Total amount of time the async IOs for this cgroup spent waiting in the scheduler queues for service",
 	},
-	"container.diskio.io_wait_time.read": {
+	"container.blkio.io_wait_time.read": {
 		RateType: metadata.Counter,
 		Unit:     metadata.Nanosecond,
 		Desc:     "Total amount of time the read request for this cgroup spent waiting in the scheduler queues for service",
 	},
-	"container.diskio.io_wait_time.sync": {
+	"container.blkio.io_wait_time.sync": {
 		RateType: metadata.Counter,
 		Unit:     metadata.Nanosecond,
 		Desc:     "Total amount of time the sync IOs for this cgroup spent waiting in the scheduler queues for service",
 	},
-	"container.diskio.io_wait_time.write": {
+	"container.blkio.io_wait_time.write": {
 		RateType: metadata.Counter,
 		Unit:     metadata.Nanosecond,
 		Desc:     "Total amount of time the write request for this cgroup spent waiting in the scheduler queues for service",
 	},
-
-	"container.diskio.io_merged.async": {
+	"container.blkio.io_merged.async": {
 		RateType: metadata.Counter,
 		Unit:     metadata.Operation,
 		Desc:     "Total number of async requests merged into requests belonging to this cgroup.",
 	},
-	"container.diskio.io_merged.read": {
+	"container.blkio.io_merged.read": {
 		RateType: metadata.Counter,
 		Unit:     metadata.Operation,
 		Desc:     "Total number of read requests merged into requests belonging to this cgroup.",
 	},
-	"container.diskio.io_merged.sync": {
+	"container.blkio.io_merged.sync": {
 		RateType: metadata.Counter,
 		Unit:     metadata.Operation,
 		Desc:     "Total number of sync requests merged into requests belonging to this cgroup.",
 	},
-	"container.diskio.io_merged.write": {
+	"container.blkio.io_merged.write": {
 		RateType: metadata.Counter,
 		Unit:     metadata.Operation,
 		Desc:     "Total number of write requests merged into requests belonging to this cgroup.",
 	},
-
-	"container.diskio.io_time.count": {
+	"container.blkio.io_time.count": {
 		RateType: metadata.Counter,
 		Unit:     metadata.MilliSecond,
 		Desc:     "Disk time allocated to cgroup per device",
 	},
-
 	"container.fs.available": {
 		RateType: metadata.Gauge,
 		Unit:     metadata.Bytes,
@@ -322,7 +313,6 @@ func containerTagSet(ts opentsdb.TagSet, container *v1.ContainerInfo) opentsdb.T
 	return tags
 }
 
-<<<<<<< HEAD
 func inBlkioWhitelist(name string) bool {
 	valid := false
 	for _, n := range blkioStatsWhitelist {

--- a/cmd/scollector/collectors/google_analytics.go
+++ b/cmd/scollector/collectors/google_analytics.go
@@ -86,7 +86,10 @@ func getActiveUsersByDimension(md *opentsdb.MultiDataPoint, svc *analytics.Servi
 	for _, row := range data.Rows {
 		// key will always be an string of the dimension we care about.
 		// For example, 'Chrome' would be a key for the 'browser' dimension.
-		key := row[0]
+		key, _ := opentsdb.Clean(row[0])
+		if key == "" {
+			key = "__blank__"
+		}
 		value, err := strconv.Atoi(row[1])
 		if err != nil {
 			return fmt.Errorf("Error parsing GA data: %s", err)

--- a/cmd/scollector/conf/conf.go
+++ b/cmd/scollector/conf/conf.go
@@ -174,7 +174,8 @@ type Github struct {
 }
 
 type Cadvisor struct {
-	URL string
+	URL         string
+	PerCpuUsage bool
 }
 
 type RedisCounters struct {

--- a/cmd/scollector/doc.go
+++ b/cmd/scollector/doc.go
@@ -241,10 +241,11 @@ management plugin on http://guest:guest@127.0.0.1:15672/ .
 Cadvisor: Cadvisor endpoints to poll.
 Cadvisor collects system statistics about running containers.
 See https://github.com/google/cadvisor/ for documentation about configuring
-cadvisor.
+cadvisor. You can enable per cpu usage metric reporting optionally.
 
 	[[Cadvisor]]
 		URL = "http://localhost:8080"
+		PerCpuUsage = true
 
 RedisCounters: Reads a hash of metric/counters from a redis database.
 

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -83,6 +83,7 @@ const (
 	Merge                = "merges"
 	Message              = "messages"
 	MilliSecond          = "milliseconds"
+	Nanosecond           = "nanoseconds"
 	Node                 = "nodes"
 	Ok                   = "ok" // "OK" or not status, 0 = ok, 1 = not ok
 	Operation            = "Operations"


### PR DESCRIPTION
This PR modifies the cadvisor collector in 3 ways:
* container.cpu.system and container.cpu.user are grouped under container.cpu with the tag type=(user|system).
* cpu usage per cpu now optional via the [[Cadvisor]].PerCpuUsage config and moved to container.cpu.usage.percpu. What was container.cpu.usage cpu=all is now alone on that metric and we can have container.cpu.usage.percpu cpu=%d for each cpu. These are still generated for each container. On a system with a lot of CPUs and containers this generated too much data that was of little use.
* corrected metadata info: cpu times are in nanoseconds.