### PR TITLE
fix 1816 issue, riak 2.x returns undefined in json instead of zeroes

### DIFF
--- a/cmd/scollector/collectors/riak.go
+++ b/cmd/scollector/collectors/riak.go
@@ -500,6 +500,10 @@ func riak(s string) (opentsdb.MultiDataPoint, error) {
 	}
 	for k, v := range r {
 		if m, ok := riakMeta[k]; ok {
+
+			if v == "undefined" {
+				continue
+			}
 			if strings.HasPrefix(m.Metric, "node.latency") {
 				if nl, ok := v.(float64); ok {
 					v = nl / 1000000


### PR DESCRIPTION
bug fix for https://github.com/bosun-monitor/bosun/issues/1816 because riak 2.1.4 returns json with 'undefined' in some fields values instead of zeros