### PR TITLE
cmd/scollector: configurable elasticsearch collector

### DIFF
--- a/cmd/scollector/conf/conf.go
+++ b/cmd/scollector/conf/conf.go
@@ -55,33 +55,30 @@ type Conf struct {
 	// SNMPTimeout is the number of seconds to wait for SNMP responses (default 30)
 	SNMPTimeout int
 
-	HAProxy        []HAProxy
-	SNMP           []SNMP
-	MIBS           map[string]MIB
-	ICMP           []ICMP
-	Vsphere        []Vsphere
-	AWS            []AWS
-	Process        []ProcessParams
-	SystemdService []ServiceParams
-	ProcessDotNet  []ProcessDotNet
-	HTTPUnit       []HTTPUnit
-	Riak           []Riak
-	Github         []Github
-	// ElasticIndexFilters takes regular expressions and excludes indicies that
-	// match those filters from being monitored for metrics in the elastic.indices
-	// namespace
-	ElasticIndexFilters []string
-	RabbitMQ            []RabbitMQ
-	Nexpose             []Nexpose
-	GoogleAnalytics     []GoogleAnalytics
-	Cadvisor            []Cadvisor
-	RedisCounters       []RedisCounters
-	ExtraHop            []ExtraHop
-	LocalListener       string
-	TagOverride         []TagOverride
-	HadoopHost          string
-	Oracles             []Oracle
-	Fastly              []Fastly
+	HAProxy         []HAProxy
+	SNMP            []SNMP
+	MIBS            map[string]MIB
+	ICMP            []ICMP
+	Vsphere         []Vsphere
+	AWS             []AWS
+	Process         []ProcessParams
+	SystemdService  []ServiceParams
+	ProcessDotNet   []ProcessDotNet
+	HTTPUnit        []HTTPUnit
+	Riak            []Riak
+	Github          []Github
+	Elasticsearch   []Elasticsearch
+	RabbitMQ        []RabbitMQ
+	Nexpose         []Nexpose
+	GoogleAnalytics []GoogleAnalytics
+	Cadvisor        []Cadvisor
+	RedisCounters   []RedisCounters
+	ExtraHop        []ExtraHop
+	LocalListener   string
+	TagOverride     []TagOverride
+	HadoopHost      string
+	Oracles         []Oracle
+	Fastly          []Fastly
 }
 
 type HAProxy struct {
@@ -233,4 +230,14 @@ type Oracle struct {
 type OracleInstance struct {
 	ConnectionString string
 	Role             string
+}
+
+type Elasticsearch struct {
+	URL         string
+	IndicesFreq int
+
+	// IndexFilters takes regular expressions and excludes indicies that
+	// match those filters from being monitored for metrics in the elastic.indices
+	// namespace
+	IndexFilters []string
 }

--- a/cmd/scollector/doc.go
+++ b/cmd/scollector/doc.go
@@ -377,6 +377,16 @@ ConnectionString and Role, which are the same as using sqlplus.
 	    ConnectionString = "/@localnodevip/sid"
 	    Role = "sysdba"
 
+Elasticsearch (array of tables, key are URL, IndicesFreq and IndexFilters): URL is
+the base path to an elasticsearch cluster. IndicesFreq is the frequency in seconds
+at which indices stats are polled (it's expensive), defaults to every 15 minutes.
+IndexFilters is an array of regular expressions that excludes indices matching from
+indices stats.
+
+	[[Elasticsearch]]
+	  URL = "http://localhost:9200/"
+	  IndicesFreq = 900
+	  IndexFilters = ["nostats.*"]
 
 Windows
 


### PR DESCRIPTION
This adds configuration options for the Elasticsearch collector as well as a timeout on the http requests it does (they can tend to get stuck). As you can see in the doc.go this break previous scollector config since we can configure multiples.
