### PR TITLE
cmd/bosun: Document Unsafe SSL parameter in example config

### DIFF
--- a/cmd/bosun/bosun.example.toml
+++ b/cmd/bosun/bosun.example.toml
@@ -85,4 +85,4 @@ CommandHookPath = "/Users/kbrandt/src/hook/hook"
 [InfluxConf]
 	URL = "https://myInfluxServer:1234"
 	Timeout = "5m"
-	UnsafeSSL = true
+	UnsafeSsl = true


### PR DESCRIPTION
The value of the `UnsafeSSL` parameter is actually read from `UnsafeSsl` as shown here: https://github.com/bosun-monitor/bosun/blob/master/cmd/bosun/conf/system.go#L420

Setting `UnsafeSSL = true` instead of `UnsafeSsl = true` therefore would have no effect in establishing trust, which would cause confusion when trying to configure HTTPS with InfluxDB when self-signed certificates are being used.