### PR TITLE
cmd/scollector: Bug fix for DNS collector

### DIFF
--- a/cmd/scollector/collectors/dns_windows.go
+++ b/cmd/scollector/collectors/dns_windows.go
@@ -40,9 +40,9 @@ func c_dns_windows() (opentsdb.MultiDataPoint, error) {
 				}
 			} else { //Unique stat, we can put it straight away
 				if "" == p.Grouping {
-					Add(&md, "dns."+p.Category+"."+p.Metric, v.Value, opentsdb.TagSet{}, p.RateType, metadata.Count, p.Description)
+					Add(&md, "dns."+p.Category+"."+p.Metric, *v.Value, opentsdb.TagSet{}, p.RateType, metadata.Count, p.Description)
 				} else {
-					Add(&md, "dns."+p.Category+"."+p.Metric, v.Value, opentsdb.TagSet{"type": p.Grouping}, p.RateType, metadata.Count, p.Description)
+					Add(&md, "dns."+p.Category+"."+p.Metric, *v.Value, opentsdb.TagSet{"type": p.Grouping}, p.RateType, metadata.Count, p.Description)
 				}
 			}
 		}
@@ -50,9 +50,9 @@ func c_dns_windows() (opentsdb.MultiDataPoint, error) {
 	for _, v := range dupes { //ForEach record in our added up duplicates
 		if p, ok := DNSStatPropertyMap[v.Name]; ok {
 			if "" == p.Grouping {
-				Add(&md, "dns."+p.Category+"."+p.Metric, v.Value, opentsdb.TagSet{}, p.RateType, metadata.Count, p.Description)
+				Add(&md, "dns."+p.Category+"."+p.Metric, *v.Value, opentsdb.TagSet{}, p.RateType, metadata.Count, p.Description)
 			} else {
-				Add(&md, "dns."+p.Category+"."+p.Metric, v.Value, opentsdb.TagSet{"type": p.Grouping}, p.RateType, metadata.Count, p.Description)
+				Add(&md, "dns."+p.Category+"."+p.Metric, *v.Value, opentsdb.TagSet{"type": p.Grouping}, p.RateType, metadata.Count, p.Description)
 			}
 		}
 


### PR DESCRIPTION
Collector was trying to parse the pointed to TSDB instead of the value, which of course is kinda bad.

This _used_ to work and stopped early August. Not sure why it used to work? Maybe something in the WMI class changed. Haven't really dug into who it used to work and now doesn't.