### PR TITLE
Send throttling

### DIFF
--- a/cmd/bosun/web/static.go
+++ b/cmd/bosun/web/static.go
@@ -155,7 +155,9 @@ func FSByte(useLocal bool, name string) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		return ioutil.ReadAll(f)
+		b, err := ioutil.ReadAll(f)
+		f.Close()
+		return b, err
 	}
 	f, err := _escStatic.prepare(name)
 	if err != nil {

--- a/cmd/scollector/conf/conf.go
+++ b/cmd/scollector/conf/conf.go
@@ -21,6 +21,8 @@ type Conf struct {
 	DisableSelf bool
 	// Freq is the default frequency in seconds for most collectors.
 	Freq int
+	// MinimumSendInterval is the interval to wait between http posts
+	MinimumSendInterval int
 	// BatchSize is the number of metrics that will be sent in each batch.
 	BatchSize int
 	// MaxQueueLen is the number of metrics keept internally.

--- a/cmd/scollector/doc.go
+++ b/cmd/scollector/doc.go
@@ -100,7 +100,12 @@ Freq (integer): is the default frequency in seconds for most collectors.
 BatchSize (integer): is the number of metrics that will be sent in each batch.
 Default is 500.
 
-MaxQueueLen (integer): is the number of metrics keept internally.
+MinimumSendInterval (integer): is the minimum time in seconds to wait between
+sending batches of data to TSDB. This property is only used if there is no
+backlog of data. This property is to be used with a higher BatchSize value
+if you wish to throttle the amount of calls to TSDB.
+
+MaxQueueLen (integer): is the number of metrics kept internally.
 Default is 200000.
 
 Filter (array of string): Only include collectors matching these terms. Prefix

--- a/cmd/scollector/main.go
+++ b/cmd/scollector/main.go
@@ -193,6 +193,13 @@ func main() {
 	}
 	collectors.DefaultFreq = freq
 	collect.Freq = freq
+
+	minimumSendInterval := time.Second * time.Duration(conf.MinimumSendInterval)
+	if minimumSendInterval < 0 {
+		slog.Fatal("minimumSendInterval must be >= 0")
+	}
+	collect.MinimumSendInterval = minimumSendInterval
+
 	if conf.BatchSize < 0 {
 		slog.Fatal("BatchSize must be > 0")
 	}

--- a/cmd/snmpTester/static.go
+++ b/cmd/snmpTester/static.go
@@ -155,7 +155,9 @@ func FSByte(useLocal bool, name string) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		return ioutil.ReadAll(f)
+		b, err := ioutil.ReadAll(f)
+		f.Close()
+		return b, err
 	}
 	f, err := _escStatic.prepare(name)
 	if err != nil {

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -24,6 +24,9 @@ var (
 	// Freq is how often metrics are sent to OpenTSDB.
 	Freq = time.Second * 15
 
+	// MinimumSendInterval is the interval to wait between http posts
+	MinimumSendInterval = time.Second * 0
+
 	// MaxQueueLen is the maximum size of the queue, above which incoming data will
 	// be discarded. Defaults to about 150MB.
 	MaxQueueLen = 200000

--- a/collect/queue.go
+++ b/collect/queue.go
@@ -66,6 +66,7 @@ func send() {
 			// If there is no backlog, wait for the minimum send interval before sending any more data
 			if i < BatchSize && time.Since(lastSent) < MinimumSendInterval {
 				qlock.Unlock()
+				time.Sleep(time.Second)
 				continue
 			}
 

--- a/collect/queue.go
+++ b/collect/queue.go
@@ -66,7 +66,8 @@ func send() {
 			// If there is no backlog, wait for the minimum send interval before sending any more data
 			if i < BatchSize && time.Since(lastSent) < MinimumSendInterval {
 				qlock.Unlock()
-				time.Sleep(time.Second)
+				waitTime := lastSent.Add(MinimumSendInterval).Sub(time.Now())
+				time.Sleep(waitTime)
 				continue
 			}
 

--- a/collect/queue.go
+++ b/collect/queue.go
@@ -56,9 +56,19 @@ func Flush() {
 }
 
 func send() {
+
+	lastSent := time.Now()
+
 	for {
 		qlock.Lock()
 		if i := len(queue); i > 0 {
+
+			// If there is no backlog, wait for the minimum send interval before sending any more data
+			if i < BatchSize && time.Since(lastSent) < MinimumSendInterval {
+				qlock.Unlock()
+				continue
+			}
+
 			if i > BatchSize {
 				i = BatchSize
 			}
@@ -70,6 +80,7 @@ func send() {
 			qlock.Unlock()
 			Sample("collect.post.batchsize", Tags, float64(len(sending)))
 			sendBatch(sending)
+			lastSent = time.Now()
 		} else {
 			qlock.Unlock()
 			time.Sleep(time.Second)


### PR DESCRIPTION
We've added the ability to throttle the rate at which SCollector sends data to TSDB. This is configurable by an optional property and by default will work as-is with no throttling.
This is useful if you need to regulate the load on your TSDB instance (or proxy in between).
