### PR TITLE
cmd/tsdbrelay: enable version numbers, fix metadata, add error metrics

### DIFF
--- a/cmd/bosun/docker/build/Dockerfile
+++ b/cmd/bosun/docker/build/Dockerfile
@@ -1,18 +1,18 @@
 FROM debian:wheezy
 
 RUN apt-get update && apt-get install -y \
-	automake \
-	curl \
-	git \
-	make \
-	openjdk-7-jdk \
-	python \
-	--no-install-recommends \
-	&& rm -rf /var/lib/apt/lists/*
+    automake \
+    curl \
+    git \
+    make \
+    openjdk-7-jdk \
+    python \
+    --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV TSDB /tsdb
 RUN git clone --single-branch --depth 1 git://github.com/OpenTSDB/opentsdb.git $TSDB && \
-	cd $TSDB && bash ./build.sh
+    cd $TSDB && bash ./build.sh
 
 ENV GOPATH /go
 ENV HBASEVER 1.1.2
@@ -24,7 +24,7 @@ RUN mkdir -p /hbase \
     | tar -xzC /hbase \
     && mv /hbase/hbase-$HBASEVER /hbase/hbase
 
-RUN curl -SL https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz \
+RUN curl -SL https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz \
     | tar -xzC /usr/local
 
 COPY bosun $GOPATH/src/bosun.org/
@@ -33,6 +33,6 @@ WORKDIR $GOPATH/src/bosun.org
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 
 RUN go run build/build.go \
-	&& bosun -version \
-	&& scollector -version
-#   && tsdbrelay -version doesn't work. See https://github.com/bosun-monitor/bosun/issues/1792
+    && bosun -version \
+    && scollector -version \
+    && tsdbrelay -version

--- a/cmd/tsdbrelay/main.go
+++ b/cmd/tsdbrelay/main.go
@@ -229,7 +229,8 @@ func (rp *relayProxy) relayPut(responseWriter http.ResponseWriter, r *http.Reque
 				req, err := http.NewRequest(r.Method, relayUrl, body)
 				if err != nil {
 					verbose("relayPutUrls connect error: %v", err)
-					return
+					collect.Add("puts.additional.error", tags, 1)
+					continue
 				}
 				req.Header.Set("Content-Type", "application/json")
 				req.Header.Set("Content-Encoding", "gzip")
@@ -238,7 +239,7 @@ func (rp *relayProxy) relayPut(responseWriter http.ResponseWriter, r *http.Reque
 				if err != nil {
 					verbose("secondary relay error: %v", err)
 					collect.Add("puts.additional.error", tags, 1)
-					return
+					continue
 				}
 				resp.Body.Close()
 				verbose("secondary relay success")
@@ -323,14 +324,14 @@ func (rp *relayProxy) relayMetadata(responseWriter http.ResponseWriter, r *http.
 				req, err := http.NewRequest(r.Method, relayUrl, body)
 				if err != nil {
 					verbose("metadata relayPutUrls error %v", err)
-					return
+					continue
 				}
 				req.Header.Set("Content-Type", "application/json")
 				req.Header.Add(relayHeader, myHost)
 				resp, err := http.DefaultClient.Do(req)
 				if err != nil {
 					verbose("secondary relay metadata error: %v", err)
-					return
+					continue
 				}
 				resp.Body.Close()
 				verbose("secondary relay metadata success")

--- a/cmd/tsdbrelay/main.go
+++ b/cmd/tsdbrelay/main.go
@@ -12,7 +12,6 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
-	"runtime"
 	"strings"
 
 	"bosun.org/cmd/tsdbrelay/denormalize"
@@ -44,7 +43,6 @@ var (
 )
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	var err error
 	myHost, err = os.Hostname()
 	if err != nil || myHost == "" {

--- a/cmd/tsdbrelay/main.go
+++ b/cmd/tsdbrelay/main.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -13,6 +14,8 @@ import (
 	"net/url"
 	"os"
 	"strings"
+
+	version "bosun.org/_version"
 
 	"bosun.org/cmd/tsdbrelay/denormalize"
 	"bosun.org/collect"
@@ -28,6 +31,7 @@ var (
 	tsdbServer      = flag.String("t", "", "Target OpenTSDB server. Can specify port with host:port.")
 	logVerbose      = flag.Bool("v", false, "enable verbose logging")
 	toDenormalize   = flag.String("denormalize", "", "List of metrics to denormalize. Comma seperated list of `metric__tagname__tagname` rules. Will be translated to `__tagvalue.tagvalue.metric`")
+	flagVersion     = flag.Bool("version", false, "Prints the version and exits.")
 
 	redisHost = flag.String("redis", "", "redis host for aggregating external counters")
 	redisDb   = flag.Int("db", 0, "redis db to use for counters")
@@ -50,9 +54,14 @@ func main() {
 	}
 
 	flag.Parse()
+	if *flagVersion {
+		fmt.Println(version.GetVersionInfo("tsdbrelay"))
+		os.Exit(0)
+	}
 	if *bosunServer == "" || *tsdbServer == "" {
 		log.Fatal("must specify both bosun and tsdb server")
 	}
+	log.Println(version.GetVersionInfo("tsdbrelay"))
 	log.Println("listen on", *listenAddr)
 	log.Println("relay to bosun at", *bosunServer)
 	log.Println("relay to tsdb at", *tsdbServer)

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -197,6 +198,9 @@ func Init(u *url.URL, debug bool) error {
 	mh, err := u.Parse("/api/metadata/put")
 	if err != nil {
 		return err
+	}
+	if strings.HasPrefix(mh.Host, ":") {
+		mh.Host = "localhost" + mh.Host
 	}
 	metahost = mh.String()
 	metadebug = debug


### PR DESCRIPTION
Also:
removes runtime.GOMAXPROCS(runtime.NumCPU()) since that is now the default
tabs to spaces in docker.sh
updates docker image to use to go1.7.linux-amd64.tar.gz
fixes missing call to metadata.init
adds metrics for tracking errors from opentsdb/bosun
adds metrics for tracking relayed/errors from secondary relays.

~~This also changes the logic so that data points are always relayed to bosun and secondary relays instead of bailing when the primary opentsdb end point returns an error.~~ Will keep thinking on this and open a separate PR.

Fixes #1792