### PR TITLE
Have opentsdb.Duration implement encoding.TextUnmarshaler.

### DIFF
--- a/opentsdb/duration.go
+++ b/opentsdb/duration.go
@@ -174,3 +174,13 @@ func (d Duration) HumanString() string {
 func (d Duration) Seconds() float64 {
 	return time.Duration(d).Seconds()
 }
+
+func (d *Duration) UnmarshalText(text []byte) error {
+	duration, err := ParseDuration(string(text))
+	if err != nil {
+		return err
+	}
+
+	*d = duration
+	return nil
+}


### PR DESCRIPTION
:eyeglasses: @captncraig  @kylebrandt 

Will be using this to read durations from a config file on a separate utility.