### PR TITLE
cmd/bosun/expr: fix crash on invalid graphite tags

### DIFF
--- a/cmd/bosun/expr/funcs.go
+++ b/cmd/bosun/expr/funcs.go
@@ -521,6 +521,10 @@ func parseGraphiteResponse(req *graphite.Request, s *graphite.Response, formatTa
 				}
 			}
 		}
+		if !tags.Valid() {
+			msg := fmt.Sprintf("returned target '%s' would make an invalid tag '%s'", res.Target, tags.String())
+			return nil, fmt.Errorf(parseErrFmt, req.URL, msg)
+		}
 		if ts := tags.String(); !seen[ts] {
 			seen[ts] = true
 		} else {


### PR DESCRIPTION
Check that we are not generating invalid tags in parseGraphiteResponse
because that would result in a crash if we try to create an Incident
with these tags.

I was able to reproduce the crash using this alert:
```
alert example.graphite {
        template = generic
        $graphite = graphite("sumSeries(constantLine(1),constantLine(2))", "5m", "", "")
        warn = avg($graphite) > 1
}

panic: opentsdb: bad tag: constantLine(2))

goroutine 67 [running]:
panic(0xd70e60, 0xc8200e2610)
	/usr/local/Cellar/go/1.6/libexec/src/runtime/panic.go:464 +0x3e6
bosun.org/models.AlertKey.Group(0xc820846700, 0x40, 0xc820846700)
	/Users/avereha/src/go/src/bosun.org/models/alertKey.go:46 +0x286
bosun.org/cmd/bosun/sched.NewIncident(0xc820846700, 0x40, 0xc82034dbc0)
	/Users/avereha/src/go/src/bosun.org/cmd/bosun/sched/check.go:46 +0x11d
bosun.org/cmd/bosun/sched.(*Schedule).runHistory(0x18fcf60, 0xc82021c2c0, 0xc820846700, 0x40, 0xc820846740, 0xc820846e80, 0x0, 0x0, 0x0)
	/Users/avereha/src/go/src/bosun.org/cmd/bosun/sched/check.go:151 +0x3f1
bosun.org/cmd/bosun/sched.(*Schedule).RunHistory(0x18fcf60, 0xc82021c2c0)
	/Users/avereha/src/go/src/bosun.org/cmd/bosun/sched/check.go:91 +0x118
bosun.org/cmd/bosun/sched.(*Schedule).checkAlert(0x18fcf60, 0xc8200c0300)
	/Users/avereha/src/go/src/bosun.org/cmd/bosun/sched/alertRunner.go:54 +0xec
bosun.org/cmd/bosun/sched.(*Schedule).RunAlert(0x18fcf60, 0xc8200c0300)
	/Users/avereha/src/go/src/bosun.org/cmd/bosun/sched/alertRunner.go:41 +0x5f
created by bosun.org/cmd/bosun/sched.(*Schedule).Run
	/Users/avereha/src/go/src/bosun.org/cmd/bosun/sched/alertRunner.go:24 +0x1d4
```

This change fixes #1608(I tested this) and probably #710(same backtrace).
