### PR TITLE
cmd/scollector: check for NaN and Inf for float64 datapoints

### DIFF
--- a/opentsdb/tsdb.go
+++ b/opentsdb/tsdb.go
@@ -93,7 +93,7 @@ func (d *DataPoint) Valid() bool {
 		return false
 	}
 	f, err := strconv.ParseFloat(fmt.Sprint(d.Value), 64)
-	if err != nil || math.IsNaN(f) {
+	if err != nil || math.IsNaN(f) || math.IsInf(f, 0) {
 		return false
 	}
 	return true


### PR DESCRIPTION
Catches Inf and NaN on float before we hit the json marshaller. Symptom before this:

```
error: queue.go:105: json: error calling MarshalJSON for type *opentsdb.DataPoint: Unparseable number NaN
info: queue.go:124: restored 2000, sleeping 5s
error: queue.go:105: json: error calling MarshalJSON for type *opentsdb.DataPoint: Unparseable number -Infinity
info: queue.go:124: restored 2000, sleeping 5s
```
