### PR TITLE
Maintain dockerized bosun working

### DIFF
--- a/cmd/bosun/docker/run/Dockerfile
+++ b/cmd/bosun/docker/run/Dockerfile
@@ -21,7 +21,8 @@ ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
 ENV TSDBRELAY_OPTS -b localhost:8070 -t localhost:4242 -l 0.0.0.0:5252 -redis localhost:9565
 ENV TERM dumb
 
-COPY bosun.conf /data/
+COPY bosun.toml /data/
+COPY rules.conf /data/
 COPY scollector.toml /data/
 COPY hbase-site.xml $HBASE/conf/
 COPY start_hbase.sh /hbase/

--- a/cmd/bosun/docker/run/bosun.conf
+++ b/cmd/bosun/docker/run/bosun.conf
@@ -1,5 +1,0 @@
-tsdbHost = localhost:4242
-tsdbVersion = 2.2
-#stateFile = /data/bosun.state #No longer used
-ledisDir = /data/ledis_data
-ledisBindAddr = 0.0.0.0:9565

--- a/cmd/bosun/docker/run/bosun.toml
+++ b/cmd/bosun/docker/run/bosun.toml
@@ -1,0 +1,5 @@
+RuleFilePath = "/data/rules.conf"
+
+[OpenTSDBConf]
+Host = "localhost:4242"
+Version = "2.2"

--- a/cmd/bosun/docker/run/supervisord.conf
+++ b/cmd/bosun/docker/run/supervisord.conf
@@ -16,7 +16,7 @@ stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 
 [program:bosun]
-command=/bosun/bosun -c /data/bosun.conf
+command=/bosun/bosun -c /data/bosun.toml
 priority=20
 redirect_stderr=true
 stdout_logfile=/dev/fd/1

--- a/cmd/bosun/docker/run/supervisord.conf
+++ b/cmd/bosun/docker/run/supervisord.conf
@@ -4,19 +4,34 @@ nodaemon=true
 [program:hbase]
 command=/hbase/start_hbase.sh
 priority=10
+redirect_stderr=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
 
 [program:opentsdb]
 command=/tsdb/start_opentsdb.sh
 priority=15
+redirect_stderr=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
 
 [program:bosun]
 command=/bosun/bosun -c /data/bosun.conf
 priority=20
+redirect_stderr=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
 
 [program:tsdbrelay]
 command=/bin/bash -c "/tsdbrelay/tsdbrelay ${TSDBRELAY_OPTS}"
 priority=100
+redirect_stderr=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
 
 [program:scollector]
 command=/scollector/scollector -conf /data/scollector.toml
 priority=200
+redirect_stderr=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0

--- a/cmd/bosun/main.go
+++ b/cmd/bosun/main.go
@@ -95,7 +95,7 @@ func main() {
 	}
 	systemConf, err := conf.LoadSystemConfigFile(*flagConf)
 	if err != nil {
-		slog.Fatal(err)
+		slog.Fatalf("couldn't read system configuration: %v", err)
 	}
 	sysProvider, err := systemConf.GetSystemConfProvider()
 	if err != nil {
@@ -103,7 +103,7 @@ func main() {
 	}
 	ruleConf, err := rule.ParseFile(sysProvider.GetRuleFilePath(), systemConf.EnabledBackends())
 	if err != nil {
-		slog.Fatal(err)
+		slog.Fatalf("couldn't read rules: %v", err)
 	}
 	if *flagTest {
 		os.Exit(0)


### PR DESCRIPTION
- Translate configuration in docker to toml
- Send supervisord logs to stdout
- Add more information to startup error messages when configuration or rules fail to be read
