### PR TITLE
opentsdb: minor optimization to Replace. No alloc on happy path.

### DIFF
--- a/opentsdb/tsdb.go
+++ b/opentsdb/tsdb.go
@@ -307,6 +307,9 @@ func Clean(s string) (string, error) {
 // tag values and replaces them.
 // See: http://opentsdb.net/docs/build/html/user_guide/writing.html#metrics-and-tags
 func Replace(s, replacement string) (string, error) {
+	if !needsReplacement(s) {
+		return s, nil
+	}
 	var c string
 	replaced := false
 	for len(s) > 0 {
@@ -315,6 +318,7 @@ func Replace(s, replacement string) (string, error) {
 			c += string(r)
 			replaced = false
 		} else if !replaced {
+			//only replace the first occurence of an invalid character.
 			c += replacement
 			replaced = true
 		}
@@ -324,6 +328,15 @@ func Replace(s, replacement string) (string, error) {
 		return "", fmt.Errorf("clean result is empty")
 	}
 	return c, nil
+}
+
+func needsReplacement(s string) bool {
+	for _, r := range []rune(s) {
+		if !isRuneValid(r) {
+			return true
+		}
+	}
+	return false
 }
 
 func isRuneValid(r rune) bool {

--- a/opentsdb/tsdb_test.go
+++ b/opentsdb/tsdb_test.go
@@ -334,3 +334,33 @@ func TestAllSubsets(t *testing.T) {
 		t.Fatal("Expect 15 subsets")
 	}
 }
+
+func TestReplace(t *testing.T) {
+	tests := []struct{ in, out string }{
+		{"abc", "abc"},
+		{"ny-web01", "ny-web01"},
+		{"_./", "_./"},
+		{"%%%a", ".a"},
+	}
+	for i, test := range tests {
+		out, err := Replace(test.in, ".")
+		if err != nil {
+			t.Errorf("Test %d: %s", i, err)
+		}
+		if out != test.out {
+			t.Errorf("Test %d: %s != %s", i, out, test.out)
+		}
+	}
+}
+
+func BenchmarkReplace_Noop(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Replace("abcdefghijklmnopqrstuvwxyz", "")
+	}
+}
+
+func BenchmarkReplace_Something(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Replace("abcdef&hij@@$$opq#stuvw*yz", "")
+	}
+}


### PR DESCRIPTION
Benchmarks:

Before:
```
BenchmarkReplace_Noop-8        	 1000000	      1865 ns/op	     592 B/op	      51 allocs/op
BenchmarkReplace_Something-8   	 1000000	      1442 ns/op	     336 B/op	      37 allocs/op
```

After:
```
BenchmarkReplace_Noop-8        	 5000000	       327 ns/op	       0 B/op	       0 allocs/op
BenchmarkReplace_Something-8   	 1000000	      1676 ns/op	     336 B/op	      37 allocs/op
```

Could potentially optimize the replacing case, especially since we are almost always reducing the size of the string, but I think this should relieve some of the allocs I saw.