### PR TITLE
cmd/scollector: bug fixes for Azure EA billing

### DIFF
--- a/cmd/scollector/collectors/azureeabilling.go
+++ b/cmd/scollector/collectors/azureeabilling.go
@@ -66,7 +66,7 @@ func processAzureEAReports(reports *azureeabilling.UsageReports, md *opentsdb.Mu
 	for _, r := range reports.AvailableMonths {
 		//There's potentially a lot of reports. We only want to process this months + last months report
 		if !(thisMonth == r.Month || lastMonth == r.Month) {
-			return nil
+			continue
 		}
 
 		csv := azBillConf.AZEABillingConfig.GetMonthReportsCSV(r, azureeabilling.DownloadForStructs)

--- a/vendor/github.com/mhenderson-so/azure-ea-billing/azure-ea-billing.go
+++ b/vendor/github.com/mhenderson-so/azure-ea-billing/azure-ea-billing.go
@@ -17,7 +17,7 @@ import (
 var AzureConfig Config
 
 // If no URI base is specificed, this is what we will use instead.
-var defaultBase = "http://ea.azure.com"
+var defaultBase = "https://ea.azure.com"
 
 // GetUsageReports returns all of the reports that are present in the EA Billing API. This is usually your first call, as
 // it returns an array of reports in .AvailableMonths, which is required for feeding into GetMonthReportCSV.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -536,10 +536,10 @@
 			"revisionTime": "2015-11-05T14:43:36+01:00"
 		},
 		{
-			"checksumSHA1": "eOQgUSMZQ82Xm255tBLjWaEeCsg=",
+			"checksumSHA1": "ltMx61rRH1F1LsSto7voLWuRQpw=",
 			"path": "github.com/mhenderson-so/azure-ea-billing",
-			"revision": "4eed67242fcc782d56e769a4aa0ac71a2a20281b",
-			"revisionTime": "2016-08-25T19:57:35Z"
+			"revision": "4fd1a790460cd26f319b17f40c9559142db03bf0",
+			"revisionTime": "2016-08-29T17:56:29Z"
 		},
 		{
 			"path": "github.com/olivere/elastic",


### PR DESCRIPTION
Two bug fixes for Azure EA Billing:

1. Use HTTPS as the default protocol. This has been fixed upstream, so did a `vendor update` here
2. Don't return when we don't immediately find an appropriate month. I think this worked in the testing because the list was in the reverse order (so it would process two records and then stop), but the order is not reliable, obviously.