### PR TITLE
cmd/scollector: Record the current_source as a tag rather than a separate metric.

### DIFF
--- a/cmd/scollector/collectors/ntp_unix.go
+++ b/cmd/scollector/collectors/ntp_unix.go
@@ -70,11 +70,9 @@ func c_ntp_peers_unix() (opentsdb.MultiDataPoint, error) {
 		}
 		remote := fields[0]
 		tags := opentsdb.TagSet{"remote": remote, "refid": fields[1]}
-		var current_source int
 		if fl == "*" {
-			current_source = 1
+			tags = tags.Merge(opentsdb.TagSet{"current_source": "1"})
 		}
-		Add(&md, metric+"current_source", current_source, tags, metadata.Gauge, metadata.Bool, "")
 		Add(&md, metric+"stratum", fields[2], tags, metadata.Gauge, "Stratum", "")
 		when, err := ntpUnPretty(fields[4])
 		if err != nil {


### PR DESCRIPTION
Currently, things like ntp.offset are of limited use by themselves. You can't tell which remote the metric is measured against without cross-referencing against ntp.current_source, which seems a bit silly.

This change will allow us to alert things like ntp.offset properly with much more ease, as we can simply filter it using the tag rather than cross referencing. The ntp.current_source metric is currently entirely unused in our config.

:eyeglasses: @kylebrandt  / @captncraig 
