### PR TITLE
cmd/scollector: add tests and descr for disk_inode

### DIFF
--- a/cmd/scollector/collectors/collectors.go
+++ b/cmd/scollector/collectors/collectors.go
@@ -299,6 +299,7 @@ func Add(md *opentsdb.MultiDataPoint, name string, value interface{}, t opentsdb
 	AddTS(md, name, now(), value, t, rate, unit, desc)
 }
 
+// readLine read each line from file fname and apply line() function
 func readLine(fname string, line func(string) error) error {
 	f, err := os.Open(fname)
 	if err != nil {

--- a/cmd/scollector/collectors/disk_linux.go
+++ b/cmd/scollector/collectors/disk_linux.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"bosun.org/cmd/scollector/collectors/fs"
 	"bosun.org/metadata"
 	"bosun.org/opentsdb"
 	"bosun.org/slog"

--- a/cmd/scollector/collectors/fs/fs.go
+++ b/cmd/scollector/collectors/fs/fs.go
@@ -1,0 +1,66 @@
+package fs
+
+// filesystems information
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"os"
+	"strings"
+)
+
+const procFilesystems = "/proc/filesystems"
+
+// PseudoFS is a mapping between filesystem type and pseudoFS
+type PseudoFS map[string]bool
+
+// IsPseudo tells if a filesystem type is a pseudoFS
+func (pseudoFS PseudoFS) IsPseudo(name string) bool {
+	if res, ok := pseudoFS[name]; ok {
+		return res
+	}
+	// drop fs types not in /proc/filesystems
+	return true
+}
+
+// GetPseudoFS returns mapping between filesystem to isPseudo()
+// it is used to cache the results during a single run
+func GetPseudoFS() (fs PseudoFS, err error) {
+	f, err := os.Open(procFilesystems)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return getPseudoFS(f)
+}
+
+func getPseudoFS(r io.Reader) (fs PseudoFS, err error) {
+	fs = make(PseudoFS)
+	scan := bufio.NewScanner(r)
+	for scan.Scan() {
+		name, isPseudoFS := parseFSLine(scan.Text())
+		if name != "" {
+			fs[name] = isPseudoFS
+		}
+	}
+	if err = scan.Err(); err != nil {
+		return nil, err
+	}
+	if len(fs) == 0 {
+		return fs, errors.New(procFilesystems + " is empty")
+	}
+	return
+}
+
+func parseFSLine(line string) (name string, pseudoFS bool) {
+	ss := strings.Split(line, "\t")
+	// don't go further if line is not the way we want it
+	if len(ss) != 2 {
+		return "", true
+	}
+	if ss[0] != "nodev" {
+		return ss[1], false
+	}
+	return ss[1], true
+}

--- a/cmd/scollector/collectors/fs/fs_linux_test.go
+++ b/cmd/scollector/collectors/fs/fs_linux_test.go
@@ -1,0 +1,58 @@
+package fs
+
+import (
+	"bufio"
+	"os"
+	"strings"
+	"testing"
+
+	"bosun.org/slog"
+)
+
+// some benchmark on linux platform
+// shows /proc/filesystems mapping speed changes
+
+// BenchmarkOldIsPseudoFS-2          100000             14176 ns/op
+// BenchmarkIsPseudoFS-2           50000000                27 ns/op
+
+func readLine(fname string, line func(string) error) error {
+	f, err := os.Open(fname)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		if err := line(scanner.Text()); err != nil {
+			return err
+		}
+	}
+	return scanner.Err()
+}
+
+func OldIsPseudoFS(name string) (res bool) {
+	err := readLine("/proc/filesystems", func(s string) error {
+		ss := strings.Split(s, "\t")
+		if len(ss) == 2 && ss[1] == name && ss[0] == "nodev" {
+			res = true
+		}
+		return nil
+	})
+	if err != nil {
+		slog.Errorf("can not read '/proc/filesystems': %v", err)
+	}
+	return
+}
+
+func BenchmarkOldIsPseudoFS(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = OldIsPseudoFS("titi")
+	}
+}
+
+func BenchmarkIsPseudoFS(b *testing.B) {
+	fs, _ := GetPseudoFS()
+	for i := 0; i < b.N; i++ {
+		_ = fs.IsPseudo("titi")
+	}
+}

--- a/cmd/scollector/collectors/fs/fs_test.go
+++ b/cmd/scollector/collectors/fs/fs_test.go
@@ -1,0 +1,55 @@
+package fs
+
+import (
+	"strings"
+	"testing"
+)
+
+var procFS = "nodev\tpstore\n" +
+	"nodev\tmqueue\n" +
+	"\text3\n" +
+	"\text2\n" +
+	"nodev\tbinfmt_misc\n" +
+	"nodev\tautofs"
+
+func TestGetPseudoFS(t *testing.T) {
+	fs, err := getPseudoFS(strings.NewReader(procFS))
+	if err != nil {
+		t.Fatalf("should not return an error. Got: %v", err)
+	}
+
+	pseudo, ok := fs["pstore"]
+	if ok == false {
+		t.Fatalf("fs[\"pstore\"] should be present")
+	}
+	if pseudo == false {
+		t.Fatalf("fs[\"pstore\"] should be true")
+	}
+
+	procFS = ""
+	_, err = getPseudoFS(strings.NewReader(procFS))
+	if err == nil {
+		t.Fatalf("an empty file should return an error")
+	}
+}
+
+func TestIsPseudo(t *testing.T) {
+	fs, _ := getPseudoFS(strings.NewReader(procFS))
+
+	for name, isPseudo := range fs {
+		if isPseudo != fs.IsPseudo(name) {
+			t.Fatalf("%v: got %v, should have %v", name, isPseudo, fs.IsPseudo(name))
+		}
+	}
+
+	if fs.IsPseudo("doesn't exist") == false {
+		t.Fatalf("Should consider nonexisting filesystems type as pseudofs")
+	}
+}
+
+func TestParseLine(t *testing.T) {
+	s, _ := parseFSLine("\ttiti\ttoto\ttata")
+	if s != "" {
+		t.Fatalf("should return an empty string: too many tabs")
+	}
+}


### PR DESCRIPTION
This small patch should enhance visibility for future users and developers.

* more descriptions on metrics inodes_used, inodes_total, inodes_free,
* /proc/filesystems is pseudoFS tests,
* cache /proc/filesystems content each time. Don't parse again the whole file for each mountpoint
  => small benchmark given

