### PR TITLE
allow filtering using syntax hasTags:host1|host2|host3

### DIFF
--- a/cmd/bosun/sched/views.go
+++ b/cmd/bosun/sched/views.go
@@ -143,9 +143,12 @@ func (is IncidentSummaryView) Ask(filter string) (bool, error) {
 			if len(sp) != 2 {
 				return false, fmt.Errorf("unexpected tag specification: %v", value)
 			}
+			tagValues := strings.Split(sp[1], "|")
 			for k, v := range is.Tags {
-				if k == sp[0] && glob.Glob(sp[1], v) {
-					return true, nil
+				for _, tagValue := range tagValues {
+					if k == sp[0] && glob.Glob(tagValue, v) {
+						return true, nil
+					}
 				}
 			}
 			return false, nil


### PR DESCRIPTION
Instead of using
`hasTags:host=host1 OR hasTags:host=host2`

this change allows the user to use just:

`hasTag:host=host1|host2`
