### PR TITLE
Add trafficSource tracking for detailed GA metrics.

### DIFF
--- a/cmd/scollector/collectors/google_analytics.go
+++ b/cmd/scollector/collectors/google_analytics.go
@@ -58,7 +58,7 @@ func c_google_analytics(clientid string, secret string, tokenstr string, sites [
 		return nil, err
 	}
 
-	dimensions := []string{"browser", "trafficType", "deviceCategory", "operatingSystem"}
+	dimensions := []string{"browser", "trafficType", "trafficSource", "deviceCategory", "operatingSystem"}
 	for _, site := range sites {
 		getPageviews(&md, svc, site)
 		if site.Detailed {


### PR DESCRIPTION
:eyeglasses: @kylebrandt / @captncraig 

This is so we can keep an eye on referral traffic for SO.