### PR TITLE
cmd/bosun: alternate templates for POST notifications

### DIFF
--- a/cmd/bosun/conf/conf.go
+++ b/cmd/bosun/conf/conf.go
@@ -329,6 +329,7 @@ type Notification struct {
 	Email        []*mail.Address
 	Post, Get    *url.URL
 	Body         *ttemplate.Template
+	ActionBody   *ttemplate.Template
 	Print        bool
 	Next         *Notification
 	Timeout      time.Duration
@@ -336,10 +337,11 @@ type Notification struct {
 	RunOnActions bool
 	UseBody      bool
 
-	next      string
-	email     string
-	post, get string
-	body      string
+	next       string
+	email      string
+	post, get  string
+	body       string
+	actionbody string
 }
 
 func (n *Notification) MarshalJSON() ([]byte, error) {
@@ -1135,6 +1137,14 @@ func (c *Conf) loadNotification(s *parse.SectionNode) {
 				c.error(err)
 			}
 			n.Body = tmpl
+		case "actionBody":
+			n.actionbody = v
+			tmpl := ttemplate.New(name).Funcs(funcs)
+			_, err := tmpl.Parse(n.actionbody)
+			if err != nil {
+				c.error(err)
+			}
+			n.ActionBody = tmpl
 		case "runOnActions":
 			n.RunOnActions = v == "true"
 		case "useBody":

--- a/cmd/bosun/conf/conf.go
+++ b/cmd/bosun/conf/conf.go
@@ -84,6 +84,7 @@ type Conf struct {
 	node            parse.Node
 	unknownTemplate string
 	bodies          *htemplate.Template
+	postbodies      *ttemplate.Template
 	subjects        *ttemplate.Template
 	squelch         []string
 }
@@ -313,11 +314,12 @@ func (c *Conf) parseNotifications(v string) (map[string]*Notification, error) {
 type Template struct {
 	Text string
 	Vars
-	Name    string
-	Body    *htemplate.Template `json:"-"`
-	Subject *ttemplate.Template `json:"-"`
+	Name     string
+	Body     *htemplate.Template `json:"-"`
+	PostBody *ttemplate.Template `json:"-"`
+	Subject  *ttemplate.Template `json:"-"`
 
-	body, subject string
+	body, postbody, subject string
 }
 
 type Notification struct {
@@ -376,6 +378,7 @@ func New(name, text string) (c *Conf, err error) {
 		Notifications:    make(map[string]*Notification),
 		RawText:          text,
 		bodies:           htemplate.New(name).Funcs(htemplate.FuncMap(defaultFuncs)),
+		postbodies:       ttemplate.New(name).Funcs(defaultFuncs),
 		subjects:         ttemplate.New(name).Funcs(defaultFuncs),
 		Lookups:          make(map[string]*Lookup),
 		Macros:           make(map[string]*Macro),
@@ -825,6 +828,14 @@ func (c *Conf) loadTemplate(s *parse.SectionNode) {
 					c.error(err)
 				}
 				t.Body = tmpl
+			case "postBody":
+				t.postbody = v
+				tmpl := c.postbodies.New(name).Funcs(funcs)
+				_, err := tmpl.Parse(t.postbody)
+				if err != nil {
+					c.error(err)
+				}
+				t.PostBody = tmpl
 			case "subject":
 				t.subject = v
 				tmpl := c.subjects.New(name).Funcs(funcs)

--- a/cmd/bosun/conf/notify.go
+++ b/cmd/bosun/conf/notify.go
@@ -26,12 +26,12 @@ func init() {
 		"The number of email notifications that Bosun failed to send.")
 }
 
-func (n *Notification) Notify(subject, body string, emailsubject, emailbody []byte, c *Conf, ak string, attachments ...*models.Attachment) {
+func (n *Notification) Notify(subject, body string, emailsubject, emailbody []byte, postbody string, c *Conf, ak string, attachments ...*models.Attachment) {
 	if len(n.Email) > 0 {
 		go n.DoEmail(emailsubject, emailbody, c, ak, attachments...)
 	}
 	if n.Post != nil {
-		go n.DoPost(n.GetPayload(subject, body), ak)
+		go n.DoPost(n.GetPayload(subject, body, postbody), ak)
 	}
 	if n.Get != nil {
 		go n.DoGet(ak)
@@ -45,7 +45,10 @@ func (n *Notification) Notify(subject, body string, emailsubject, emailbody []by
 	}
 }
 
-func (n *Notification) GetPayload(subject, body string) (payload []byte) {
+func (n *Notification) GetPayload(subject, body, postbody string) (payload []byte) {
+	if postbody != "" {
+		return []byte(postbody)
+	}
 	if n.UseBody {
 		return []byte(body)
 	} else {

--- a/cmd/bosun/conf/notify.go
+++ b/cmd/bosun/conf/notify.go
@@ -61,7 +61,14 @@ func (n *Notification) DoPrint(payload string) {
 }
 
 func (n *Notification) DoPost(payload []byte, ak string) {
-	if n.Body != nil {
+	if ak == "actionNotification" && n.ActionBody != nil {
+		buf := new(bytes.Buffer)
+		if err := n.ActionBody.Execute(buf, string(payload)); err != nil {
+			slog.Errorln(err)
+			return
+		}
+		payload = buf.Bytes()
+	} else if n.Body != nil {
 		buf := new(bytes.Buffer)
 		if err := n.Body.Execute(buf, string(payload)); err != nil {
 			slog.Errorln(err)

--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -289,6 +289,15 @@ func (s *Schedule) executeTemplates(state *models.IncidentState, event *models.E
 		}
 		endTiming()
 
+		//Render post body
+		endTiming = collect.StartTimer(metric, opentsdb.TagSet{"alert": a.Name, "type": "postbody"})
+		postbody, _, err := s.ExecuteBody(r, a, state, false, true)
+		if err != nil {
+			slog.Infof("%s: %v", state.AlertKey, err)
+			errs = append(errs, err)
+		}
+		endTiming()
+
 		//Render email body
 		endTiming = collect.StartTimer(metric, opentsdb.TagSet{"alert": a.Name, "type": "emailbody"})
 		emailbody, attachments, err := s.ExecuteBody(r, a, state, true)
@@ -328,6 +337,7 @@ func (s *Schedule) executeTemplates(state *models.IncidentState, event *models.E
 		}
 		state.Subject = string(subject)
 		state.Body = string(body)
+		state.PostBody = string(postbody)
 		//don't save email seperately if they are identical
 		if string(state.EmailBody) != state.Body {
 			state.EmailBody = emailbody

--- a/cmd/bosun/sched/notify.go
+++ b/cmd/bosun/sched/notify.go
@@ -200,7 +200,7 @@ func (s *Schedule) notify(st *models.IncidentState, n *conf.Notification) {
 	if len(st.EmailBody) == 0 {
 		st.EmailBody = []byte(st.Body)
 	}
-	n.Notify(st.Subject, st.Body, st.EmailSubject, st.EmailBody, s.Conf, string(st.AlertKey), st.Attachments...)
+	n.Notify(st.Subject, st.Body, st.EmailSubject, st.EmailBody, st.PostBody, s.Conf, string(st.AlertKey), st.Attachments...)
 }
 
 // utnotify is single notification for N unknown groups into a single notification
@@ -223,7 +223,7 @@ func (s *Schedule) utnotify(groups map[string]models.AlertKeys, n *conf.Notifica
 	}); err != nil {
 		slog.Errorln(err)
 	}
-	n.Notify(subject, body.String(), []byte(subject), body.Bytes(), s.Conf, "unknown_treshold")
+	n.Notify(subject, body.String(), []byte(subject), body.Bytes(), "", s.Conf, "unknown_treshold")
 }
 
 var defaultUnknownTemplate = &conf.Template{
@@ -258,7 +258,7 @@ func (s *Schedule) unotify(name string, group models.AlertKeys, n *conf.Notifica
 			slog.Infoln("unknown template error:", err)
 		}
 	}
-	n.Notify(subject.String(), body.String(), subject.Bytes(), body.Bytes(), s.Conf, name)
+	n.Notify(subject.String(), body.String(), subject.Bytes(), body.Bytes(), "", s.Conf, name)
 }
 
 func (s *Schedule) QueueNotification(ak models.AlertKey, n *conf.Notification, started time.Time) error {
@@ -314,7 +314,7 @@ func (s *Schedule) ActionNotify(at models.ActionType, user, message string, aks 
 			slog.Error("Error rendering action notification body", err)
 		}
 
-		notification.Notify(subject, buf.String(), []byte(subject), buf.Bytes(), s.Conf, "actionNotification")
+		notification.Notify(subject, buf.String(), []byte(subject), buf.Bytes(), "", s.Conf, "actionNotification")
 	}
 	return nil
 }

--- a/models/incidents.go
+++ b/models/incidents.go
@@ -24,6 +24,7 @@ type IncidentState struct {
 
 	Subject      string
 	Body         string
+	PostBody     string
 	EmailBody    []byte
 	EmailSubject []byte
 	Attachments  []*Attachment


### PR DESCRIPTION
This is an attempt to support rich Slack notifications with markup and weblinks:
![slack](https://cloud.githubusercontent.com/assets/712402/15276348/ff4655a6-1aed-11e6-869b-4ee30e9d6777.png)

Templates should contain JSON code, but here are the current issues:
- if the code is put into `subject`, Bosun shows ugly incident titles on a web page: https://github.com/bosun-monitor/bosun/issues/1096#issue-90477041.
- `useBody` setting does not help - HTML markup is automatically added to JSON content, and Slack servers do not accept such calls.
- Acknowledgement notifications do not work.

Ideally, we need additional variable resolution in notification settings: #689 & #1726. But this is a complex feature, I found no easy way how to implement it.

Instead, I've added two more settings: 
- `postBody` provide alternate template for common notifications.
- `actionBody` is used for action notifications.

Unfortunately, they have to be configured in different places.

Here is a full example:

```
template lowDatastoreSpace {
    subject = `Datastore free space = {{ bytes (.Eval .Alert.Vars.freeSpace)}}`
    body = `{{ .Graph .Alert.Vars.metric }}`
    postBody = `{ "attachments": [{
        "color": "danger",
        "title": "Incident #{{ .Id }}",
        "title_link": "{{ .Incident }}",
        "text": "Datastore free space = {{ bytes (.Eval .Alert.Vars.freeSpace)}}",
        "fallback": "Incident #{{ .Id }}: Datastore free space = {{ bytes (.Eval .Alert.Vars.freeSpace)}}"
    }]}`
}

notification slack {
    post = https://hooks.slack.com/services/<ID>
    actionBody = `{ "attachments": [{"color": "good", "text": "{{ . }}"}] }`
}
```

If anyone wants to try, here are [binaries](https://github.com/mkuzmin/bosun/releases/tag/0.5.dev-mkuzmin1) and a [Docker image](https://hub.docker.com/r/mkuzmin/bosun/).
