### PR TITLE
tod(scalar) was returning minutes as hours

### DIFF
--- a/cmd/bosun/expr/funcs_test.go
+++ b/cmd/bosun/expr/funcs_test.go
@@ -48,19 +48,40 @@ func TestDuration(t *testing.T) {
 }
 
 func TestToDuration(t *testing.T) {
-	d := exprInOut{
-		`tod(3600*2)`,
-		Results{
-			Results: ResultSlice{
-				&Result{
-					Value: String("2h"),
+	inputs := []int{
+		0,
+		1,
+		60,
+		3600,
+		86400,
+		604800,
+		31536000,
+	}
+	outputs := []string{
+		"0ms",
+		"1s",
+		"1m",
+		"1h",
+		"1d",
+		"1w",
+		"1y",
+	}
+
+	for i := range inputs {
+		d := exprInOut{
+			fmt.Sprintf(`tod(%d)`, inputs[i]),
+			Results{
+				Results: ResultSlice{
+					&Result{
+						Value: String(outputs[i]),
+					},
 				},
 			},
-		},
-	}
-	err := testExpression(d)
-	if err != nil {
-		t.Error(err)
+		}
+		err := testExpression(d)
+		if err != nil {
+			t.Error(err)
+		}
 	}
 }
 

--- a/opentsdb/duration.go
+++ b/opentsdb/duration.go
@@ -162,7 +162,7 @@ func (d Duration) HumanString() string {
 		return fmt.Sprintf("%dh", d/Hour)
 	}
 	if d >= Minute && d%Minute == 0 {
-		return fmt.Sprintf("%dh", d/Minute)
+		return fmt.Sprintf("%dm", d/Minute)
 	}
 	if d >= Second && d%Second == 0 {
 		return fmt.Sprintf("%ds", d/Second)


### PR DESCRIPTION
e.g. tod(4500) was evaluating as 75h instead of 75 minutes