### PR TITLE
cmd/scollector: fix empty host= tags not working after PR #1856

### DIFF
--- a/cmd/scollector/collectors/collectors.go
+++ b/cmd/scollector/collectors/collectors.go
@@ -241,6 +241,11 @@ func AddTS(md *opentsdb.MultiDataPoint, name string, ts int64, value interface{}
 	}
 
 	tags := t.Copy()
+	if host, present := tags["host"]; !present {
+		tags["host"] = util.Hostname
+	} else if host == "" {
+		delete(tags, "host")
+	}
 	// if tags are not cleanable, log a message and skip it
 	if err := tags.Clean(); err != nil {
 		line := ""
@@ -255,11 +260,6 @@ func AddTS(md *opentsdb.MultiDataPoint, name string, ts int64, value interface{}
 		}
 		slog.Errorf("Invalid tagset discovered: %s. Skipping datapoint. Added from: %s", tags.String(), line)
 		return
-	}
-	if host, present := tags["host"]; !present {
-		tags["host"] = util.Hostname
-	} else if host == "" {
-		delete(tags, "host")
 	}
 	if rate != metadata.Unknown {
 		metadata.AddMeta(name, nil, "rate", rate, false)


### PR DESCRIPTION
The add function in cmd/scollector/collectors/collectors.go uses host= to indicate that tag should be omitted

See https://github.com/bosun-monitor/bosun/blob/ac7f667fa1e649b877b77bfab7f2a643f5d8e615/cmd/scollector/collectors/collectors.go#L292

This should fix the vsphere errors on ny-bosun01:
```
error: collectors.go:256: Invalid tagset discovered: {disk=CO-EQL,host=}. Skipping datapoint. Added from: vsphere.go:138
error: collectors.go:256: Invalid tagset discovered: {disk=datastore1,host=}. Skipping datapoint. Added from: vsphere.go:105
error: collectors.go:256: Invalid tagset discovered: {disk=datastore1,host=}. Skipping datapoint. Added from: vsphere.go:136
error: collectors.go:256: Invalid tagset discovered: {disk=datastore1,host=}. Skipping datapoint. Added from: vsphere.go:138
```