### PR TITLE
cmd/scollector: bugfix - datapoint validation

### DIFF
--- a/opentsdb/tsdb.go
+++ b/opentsdb/tsdb.go
@@ -293,6 +293,9 @@ func (t TagSet) Clean() error {
 		if err != nil {
 			return fmt.Errorf("cleaning value %s for tag %s: %s", v, k, err)
 		}
+		if kc == "" || vc == "" {
+			return fmt.Errorf("cleaning value [%s] for tag [%s] result in an empty string", v, k)
+		}
 		if kc != k || vc != v {
 			delete(t, k)
 			t[kc] = vc


### PR DESCRIPTION
- TagSet.Clean() validates cleaned key/value are not empty.
- DataPoint.Clean() is also called when quickly dequeuing the datapoint channel.
- Data points deemed unclean increment scollector.collect.discarded instead of scollector.collect.dropped.