### PR TITLE
Pass IncidentState to notifications for richer templating

### DIFF
--- a/cmd/bosun/conf/conf.go
+++ b/cmd/bosun/conf/conf.go
@@ -352,16 +352,17 @@ type Template struct {
 type Notification struct {
 	Text string
 	Vars
-	Name         string
-	Email        []*mail.Address
-	Post, Get    *url.URL
-	Body         *ttemplate.Template
-	Print        bool
-	Next         *Notification
-	Timeout      time.Duration
-	ContentType  string
-	RunOnActions bool
-	UseBody      bool
+	Name           string
+	Email          []*mail.Address
+	Post, Get      *url.URL
+	Body           *ttemplate.Template
+	Print          bool
+	Next           *Notification
+	Timeout        time.Duration
+	ContentType    string
+	RunOnActions   bool
+	UseBody        bool
+	UseFullContext bool
 
 	next      string
 	email     string
@@ -1153,6 +1154,8 @@ func (c *Conf) loadNotification(s *parse.SectionNode) {
 			n.RunOnActions = v == "true"
 		case "useBody":
 			n.UseBody = v == "true"
+		case "useFullContext":
+			n.UseFullContext = v == "true"
 		default:
 			c.errorf("unknown key %s", k)
 		}

--- a/cmd/bosun/conf/notify.go
+++ b/cmd/bosun/conf/notify.go
@@ -62,8 +62,14 @@ func (n *Notification) DoPost(st *models.IncidentState) {
 	ak := string(st.AlertKey)
 
 	if n.Body != nil {
+		var context interface{}
+		if n.UseFullContext {
+			context = st
+		} else {
+			context = string(payload)
+		}
 		buf := new(bytes.Buffer)
-		if err := n.Body.Execute(buf, string(payload)); err != nil {
+		if err := n.Body.Execute(buf, context); err != nil {
 			slog.Errorln(err)
 			return
 		}

--- a/cmd/bosun/conf/notify.go
+++ b/cmd/bosun/conf/notify.go
@@ -26,21 +26,21 @@ func init() {
 		"The number of email notifications that Bosun failed to send.")
 }
 
-func (n *Notification) Notify(subject, body string, emailsubject, emailbody []byte, c *Conf, ak string, attachments ...*models.Attachment) {
+func (n *Notification) Notify(st *models.IncidentState, c *Conf) {
 	if len(n.Email) > 0 {
-		go n.DoEmail(emailsubject, emailbody, c, ak, attachments...)
+		go n.DoEmail(st, c)
 	}
 	if n.Post != nil {
-		go n.DoPost(n.GetPayload(subject, body), ak)
+		go n.DoPost(st)
 	}
 	if n.Get != nil {
-		go n.DoGet(ak)
+		go n.DoGet(string(st.AlertKey))
 	}
 	if n.Print {
 		if n.UseBody {
-			go n.DoPrint("Subject: " + subject + ", Body: " + body)
+			go n.DoPrint("Subject: " + st.Subject + ", Body: " + st.Body)
 		} else {
-			go n.DoPrint(subject)
+			go n.DoPrint(st.Subject)
 		}
 	}
 }
@@ -57,7 +57,10 @@ func (n *Notification) DoPrint(payload string) {
 	slog.Infoln(payload)
 }
 
-func (n *Notification) DoPost(payload []byte, ak string) {
+func (n *Notification) DoPost(st *models.IncidentState) {
+	payload := n.GetPayload(st.Subject, st.Body)
+	ak := string(st.AlertKey)
+
 	if n.Body != nil {
 		buf := new(bytes.Buffer)
 		if err := n.Body.Execute(buf, string(payload)); err != nil {
@@ -94,17 +97,20 @@ func (n *Notification) DoGet(ak string) {
 	}
 }
 
-func (n *Notification) DoEmail(subject, body []byte, c *Conf, ak string, attachments ...*models.Attachment) {
+func (n *Notification) DoEmail(st *models.IncidentState, c *Conf) {
 	e := email.NewEmail()
 	e.From = c.EmailFrom
 	for _, a := range n.Email {
 		e.To = append(e.To, a.Address)
 	}
-	e.Subject = string(subject)
-	e.HTML = body
-	for _, a := range attachments {
-		e.Attach(bytes.NewBuffer(a.Data), a.Filename, a.ContentType)
+	e.Subject = string(st.EmailSubject)
+	e.HTML = st.EmailBody
+	if st.Attachments != nil {
+		for _, a := range st.Attachments {
+			e.Attach(bytes.NewBuffer(a.Data), a.Filename, a.ContentType)
+		}
 	}
+	ak := string(st.AlertKey)
 	e.Headers.Add("X-Bosun-Server", util.Hostname)
 	if err := Send(e, c.SMTPHost, c.SMTPUsername, c.SMTPPassword); err != nil {
 		collect.Add("email.sent_failed", nil, 1)
@@ -112,7 +118,7 @@ func (n *Notification) DoEmail(subject, body []byte, c *Conf, ak string, attachm
 		return
 	}
 	collect.Add("email.sent", nil, 1)
-	slog.Infof("relayed alert %v to %v sucessfully. Subject: %d bytes. Body: %d bytes.", ak, e.To, len(subject), len(body))
+	slog.Infof("relayed alert %v to %v sucessfully. Subject: %d bytes. Body: %d bytes.", ak, e.To, len(st.EmailSubject), len(st.EmailBody))
 }
 
 // Send an email using the given host and SMTP auth (optional), returns any

--- a/cmd/bosun/web/expr.go
+++ b/cmd/bosun/web/expr.go
@@ -243,7 +243,11 @@ func procRule(t miniprofiler.Timer, c *conf.Conf, a *conf.Alert, now time.Time, 
 			} else if s_err != nil {
 				warning = append(warning, s_err.Error())
 			} else {
-				n.DoEmail(email_subject, email, schedule.Conf, string(primaryIncident.AlertKey), attachments...)
+				st := sched.NewIncident(primaryIncident.AlertKey)
+				st.EmailSubject = email_subject
+				st.EmailBody = email
+				st.Attachments = attachments
+				n.DoEmail(st, schedule.Conf)
 			}
 		}
 		data = s.Data(rh, primaryIncident, a, false)

--- a/cmd/bosun/web/static/js/ace/mode-bosun.js
+++ b/cmd/bosun/web/static/js/ace/mode-bosun.js
@@ -11,7 +11,7 @@ var BosunHighlightRules = function() {
 	var inAlertKeywords = "macro|template|crit|warn|depends|squelch|critNotification|" +
 	"warnNotification|unknown|unjoinedOk|ignoreUnknown|log|maxLogFrequency"
 
-	var inNotificationKeywords = "email|post|get|print|contentType|next|timeout|body|useBody";
+	var inNotificationKeywords = "email|post|get|print|contentType|next|timeout|body|useBody|useFullContext";
 
 	var inTemplateKeywords = "subject|body";
 


### PR DESCRIPTION
This series adds `useFullContext` notification setting. If it's set to true, instead of the template subject/body, the notification template gets passed the whole IncidentState. This allows for richer notifications, e.g.:

```
template common {
    subject = {{.Alert.Vars.title}} on {{.Group.host}}
    body = `<h1><a href="{{.Incident}}">[{{.Last.Status}}] {{.Alert.Vars.title}} on {{.Group.host}}</a></h1>`
}

notification some_webservice {
    post = http://localhost:8000/some_webservice
    useFullContext = true
    body = `{
        "author": "Bosun",
        "thread_id": "{{.AlertKey}}",
        "status": "{{.CurrentStatus}}",
        "subject": "{{.Subject}}",
        "body": {{.Body|json}}
    }`
    contentType = application/json
}
```
