### PR TITLE
let the user sets an expiry date for tags when using the http api

### DIFF
--- a/cmd/bosun/sched/host.go
+++ b/cmd/bosun/sched/host.go
@@ -29,7 +29,7 @@ func (s *Schedule) Host(filter string) (map[string]*HostData, error) {
 	// so this makes for the fastest response
 	tagsByKey := func(metric, hostKey string) (map[string][]opentsdb.TagSet, error) {
 		byKey := make(map[string][]opentsdb.TagSet)
-		tags, err := s.Search.FilteredTagSets(metric, nil)
+		tags, err := s.Search.FilteredTagSets(metric, nil, 0)
 		if err != nil {
 			return byKey, err
 		}

--- a/cmd/bosun/search/search.go
+++ b/cmd/bosun/search/search.go
@@ -323,18 +323,21 @@ func (s *Search) TagValuesByMetricTagKey(metric, tagK string, since time.Duratio
 	return r, nil
 }
 
-func (s *Search) FilteredTagSets(metric string, tags opentsdb.TagSet) ([]opentsdb.TagSet, error) {
+func (s *Search) FilteredTagSets(metric string, tags opentsdb.TagSet, since int64) ([]opentsdb.TagSet, error) {
 	sets, err := s.DataAccess.Search().GetMetricTagSets(metric, tags)
 	if err != nil {
 		return nil, err
 	}
 	r := []opentsdb.TagSet{}
-	for k := range sets {
+	for k, lastSeen := range sets {
 		ts, err := opentsdb.ParseTags(k)
 		if err != nil {
 			return nil, err
 		}
-		r = append(r, ts)
+		if lastSeen >= since {
+			r = append(r, ts)
+		}
+
 	}
 	return r, nil
 }

--- a/cmd/bosun/web/search.go
+++ b/cmd/bosun/web/search.go
@@ -63,7 +63,16 @@ func FilteredTagsetsByMetric(t miniprofiler.Timer, w http.ResponseWriter, r *htt
 			return nil, err
 		}
 	}
-	return schedule.Search.FilteredTagSets(metric, tagset)
+
+	since := int64(0)
+	sinceStr := r.FormValue("since")
+	if sinceStr != "" {
+		since, err = strconv.ParseInt(sinceStr, 10, 64) //since will be set to 0 again in case of errors
+		if err != nil {
+			return nil, err
+		}
+	}
+	return schedule.Search.FilteredTagSets(metric, tagset, since)
 }
 
 func MetricsByTagPair(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (interface{}, error) {


### PR DESCRIPTION
this can be tested with the command:

curl -G 'http://bosun-host:8070/api/tagsets/os.net.bytes?since=1468592138' --data-urlencode 'tags=host=daileon'

"since" is an optional parameter and will default to retrieve all tags,
which is the previous behavior. Invalid timestamps will result in error.