### PR TITLE
cmd/scollector: Fix snmp.go panic: runtime error: index out of range

### DIFF
--- a/snmp/snmp.go
+++ b/snmp/snmp.go
@@ -279,7 +279,7 @@ func check(resp *response, req *request) (err error) {
 	if e, i := resp.ErrorStatus, resp.ErrorIndex; e != 0 {
 		err := fmt.Errorf("server error: %v", errorStatus(e))
 		if i >= 0 && i < len(resp.Bindings) {
-			err = fmt.Errorf("binding %+v: %v", req.Bindings[i], err)
+			err = fmt.Errorf("binding %+v: %v", resp.Bindings[i], err)
 		}
 		return err
 	}


### PR DESCRIPTION
Should prevent scollector to crash.
