### PR TITLE
cmd/scollector: add a kill switch for total memory used by scollector

### DIFF
--- a/cmd/scollector/collectors/collectors.go
+++ b/cmd/scollector/collectors/collectors.go
@@ -120,6 +120,9 @@ var (
 	WatchProcessesDotNet = func() {}
 
 	KeepalivedCommunity = ""
+
+	//TotalScollectorMemory stores the total memory used by Scollector (including CGO and WMI)
+	TotalScollectorMemoryMB uint64
 )
 
 func init() {

--- a/cmd/scollector/collectors/processes_windows.go
+++ b/cmd/scollector/collectors/processes_windows.go
@@ -2,6 +2,7 @@ package collectors
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 
@@ -134,6 +135,10 @@ func c_windows_processes() (opentsdb.MultiDataPoint, error) {
 				name = strings.Join([]string{"iis", a_pool.AppPoolName}, "_")
 				break
 			}
+		}
+
+		if v.IDProcess == uint32(os.Getpid()) {
+			TotalScollectorMemoryMB = v.WorkingSetPrivate / 1024 / 1024
 		}
 
 		if !(service_match || process_match || iis_match) {


### PR DESCRIPTION
This should help prevent memory leaks in CGO or WMI from causing scollector to consume too much memory.