### PR TITLE
Send actual hostname in SMTP Hello

### DIFF
--- a/cmd/bosun/conf/notify.go
+++ b/cmd/bosun/conf/notify.go
@@ -148,7 +148,7 @@ func SendMail(addr, username, password string, from string, to []string, msg []b
 		return err
 	}
 	defer c.Close()
-	if err = c.Hello("localhost"); err != nil {
+	if err = c.Hello(util.Hostname); err != nil {
 		return err
 	}
 	if ok, _ := c.Extension("STARTTLS"); ok {


### PR DESCRIPTION
Sending "localhost" in the SMTP Hello can trip some spam filters that expect the Hello hostname to be a valid FQDN.

Note: I don't have a Go development environment set up, so this change is untested.
It seems simple enough, but perhaps someone could run a quick test to see if it runs alright.
