### PR TITLE
docker: update docker build files

### DIFF
--- a/cmd/bosun/docker/build/Dockerfile
+++ b/cmd/bosun/docker/build/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir -p /hbase \
     | tar -xzC /hbase \
     && mv /hbase/hbase-$HBASEVER /hbase/hbase
 
-RUN curl -SL https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz \
+RUN curl -SL https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz \
     | tar -xzC /usr/local
 
 COPY bosun $GOPATH/src/bosun.org/
@@ -35,3 +35,4 @@ ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 RUN go run build/build.go \
 	&& bosun -version \
 	&& scollector -version
+#   && tsdbrelay -version doesn't work. See https://github.com/bosun-monitor/bosun/issues/1792

--- a/cmd/bosun/docker/docker.sh
+++ b/cmd/bosun/docker/docker.sh
@@ -13,9 +13,10 @@ rm -rf build/bosun $TMP
 git clone -b $branch --single-branch ../../.. build/bosun
 docker build -t bosun-build build
 ID=$(docker create bosun-build)
-mkdir -p $TMP/hbase $TMP/bosun $TMP/tsdb $TMP/scollector
+mkdir -p $TMP/hbase $TMP/bosun $TMP/tsdb $TMP/scollector $TMP/tsdbrelay
 docker cp ${ID}:/go/bin/bosun $TMP/bosun/.
 docker cp ${ID}:/go/bin/scollector $TMP/scollector/.
+docker cp ${ID}:/go/bin/tsdbrelay $TMP/tsdbrelay/.
 docker cp ${ID}:/hbase $TMP
 docker cp ${ID}:/tsdb $TMP
 docker rm ${ID}

--- a/cmd/bosun/docker/run/Dockerfile
+++ b/cmd/bosun/docker/run/Dockerfile
@@ -5,6 +5,9 @@ RUN apt-get update && apt-get install -y \
 	make \
 	openjdk-7-jre-headless \
 	supervisor \
+	nano \
+	vim \
+	less \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
@@ -14,8 +17,11 @@ ENV TSDB /tsdb
 ENV HBASE /hbase/hbase
 ENV HBASE_HOME $HBASE
 ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
+ENV TSDBRELAY_OPTS -b localhost:8070 -t localhost:4242 -l 0.0.0.0:5252 -redis localhost:9565
+ENV TERM dumb
 
 COPY bosun.conf /data/
+COPY scollector.toml /data/
 COPY hbase-site.xml $HBASE/conf/
 COPY start_hbase.sh /hbase/
 COPY opentsdb.conf /tsdb/
@@ -25,5 +31,6 @@ COPY create_tsdb_tables.sh /tsdb/
 
 COPY tmp /
 
-EXPOSE 8070 4242 9565
+EXPOSE 8070 4242 5252 9565 16010
+VOLUME ["/data", "/var/log", "/tmp", "/tsdb"]
 CMD ["/usr/bin/supervisord"]

--- a/cmd/bosun/docker/run/Dockerfile
+++ b/cmd/bosun/docker/run/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
 	nano \
 	vim \
 	less \
+	wget \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 

--- a/cmd/bosun/docker/run/bosun.conf
+++ b/cmd/bosun/docker/run/bosun.conf
@@ -1,3 +1,5 @@
 tsdbHost = localhost:4242
-stateFile = /data/bosun.state
+tsdbVersion = 2.2
+#stateFile = /data/bosun.state #No longer used
+ledisDir = /data/ledis_data
 ledisBindAddr = 0.0.0.0:9565

--- a/cmd/bosun/docker/run/scollector.toml
+++ b/cmd/bosun/docker/run/scollector.toml
@@ -6,6 +6,9 @@ Host = "localhost:5252"
 
 BatchSize = 5000
 
+#Monitoring of hbase inside the container
+HadoopHost = "localhost:16010"
+
 #Redis or ledis based external counters. See https://godoc.org/bosun.org/cmd/tsdbrelay
 [[RedisCounters]]
     Server = "localhost:9565"

--- a/cmd/bosun/docker/run/scollector.toml
+++ b/cmd/bosun/docker/run/scollector.toml
@@ -1,0 +1,11 @@
+#Direct to Bosun
+#Host = "localhost:8070"
+
+#Send to tsdbrelay. Use TSDBRELAY_OPTS environment variable for forwarding options
+Host = "localhost:5252"
+
+BatchSize = 5000
+
+#Redis or ledis based external counters. See https://godoc.org/bosun.org/cmd/tsdbrelay
+[[RedisCounters]]
+    Server = "localhost:9565"

--- a/cmd/bosun/docker/run/supervisord.conf
+++ b/cmd/bosun/docker/run/supervisord.conf
@@ -3,12 +3,20 @@ nodaemon=true
 
 [program:hbase]
 command=/hbase/start_hbase.sh
+priority=10
 
 [program:opentsdb]
 command=/tsdb/start_opentsdb.sh
+priority=15
 
 [program:bosun]
 command=/bosun/bosun -c /data/bosun.conf
+priority=20
+
+[program:tsdbrelay]
+command=/bin/bash -c "/tsdbrelay/tsdbrelay ${TSDBRELAY_OPTS}"
+priority=100
 
 [program:scollector]
-command=/scollector/scollector -h localhost:8070
+command=/scollector/scollector -conf /data/scollector.toml
+priority=200


### PR DESCRIPTION
Use go 1.6.2 instead of 1.6
Include tsdbrelay in container. Use TSDBRELAY_OPTS env var to override startup settings
Include /data/scollector.toml file with settings required for ledis backed counters

The latest OpenTSDB version is downloaded at build time from https://github.com/OpenTSDB/opentsdb/releases

This also updates the bosun.conf file to use `tsdbVersion = 2.2` and `ledisDir = /data/ledis_data`