### PR TITLE
Not allowing invalid datapoints to ruin entire batches

### DIFF
--- a/cmd/scollector/collectors/collectors.go
+++ b/cmd/scollector/collectors/collectors.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -17,6 +19,7 @@ import (
 	"bosun.org/cmd/scollector/conf"
 	"bosun.org/metadata"
 	"bosun.org/opentsdb"
+	"bosun.org/slog"
 	"bosun.org/util"
 )
 
@@ -236,14 +239,23 @@ func AddTS(md *opentsdb.MultiDataPoint, name string, ts int64, value interface{}
 	if skipMetric(name) {
 		return
 	}
-	if b, ok := value.(bool); ok {
-		if b {
-			value = 1
-		} else {
-			value = 0
-		}
-	}
+
 	tags := t.Copy()
+	// if tags are not cleanable, log a message and skip it
+	if err := tags.Clean(); err != nil {
+		line := ""
+		//attempt to log where Add was called from
+		if _, filename, l, ok := runtime.Caller(1); ok {
+			if filepath.Base(filename) == "collectors.go" {
+				_, filename, l, ok = runtime.Caller(2)
+			}
+			if ok {
+				line = fmt.Sprintf("%s:%d", filepath.Base(filename), l)
+			}
+		}
+		slog.Errorf("Invalid tagset discovered: %s. Skipping datapoint. Added from: %s", tags.String(), line)
+		return
+	}
 	if host, present := tags["host"]; !present {
 		tags["host"] = util.Hostname
 	} else if host == "" {
@@ -258,8 +270,14 @@ func AddTS(md *opentsdb.MultiDataPoint, name string, ts int64, value interface{}
 	if desc != "" {
 		metadata.AddMeta(name, tags, "desc", desc, false)
 	}
-
 	tags = AddTags.Copy().Merge(tags)
+	if b, ok := value.(bool); ok {
+		if b {
+			value = 1
+		} else {
+			value = 0
+		}
+	}
 	d := opentsdb.DataPoint{
 		Metric:    name,
 		Timestamp: ts,

--- a/cmd/scollector/collectors/collectors_test.go
+++ b/cmd/scollector/collectors/collectors_test.go
@@ -1,6 +1,9 @@
 package collectors
 
-import "testing"
+import (
+	"bosun.org/opentsdb"
+	"testing"
+)
 
 func TestIsDigit(t *testing.T) {
 	if IsDigit("1a3") {
@@ -8,5 +11,14 @@ func TestIsDigit(t *testing.T) {
 	}
 	if !IsDigit("029") {
 		t.Error("029: expected true")
+	}
+}
+
+func TestAddTS_Invalid(t *testing.T) {
+	mdp := &opentsdb.MultiDataPoint{}
+	ts := opentsdb.TagSet{"srv": "%%%"}
+	Add(mdp, "aaaa", 42, ts, "", "", "") //don't have a good way to tesst this automatically, but I look for a log message with this line number in it.
+	if len(*mdp) != 0 {
+		t.Fatal("Shouldn't have added invalid tags.")
 	}
 }

--- a/cmd/scollector/collectors/processes_linux.go
+++ b/cmd/scollector/collectors/processes_linux.go
@@ -276,7 +276,7 @@ func NewWatchedProc(params conf.ProcessParams) (*WatchedProc, error) {
 	if params.Name == "" {
 		params.Name = params.Command
 	}
-	if !opentsdb.ValidTag(params.Name) {
+	if !opentsdb.ValidTSDBString(params.Name) {
 		return nil, fmt.Errorf("bad process name: %v", params.Name)
 	}
 	return &WatchedProc{

--- a/cmd/scollector/collectors/program.go
+++ b/cmd/scollector/collectors/program.go
@@ -219,7 +219,7 @@ func parseTcollectorValue(line string) (*opentsdb.DataPoint, error) {
 	if err != nil {
 		return nil, fmt.Errorf("bad value: %s", sp[2])
 	}
-	if !opentsdb.ValidTag(sp[0]) {
+	if !opentsdb.ValidTSDBString(sp[0]) {
 		return nil, fmt.Errorf("bad metric: %s", sp[0])
 	}
 	dp := opentsdb.DataPoint{

--- a/opentsdb/tsdb_test.go
+++ b/opentsdb/tsdb_test.go
@@ -288,7 +288,7 @@ func TestQueryString(t *testing.T) {
 	}
 }
 
-func TestValidTag(t *testing.T) {
+func TestValidTSDBString(t *testing.T) {
 	tests := map[string]bool{
 		"abcXYZ012_./-": true,
 
@@ -297,7 +297,7 @@ func TestValidTag(t *testing.T) {
 		"a=b": false,
 	}
 	for s, v := range tests {
-		r := ValidTag(s)
+		r := ValidTSDBString(s)
 		if v != r {
 			t.Errorf("%v: got %v, expected %v", s, r, v)
 		}


### PR DESCRIPTION
1. opentsdb.DataPoint.IsValid is largely unchanged. Determines if datapoint is valid to submit as is.
2. If collect gets a non-cleanable datapoint it silently drops it.
3. When you `Add` a datapoint, if the tags cannot be cleaned, it will log a message with (hopefully) a helpful line number, and drop it.