### PR TITLE
Add support for fill policies when using opentsdb 2.2

### DIFF
--- a/opentsdb/tsdb.go
+++ b/opentsdb/tsdb.go
@@ -449,25 +449,36 @@ func ParseRequest(req string, version Version) (*Request, error) {
 	return &r, nil
 }
 
-var qRE2_1 = regexp.MustCompile(`^(\w+):(?:(\w+-\w+):)?(?:(rate.*):)?([\w./-]+)(?:\{([\w./,=*-|]+)\})?$`)
-var qRE2_2 = regexp.MustCompile(`^(\w+):(?:(\w+-\w+):)?(?:(rate.*):)?([\w./-]+)(?:\{([^}]+)?\})?(?:\{([^}]+)?\})?$`)
+var qRE2_1 = regexp.MustCompile(`^(?P<aggregator>\w+):(?:(?P<downsample>\w+-\w+):)?(?:(?P<rate>rate.*):)?(?P<metric>[\w./-]+)(?:\{([\w./,=*-|]+)\})?$`)
+var qRE2_2 = regexp.MustCompile(`^(?P<aggregator>\w+):(?:(?P<downsample>\w+-\w+(?:-(?:\w+))?):)?(?:(?P<rate>rate.*):)?(?P<metric>[\w./-]+)(?:\{([^}]+)?\})?(?:\{([^}]+)?\})?$`)
 
 // ParseQuery parses OpenTSDB queries of the form: avg:rate:cpu{k=v}. Validation
 // errors will be returned along with a valid Query.
 func ParseQuery(query string, version Version) (q *Query, err error) {
+	var regExp = qRE2_1
 	q = new(Query)
-	m := qRE2_1.FindStringSubmatch(query)
 	if version.FilterSupport() {
-		m = qRE2_2.FindStringSubmatch(query)
+		regExp = qRE2_2
 	}
+
+	m := regExp.FindStringSubmatch(query)
+
 	if m == nil {
 		return nil, fmt.Errorf("opentsdb: bad query format: %s", query)
 	}
-	q.Aggregator = m[1]
-	q.Downsample = m[2]
-	q.Rate = strings.HasPrefix(m[3], "rate")
-	if q.Rate && len(m[3]) > 4 {
-		s := m[3][4:]
+
+	result := make(map[string]string)
+	for i, name := range regExp.SubexpNames() {
+		if i != 0 {
+			result[name] = m[i]
+		}
+	}
+
+	q.Aggregator = result["aggregator"]
+	q.Downsample = result["downsample"]
+	q.Rate = strings.HasPrefix(result["rate"], "rate")
+	if q.Rate && len(result["rate"]) > 4 {
+		s := result["rate"][4:]
 		if !strings.HasSuffix(s, "}") || !strings.HasPrefix(s, "{") {
 			err = fmt.Errorf("opentsdb: invalid rate options")
 			return
@@ -487,20 +498,23 @@ func ParseQuery(query string, version Version) (q *Query, err error) {
 			}
 		}
 	}
-	q.Metric = m[4]
-	if !version.FilterSupport() {
-		if len(m) > 5 && m[5] != "" {
-			tags, e := ParseTags(m[5])
-			if e != nil {
-				err = e
-				if tags == nil {
-					return
-				}
+	q.Metric = result["metric"]
+
+	if !version.FilterSupport() && len(m) > 5 && m[5] != "" {
+		tags, e := ParseTags(m[5])
+		if e != nil {
+			err = e
+			if tags == nil {
+				return
 			}
-			q.Tags = tags
 		}
+		q.Tags = tags
+	}
+
+	if !version.FilterSupport() {
 		return
 	}
+
 	// OpenTSDB Greater than 2.2, treating as filters
 	q.GroupByTags = make(TagSet)
 	q.Filters = make([]Filter, 0)
@@ -514,10 +528,11 @@ func ParseQuery(query string, version Version) (q *Query, err error) {
 	if m[6] != "" {
 		f, err := ParseFilters(m[6], false, q)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to parse filter(s): %s", m[5])
+			return nil, fmt.Errorf("Failed to parse filter(s): %s", m[6])
 		}
 		q.Filters = append(q.Filters, f...)
 	}
+
 	return
 }
 

--- a/opentsdb/tsdb_test.go
+++ b/opentsdb/tsdb_test.go
@@ -67,6 +67,12 @@ func TestParseQueryV2_2(t *testing.T) {
 		// return errors. This is because there can be a regex filter now. Might
 		// be issues with escaping there however
 		{"sum:stat{a=b=c}", false},
+
+		//test fill policies
+		{"sum:10m-avg-zero:proc.stat.cpu{t=v,o=k}", false},
+		{"sum:10m-avg-:proc.stat.cpu{t=v,o=k}", true},
+		{"sum:10m-avg-none:rate:proc.stat.cpu", false},
+		{"sum:10m-avg-:rate{counter,1,2}:proc.stat.cpu{t=v,o=k}", true},
 	}
 	for _, q := range tests {
 		_, err := ParseQuery(q.query, Version2_2)


### PR DESCRIPTION
The only problem I've found so far is that bosun cannot handle nan's from openTSDB, so that policy cannot be used yet. Closes #1707 