### PR TITLE
Adding additional Elasticsearch Config options

### DIFF
--- a/cmd/bosun/expr/expr.go
+++ b/cmd/bosun/expr/expr.go
@@ -50,7 +50,7 @@ type Backends struct {
 	TSDBContext     opentsdb.Context
 	GraphiteContext graphite.Context
 	LogstashHosts   LogstashElasticHosts
-	ElasticHosts    ElasticHosts
+	ElasticConfig   ElasticConfig
 	InfluxConfig    client.Config
 }
 

--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -73,7 +73,7 @@ func (s *Schedule) NewRunHistory(start time.Time, cache *cache.Cache) *RunHistor
 			GraphiteContext: s.Conf.GraphiteContext(),
 			InfluxConfig:    s.Conf.InfluxConfig,
 			LogstashHosts:   s.Conf.LogstashElasticHosts,
-			ElasticHosts:    s.Conf.ElasticHosts,
+			ElasticConfig:   s.Conf.ElasticConfig,
 		},
 	}
 	return r

--- a/cmd/bosun/sched/template.go
+++ b/cmd/bosun/sched/template.go
@@ -514,7 +514,7 @@ func (c *Context) ESQuery(indexRoot expr.ESIndexer, filter expr.ESQuery, sdurati
 	if err != nil {
 		return nil, err
 	}
-	results, err := c.runHistory.Backends.ElasticHosts.Query(req)
+	results, err := c.runHistory.Backends.ElasticConfig.Query(req)
 	if err != nil {
 		return nil, err
 	}
@@ -534,7 +534,7 @@ func (c *Context) ESQueryAll(indexRoot expr.ESIndexer, filter expr.ESQuery, sdur
 	if err != nil {
 		return nil, err
 	}
-	results, err := c.runHistory.Backends.ElasticHosts.Query(req)
+	results, err := c.runHistory.Backends.ElasticConfig.Query(req)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/bosun/web/chart.go
+++ b/cmd/bosun/web/chart.go
@@ -241,7 +241,7 @@ func ExprGraph(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (in
 		GraphiteContext: schedule.Conf.GraphiteContext(),
 		InfluxConfig:    schedule.Conf.InfluxConfig,
 		LogstashHosts:   schedule.Conf.LogstashElasticHosts,
-		ElasticHosts:    schedule.Conf.ElasticHosts,
+		ElasticConfig:   schedule.Conf.ElasticConfig,
 	}
 	providers := &expr.BosunProviders{
 		Cache:     cacheObj,

--- a/cmd/bosun/web/expr.go
+++ b/cmd/bosun/web/expr.go
@@ -77,7 +77,7 @@ func Expr(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (v inter
 		GraphiteContext: schedule.Conf.GraphiteContext(),
 		InfluxConfig:    schedule.Conf.InfluxConfig,
 		LogstashHosts:   schedule.Conf.LogstashElasticHosts,
-		ElasticHosts:    schedule.Conf.ElasticHosts,
+		ElasticConfig:   schedule.Conf.ElasticConfig,
 	}
 	providers := &expr.BosunProviders{
 		Cache:     cacheObj,


### PR DESCRIPTION
This should give you access to more configuration options for the elastic search datasource. I think its possible that some things are still broken I will need to test some more. There will be no breaking changes to existsing elasticHosts config.

Things that still need to happen:
- docs need to be updated
- syntax hlighting needs to be updated
- annotations endpoint needs to have similar config options
