### PR TITLE
Bosun function tail

### DIFF
--- a/cmd/bosun/expr/expr.go
+++ b/cmd/bosun/expr/expr.go
@@ -231,6 +231,14 @@ func (s SortableSeries) Len() int           { return len(s) }
 func (s SortableSeries) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s SortableSeries) Less(i, j int) bool { return s[i].T.Before(s[j].T) }
 
+func NewSortableSeries(dps Series) SortableSeries {
+	series := make(SortableSeries, 0, len(dps))
+	for t, v := range dps {
+		series = append(series, SortablePoint{t, v})
+	}
+	return series
+}
+
 func NewSortedSeries(dps Series) SortableSeries {
 	series := make(SortableSeries, 0, len(dps))
 	for t, v := range dps {

--- a/cmd/bosun/expr/expr.go
+++ b/cmd/bosun/expr/expr.go
@@ -231,14 +231,6 @@ func (s SortableSeries) Len() int           { return len(s) }
 func (s SortableSeries) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s SortableSeries) Less(i, j int) bool { return s[i].T.Before(s[j].T) }
 
-func NewSortableSeries(dps Series) SortableSeries {
-	series := make(SortableSeries, 0, len(dps))
-	for t, v := range dps {
-		series = append(series, SortablePoint{t, v})
-	}
-	return series
-}
-
 func NewSortedSeries(dps Series) SortableSeries {
 	series := make(SortableSeries, 0, len(dps))
 	for t, v := range dps {

--- a/cmd/bosun/expr/funcs.go
+++ b/cmd/bosun/expr/funcs.go
@@ -473,7 +473,7 @@ func Tail(e *State, T miniprofiler.Timer, series *Results, number *Results) (*Re
 		// load up new series with desired
 		// number of points
 		// we already checked len so this is safe
-		for _, item := range sorted[len(sorted)-tailLength : len(sorted)] {
+		for _, item := range sorted[len(sorted)-tailLength:] {
 			newSeries[item.T] = item.V
 		}
 		res.Results = append(res.Results, s)

--- a/cmd/bosun/expr/funcs.go
+++ b/cmd/bosun/expr/funcs.go
@@ -453,6 +453,9 @@ func quickSelect(data sort.Interface, k int, max bool) {
 	low := 0
 	high := data.Len() - 1
 
+	// if we asked to last k and we
+	// don't have that much everyone
+	// is in the set
 	if k > data.Len() {
 		return
 	}

--- a/cmd/bosun/expr/funcs.go
+++ b/cmd/bosun/expr/funcs.go
@@ -3,7 +3,6 @@ package expr
 import (
 	"fmt"
 	"math"
-	"math/rand"
 	"sort"
 	"strings"
 	"time"
@@ -447,80 +446,33 @@ func Filter(e *State, T miniprofiler.Timer, series *Results, number *Results) (*
 	return series, nil
 }
 
-func quickSelect(data sort.Interface, k int, max bool) {
-
-	var pivotIndex int
-	low := 0
-	high := data.Len() - 1
-
-	// if we asked to last k and we
-	// don't have that much everyone
-	// is in the set
-	if k > data.Len() {
-		return
-	}
-
-	for {
-
-		if low >= high {
-			return
-		}
-
-		pivotIndex = rand.Intn(high+1-low) + low
-		pivotIndex = partition(data, low, high, pivotIndex, max)
-
-		if k < pivotIndex {
-			high = pivotIndex - 1
-		} else if k > pivotIndex {
-			low = pivotIndex + 1
-		} else {
-			return
-		}
-	}
-}
-
-func partition(data sort.Interface, low, high, pivotIndex int, max bool) int {
-	partitionIndex := low
-	data.Swap(pivotIndex, high)
-	for i := low; i < high; i++ {
-		if (!data.Less(i, high) && max) || (data.Less(i, high) && !max) {
-			data.Swap(i, partitionIndex)
-			partitionIndex++
-		}
-
-	}
-	data.Swap(partitionIndex, high)
-	return partitionIndex
-}
-
 func Tail(e *State, T miniprofiler.Timer, series *Results, v float64) (*Results, error) {
+	tailLength := int(v)
 	for _, sr := range series.Results {
 		// if there are fewer points than the requested tail
 		// short circut and just return current series
-		if len(sr.Value.Value().(Series)) > int(v) {
+		if len(sr.Value.Value().(Series)) <= tailLength {
+			continue
+		}
 
-			// create new sortable series
-			// that is not sorted
-			oldSr := sr.Value.Value().(Series)
-			sortable := NewSortableSeries(oldSr)
+		// create new sorted series
+		// not going to do quick select
+		// see https://github.com/bosun-monitor/bosun/pull/1802
+		// for details
+		oldSr := sr.Value.Value().(Series)
+		sorted := NewSortedSeries(oldSr)
 
-			// create new series keep a reference
-			// and point sr.Value interface at reference
-			// as we don't need old series any more
-			newSeries := make(Series)
-			sr.Value = newSeries
+		// create new series keep a reference
+		// and point sr.Value interface at reference
+		// as we don't need old series any more
+		newSeries := make(Series)
+		sr.Value = newSeries
 
-			// make the front of series have
-			// largest ts be in the front of
-			// sortable series
-			quickSelect(sortable, int(v), true)
-
-			// load up new series with desired
-			// number of points
-			// we already checked len so this is safe
-			for count := 0; count < int(v); count++ {
-				newSeries[sortable[count].T] = sortable[count].V
-			}
+		// load up new series with desired
+		// number of points
+		// we already checked len so this is safe
+		for _, item := range sorted[len(sorted)-tailLength : len(sorted)] {
+			newSeries[item.T] = item.V
 		}
 	}
 

--- a/cmd/bosun/expr/funcs_test.go
+++ b/cmd/bosun/expr/funcs_test.go
@@ -2,8 +2,6 @@ package expr
 
 import (
 	"fmt"
-	"reflect"
-	"sort"
 	"testing"
 	"time"
 
@@ -197,73 +195,6 @@ func TestTimedelta(t *testing.T) {
 
 		if err != nil {
 			t.Error(err)
-		}
-	}
-}
-
-func TestQuickSelect(t *testing.T) {
-	for testCase, i := range []struct {
-		description string
-		input       sort.IntSlice
-		number      int
-		max         bool
-		expected    sort.IntSlice
-	}{
-		{
-			"sanity check that returns 3 min results",
-			[]int{1, 2, 4, 5, 6, 7, 8},
-			3,
-			false,
-			[]int{1, 2, 4},
-		},
-		{
-			"case with multiple of the same number in return",
-			[]int{1, 2, 4, 1, 5, 1, 6, 7, 8, 1},
-			3,
-			false,
-			[]int{1, 1, 1},
-		},
-		{
-			"sanity check that returns 3 max results",
-			[]int{99, 2, 4, 1, 5, 1, 6, 7, 8, 1, 0, 100},
-			3,
-			true,
-			[]int{99, 100, 8},
-		},
-		{
-			"case where requested results are longer than array",
-			[]int{1},
-			3,
-			true,
-			[]int{1},
-		},
-	} {
-
-		quickSelect(i.input, i.number, i.max)
-
-		// quickSelect doesn't provide order
-		// lets just sort for ease of test
-		// also quickSelect doesn't care if
-		// you ask for more results than it has
-		found := i.input
-		if i.number < len(i.input) {
-			found = i.input[:i.number]
-		}
-
-		expected := i.expected
-		sort.Sort(found)
-		sort.Sort(expected)
-
-		if !reflect.DeepEqual(
-			found,
-			expected,
-		) {
-			t.Errorf(
-				"Test case %d: found %v expected %v\n",
-				testCase,
-				i.input[:i.number],
-				i.expected,
-			)
 		}
 	}
 }

--- a/cmd/bosun/expr/funcs_test.go
+++ b/cmd/bosun/expr/funcs_test.go
@@ -217,6 +217,13 @@ func TestTail(t *testing.T) {
 				time.Unix(1466133600, 0): 1,
 			},
 		},
+		{
+			`tail(series("foo=bar", 1466133600, 1, 1466133610, 1, 1466133710, 1), last(series("foo=bar", 1466133600, 2)))`,
+			Series{
+				time.Unix(1466133610, 0): 1,
+				time.Unix(1466133710, 0): 1,
+			},
+		},
 	} {
 
 		err := testExpression(exprInOut{

--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -593,4 +593,18 @@ Would return a seriesSet equal to:
 series("foo=bar", 1466133610, 10, 1466133710, 100)
 ```
 
+## tail(seriesSet, num scaler) seriesSet
+
+Returns the most recent num points from a series. If the series is shorter than the number of requeted points the series is unchanged as all points are in the requested window. This function is useful for making calculating on the leading edge. For example:
+
+```
+tail(series("foo=bar", 1466133600, 1, 1466133610, 1, 1466133710, 1), 2)
+```
+
+Would return a seriesSet equal to:
+
+```
+series("foo=bar", 1466133610, 1, 1466133710, 1)
+```
+
 </div>

--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -593,7 +593,7 @@ Would return a seriesSet equal to:
 series("foo=bar", 1466133610, 10, 1466133710, 100)
 ```
 
-## tail(seriesSet, num scaler) seriesSet
+## tail(seriesSet, num numberSet) seriesSet
 
 Returns the most recent num points from a series. If the series is shorter than the number of requeted points the series is unchanged as all points are in the requested window. This function is useful for making calculating on the leading edge. For example:
 


### PR DESCRIPTION
There are a good amount of changes here so I will break them down here.

- Added new `NewSortableSeries` function. This allows you to convert a series into a sortable series but it doesn't do the sorting for you. This is useful if you want to use the comparison operators and hold onto state but you don't care about it being ordered from the onset.

- Added new `Tail` function to builtins. This function uses a very basic quickSelect to find the latest data points and returns just the final k data points. I will be adding additional documentation for this in the next commit. If there are less data points in the series than requested for by tail the series is left untouched.

- New unit test for the `tail` function and the `quickSelect` function are now part of the `funcs_test.go`

- New `quickSelect` function is available for anything implementing `sort.Interface` A few things here. Im not sure if we want to just eat the `log(n)` and just use `sort.Sort()` from the std lib. Im also not sure if we want to move these kinds of helpers out of the `funcs.go` to someplace else and not sure if there is an outside lib we would rather use.

Use cases for tail are inspired by `tail_avg` that you see in the skyline project https://github.com/etsy/skyline/blob/master/src/analyzer/algorithms.py Having the tail function will allow us to use some of the other bosun machinery to do math on a known length set of the most recent data points. Increasing the tail length will make the metrics more resilient to changes while shortening it will make it more sensitive. This will be helpful for situations where metrics are pushed by external systems and you cannot make guarantees about when metrics will arrive and at what density.