### PR TITLE
BufferReader returns directly a reader...

### DIFF
--- a/cmd/bosun/web/web.go
+++ b/cmd/bosun/web/web.go
@@ -377,7 +377,7 @@ func Shorten(w http.ResponseWriter, r *http.Request) {
 	}
 	c := http.Client{Transport: transport}
 
-	req, err := c.Post(u.String(), "application/json", bytes.NewBuffer(j))
+	req, err := c.Post(u.String(), "application/json", bytes.NewReader(j))
 	if err != nil {
 		serveError(w, err)
 		return


### PR DESCRIPTION
...which should spare a string copy.
Would be more the go way.