### PR TITLE
Adding monitoring for more types of interfaces

### DIFF
--- a/cmd/scollector/collectors/ifstat_linux.go
+++ b/cmd/scollector/collectors/ifstat_linux.go
@@ -52,7 +52,8 @@ var netFields = []struct {
 }
 
 var ifstatRE = regexp.MustCompile(`\s+(eth\d+|em\d+_\d+/\d+|em\d+_\d+|em\d+|` +
-	`bond\d+|team\d+|` + `p\d+p\d+_\d+/\d+|p\d+p\d+_\d+|p\d+p\d+):(.*)`)
+	`bond\d+|team\d+|` + `p\d+p\d+_\d+/\d+|p\d+p\d+_\d+|p\d+p\d+|wlan\d+|` +
+	`ppp\d+|tun\d+):(.*)`)
 
 func c_ipcount_linux() (opentsdb.MultiDataPoint, error) {
 	var md opentsdb.MultiDataPoint


### PR DESCRIPTION
- Scollector monitors interfaces whose interface names have a specific prefix.
- Adding tun, wlan and ppp to be monitored too
