### PR TITLE
cmd/scollector: Update linux interface collector names.

### DIFF
--- a/cmd/scollector/collectors/ifstat_linux.go
+++ b/cmd/scollector/collectors/ifstat_linux.go
@@ -51,8 +51,11 @@ var netFields = []struct {
 	{"compressed", metadata.Counter, metadata.Count},
 }
 
-var ifstatRE = regexp.MustCompile(`\s+(eth\d+|em\d+_\d+/\d+|em\d+_\d+|em\d+|` +
-	`bond\d+|team\d+|` + `p\d+p\d+_\d+/\d+|p\d+p\d+_\d+|p\d+p\d+):(.*)`)
+var ifstatRE = regexp.MustCompile(`\s*(eth\d+|em\d+_\d+/\d+|em\d+_\d+|em\d+|` +
+	`bond\d+|team\d+|` +
+	`p\d+p\d+_\d+/\d+|p\d+p\d+_\d+|p\d+p\d+|` +
+	`en[[:alnum:]]+|wl[[:alnum:]]+|ww[[:alnum:]]+` + // Systemd predictable interface names
+	`):(.*)`)
 
 func c_ipcount_linux() (opentsdb.MultiDataPoint, error) {
 	var md opentsdb.MultiDataPoint


### PR DESCRIPTION
Add systemd predictable network interface names into linux network name regex. The systemd mention of these prefixes exists here: https://github.com/systemd/systemd/blob/master/src/udev/udev-builtin-net_id.c#L29

This adds `ww`, `wl`, and `en` to the possible prefixes for interface names and also changes the space up front to be optional. When the names get too long for the column, I have noticed that the text aligns to the start of the line instead of the colon.

This should fix issues others have been having with network interfaces not showing up. 
Related:
https://github.com/bosun-monitor/bosun/pull/1756
https://github.com/bosun-monitor/bosun/issues/1912