### PR TITLE
wip: start to attempt to migrate rendered templates out of data structure

### DIFF
--- a/cmd/bosun/database/database.go
+++ b/cmd/bosun/database/database.go
@@ -34,7 +34,6 @@ type DataAccess interface {
 	Migrate() error
 }
 
-
 type MetadataDataAccess interface {
 	// Insert Metric Metadata. Field must be one of "desc", "rate", or "unit".
 	PutMetricMetadata(metric string, field string, value string) error

--- a/cmd/bosun/database/database.go
+++ b/cmd/bosun/database/database.go
@@ -19,6 +19,8 @@ import (
 	"github.com/captncraig/easyauth/providers/token/redisStore"
 )
 
+var SchemaVersion = int64(1)
+
 // Core data access interface for everything sched needs
 type DataAccess interface {
 	RedisConnector
@@ -29,7 +31,9 @@ type DataAccess interface {
 	State() StateDataAccess
 	Silence() SilenceDataAccess
 	Notifications() NotificationDataAccess
+	Migrate() error
 }
+
 
 type MetadataDataAccess interface {
 	// Insert Metric Metadata. Field must be one of "desc", "rate", or "unit".

--- a/cmd/bosun/database/migrate.go
+++ b/cmd/bosun/database/migrate.go
@@ -112,7 +112,11 @@ func migrateRenderedTemplates(d *dataAccess) error {
 			LastAbnormalStatus: oldState.LastAbnormalStatus,
 			LastAbnormalTime:   oldState.LastAbnormalTime,
 		}
-		if _, err := d.State().UpdateIncidentState(newState); err != nil {
+		data, err := json.Marshal(newState)
+		if err != nil {
+			return slog.Wrap(err)
+		}
+		if _, err := conn.Do("SET", incidentStateKey(newState.Id), data); err != nil {
 			return slog.Wrap(err)
 		}
 	}

--- a/cmd/bosun/database/migrate.go
+++ b/cmd/bosun/database/migrate.go
@@ -21,7 +21,7 @@ type Migration struct {
 }
 
 var tasks = []Migration{
-	Migration{
+	{
 		UID:     "Migrate Rendered Templates",
 		Task:    migrateRenderedTemplates,
 		Version: 1,

--- a/cmd/bosun/database/migrate.go
+++ b/cmd/bosun/database/migrate.go
@@ -6,7 +6,7 @@ import (
 
 	"bosun.org/models"
 	"bosun.org/slog"
-	"github.com/beego/redigo/redis"
+	"github.com/garyburd/redigo/redis"
 )
 
 // Version 0 is the schema that was never verisoned

--- a/cmd/bosun/database/migrate.go
+++ b/cmd/bosun/database/migrate.go
@@ -104,16 +104,17 @@ func (d *dataAccess) Migrate() error {
 	}
 
 	for _, task := range tasks {
-		if task.Version > version { // Not sure logic is correct don't care right now.
+		if task.Version > version {
 			// Check if migration has been run if not that run
 			err := task.Task(d)
 			if err != nil {
 				return slog.Wrap(err)
 			}
+			if _, err := conn.Do("SET", schemaKey, task.Version); err != nil {
+				return slog.Wrap(err)
+			}
 		}
-		if _, err := conn.Do("SET", schemaKey, SchemaVersion); err != nil {
-			return slog.Wrap(err)
-		}
+
 	}
 	return nil
 }

--- a/cmd/bosun/database/migrate.go
+++ b/cmd/bosun/database/migrate.go
@@ -1,0 +1,154 @@
+package database
+
+import (
+	"encoding/json"
+	"time"
+
+	"bosun.org/models"
+	"bosun.org/slog"
+	"github.com/beego/redigo/redis"
+)
+
+// Version 0 is the schema that was never verisoned
+// Version 1 migrates rendered templates from
+
+var schemaKey = "schemaVersion"
+
+type Migration struct {
+	UID     string
+	Task    func(d *dataAccess) error
+	Version int64
+}
+
+var tasks = []Migration{
+	Migration{
+		UID:     "Migrate Rendered Templates",
+		Task:    migrateRenderedTemplates,
+		Version: 1,
+	},
+}
+
+type oldIncidentState struct {
+	Id       int64
+	Start    time.Time
+	End      *time.Time
+	AlertKey models.AlertKey
+	Alert    string // helper data since AlertKeys don't serialize to JSON well
+	Tags     string // string representation of Group
+
+	*models.Result
+
+	// Most recent last.
+	Events  []models.Event  `json:",omitempty"`
+	Actions []models.Action `json:",omitempty"`
+
+	Subject      string
+	Body         string
+	EmailBody    []byte
+	EmailSubject []byte
+	Attachments  []*models.Attachment
+
+	NeedAck bool
+	Open    bool
+
+	Unevaluated bool
+
+	CurrentStatus models.Status
+	WorstStatus   models.Status
+
+	LastAbnormalStatus models.Status
+	LastAbnormalTime   int64
+}
+
+func migrateRenderedTemplates(d *dataAccess) error {
+	slog.Infoln("Running rendered template migration")
+
+	ids, err := d.getAllIncidentIds()
+	if err != nil {
+		return err
+	}
+
+	conn := d.Get()
+	defer conn.Close()
+
+	for _, id := range ids {
+		b, err := redis.Bytes(conn.Do("GET", incidentStateKey(id)))
+		if err != nil {
+			return slog.Wrap(err)
+		}
+		oldState := &oldIncidentState{}
+		if err := json.Unmarshal(b, oldState); err != nil {
+			slog.Wrap(err)
+		}
+		rt := &models.RenderedTemplates{
+			Body:         oldState.Body,
+			EmailBody:    oldState.EmailBody,
+			EmailSubject: oldState.EmailSubject,
+			Attachments:  oldState.Attachments,
+		}
+		if err := d.State().SetRenderedTemplates(oldState.Id, rt); err != nil {
+			return slog.Wrap(err)
+		}
+
+		newState := &models.IncidentState{
+			Id:       oldState.Id,
+			Start:    oldState.Start,
+			End:      oldState.End,
+			AlertKey: oldState.AlertKey,
+			Alert:    oldState.Alert,
+			Tags:     oldState.Tags,
+			Result:   oldState.Result,
+
+			Events:             oldState.Events,
+			Actions:            oldState.Actions,
+			Subject:            oldState.Subject,
+			NeedAck:            oldState.NeedAck,
+			Open:               oldState.Open,
+			Unevaluated:        oldState.Unevaluated,
+			CurrentStatus:      oldState.CurrentStatus,
+			WorstStatus:        oldState.WorstStatus,
+			LastAbnormalStatus: oldState.LastAbnormalStatus,
+			LastAbnormalTime:   oldState.LastAbnormalTime,
+		}
+		_ = newState
+	}
+
+	return nil
+}
+
+func (d *dataAccess) Migrate() error {
+	slog.Infoln("checking migrations")
+	conn := d.Get()
+	defer conn.Close()
+
+	// Since we didn't record a schema version from the start
+	// we have to do some assumptions to see if this is a new
+	// database, or if was a database before we started recording
+	// a schema version number
+
+	version, err := redis.Int64(conn.Do("GET", schemaKey))
+	if err != nil {
+		if err == redis.ErrNil {
+			slog.Infoln("schema version not found in db")
+			if _, err := redis.Bool(conn.Do("Get", "allIncidents")); err == redis.ErrNil {
+				slog.Infoln("assuming new installation because allIncidents key not found")
+				slog.Infoln("writing current schema version")
+				version = SchemaVersion
+				return nil
+			}
+		} else {
+			return slog.Wrap(err)
+		}
+	}
+
+	for _, task := range tasks {
+		if task.Version > version {
+			// Check if migration has been run if not that run
+			err := task.Task(d)
+			if err != nil {
+				// Mark Migration as Complete
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/bosun/database/migrate.go
+++ b/cmd/bosun/database/migrate.go
@@ -153,12 +153,11 @@ func (d *dataAccess) Migrate() error {
 			// Check if migration has been run if not that run
 			err := task.Task(d)
 			if err != nil {
-				if _, err := conn.Do("SET", schemaKey, SchemaVersion); err != nil {
-					return slog.Wrap(err)
-				}
-			} else {
 				return slog.Wrap(err)
 			}
+		}
+		if _, err := conn.Do("SET", schemaKey, SchemaVersion); err != nil {
+			return slog.Wrap(err)
 		}
 	}
 	return nil

--- a/cmd/bosun/database/migrate.go
+++ b/cmd/bosun/database/migrate.go
@@ -54,16 +54,23 @@ func migrateRenderedTemplates(d *dataAccess) error {
 		if err := json.Unmarshal(b, oldState); err != nil {
 			slog.Wrap(err)
 		}
-		if err := d.State().SetRenderedTemplates(oldState.Id, oldState.RenderedTemplates); err != nil {
-			return slog.Wrap(err)
-		}
-		data, err := json.Marshal(oldState.IncidentState)
+
+		incidentStateJSON, err := json.Marshal(oldState.IncidentState)
 		if err != nil {
 			return slog.Wrap(err)
 		}
-		if _, err := conn.Do("SET", incidentStateKey(oldState.Id), data); err != nil {
+		if _, err := conn.Do("SET", incidentStateKey(oldState.Id), incidentStateJSON); err != nil {
 			return slog.Wrap(err)
 		}
+
+		renderedTemplatesJSON, err := json.Marshal(oldState.RenderedTemplates)
+		if err != nil {
+			return slog.Wrap(err)
+		}
+		if _, err := conn.Do("SET", renderedTemplatesKey(oldState.Id), renderedTemplatesJSON); err != nil {
+			return slog.Wrap(err)
+		}
+
 	}
 	return nil
 }

--- a/cmd/bosun/database/state_data.go
+++ b/cmd/bosun/database/state_data.go
@@ -59,7 +59,6 @@ type StateDataAccess interface {
 	GetLatestIncident(ak models.AlertKey) (*models.IncidentState, error)
 	GetAllOpenIncidents() ([]*models.IncidentState, error)
 	GetIncidentState(incidentId int64) (*models.IncidentState, error)
-	//GetAllIncidentIds() ([]int64, error)
 
 	GetAllIncidentsByAlertKey(ak models.AlertKey) ([]*models.IncidentState, error)
 

--- a/cmd/bosun/database/state_data.go
+++ b/cmd/bosun/database/state_data.go
@@ -28,7 +28,6 @@ incidents:{ak} - List of incidents for alert key
 allIncidents - List of all incidents ever. Value is "incidentId:timestamp:ak"
 */
 
-
 const (
 	statesOpenIncidentsKey = "openIncidents"
 )

--- a/cmd/bosun/database/state_data.go
+++ b/cmd/bosun/database/state_data.go
@@ -211,6 +211,25 @@ func (d *dataAccess) getAllIncidentIds() ([]int64, error) {
 		}
 	}
 	return ids, nil
+}
+
+func (d *dataAccess) getAllIncidentIdsByKeys() ([]int64, error) {
+	conn := d.Get()
+	defer conn.Close()
+
+	summaries, err := redis.Strings(conn.Do("KEYS", "incidentById:*"))
+	if err != nil {
+		return nil, slog.Wrap(err)
+	}
+	ids := make([]int64, len(summaries))
+	for i, sum := range summaries {
+		var err error
+		ids[i], err = strconv.ParseInt(strings.Split(sum, ":")[1], 0, 64)
+		if err != nil {
+			return nil, slog.Wrap(err)
+		}
+	}
+	return ids, nil
 
 }
 

--- a/cmd/bosun/database/state_data.go
+++ b/cmd/bosun/database/state_data.go
@@ -3,7 +3,10 @@ package database
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
+
+	"strings"
 
 	"bosun.org/models"
 	"bosun.org/slog"
@@ -12,6 +15,8 @@ import (
 
 /*
 incidentById:{id} - json encoded state. Authoritative source.
+
+renderedTemplatesById:{id} - json encoded RenderedTemplates ny Incident Id
 
 lastTouched:{alert} - ZSET of alert key to last touched time stamp
 unknown:{alert} - Set of unknown alert keys for alert
@@ -22,6 +27,7 @@ incidents:{ak} - List of incidents for alert key
 
 allIncidents - List of all incidents ever. Value is "incidentId:timestamp:ak"
 */
+
 
 const (
 	statesOpenIncidentsKey = "openIncidents"
@@ -39,6 +45,9 @@ func statesUnevalKey(alert string) string {
 func incidentStateKey(id int64) string {
 	return fmt.Sprintf("incidentById:%d", id)
 }
+func renderedTemplatesKey(id int64) string {
+	return fmt.Sprintf("renderedTemplatesById:%d", id)
+}
 func incidentsForAlertKeyKey(ak models.AlertKey) string {
 	return fmt.Sprintf("incidents:%s", ak)
 }
@@ -51,14 +60,49 @@ type StateDataAccess interface {
 	GetLatestIncident(ak models.AlertKey) (*models.IncidentState, error)
 	GetAllOpenIncidents() ([]*models.IncidentState, error)
 	GetIncidentState(incidentId int64) (*models.IncidentState, error)
-	GetAllIncidents(ak models.AlertKey) ([]*models.IncidentState, error)
+	//GetAllIncidentIds() ([]int64, error)
+
+	GetAllIncidentsByAlertKey(ak models.AlertKey) ([]*models.IncidentState, error)
 
 	UpdateIncidentState(s *models.IncidentState) (int64, error)
 	ImportIncidentState(s *models.IncidentState) error
 
+	SetRenderedTemplates(incidentId int64, rt *models.RenderedTemplates) error
+	GetRenderedTemplates(incidentId int64) (*models.RenderedTemplates, error)
+
 	Forget(ak models.AlertKey) error
 	SetUnevaluated(ak models.AlertKey, uneval bool) error
 	GetUnknownAndUnevalAlertKeys(alert string) ([]models.AlertKey, []models.AlertKey, error)
+}
+
+func (d *dataAccess) SetRenderedTemplates(incidentId int64, rt *models.RenderedTemplates) error {
+	conn := d.Get()
+	defer conn.Close()
+
+	data, err := json.Marshal(rt)
+	if err != nil {
+		return slog.Wrap(err)
+	}
+	_, err = conn.Do("SET", renderedTemplatesKey(incidentId), data)
+	if err != nil {
+		return slog.Wrap(err)
+	}
+	return nil
+}
+
+func (d *dataAccess) GetRenderedTemplates(incidentId int64) (*models.RenderedTemplates, error) {
+	conn := d.Get()
+	defer conn.Close()
+
+	b, err := redis.Bytes(conn.Do("GET", renderedTemplatesKey(incidentId)))
+	if err != nil {
+		return nil, slog.Wrap(err)
+	}
+	renderedT := &models.RenderedTemplates{}
+	if err = json.Unmarshal(b, renderedT); err != nil {
+		return nil, slog.Wrap(err)
+	}
+	return renderedT, nil
 }
 
 func (d *dataAccess) State() StateDataAccess {
@@ -139,7 +183,7 @@ func (d *dataAccess) GetAllOpenIncidents() ([]*models.IncidentState, error) {
 	return d.incidentMultiGet(conn, ids)
 }
 
-func (d *dataAccess) GetAllIncidents(ak models.AlertKey) ([]*models.IncidentState, error) {
+func (d *dataAccess) GetAllIncidentsByAlertKey(ak models.AlertKey) ([]*models.IncidentState, error) {
 	conn := d.Get()
 	defer conn.Close()
 
@@ -148,6 +192,26 @@ func (d *dataAccess) GetAllIncidents(ak models.AlertKey) ([]*models.IncidentStat
 		return nil, slog.Wrap(err)
 	}
 	return d.incidentMultiGet(conn, ids)
+}
+
+func (d *dataAccess) getAllIncidentIds() ([]int64, error) {
+	conn := d.Get()
+	defer conn.Close()
+
+	summaries, err := redis.Strings(conn.Do("LRANGE", "allIncidents", 0, -1))
+	if err != nil {
+		return nil, slog.Wrap(err)
+	}
+	ids := make([]int64, len(summaries))
+	for i, sum := range summaries {
+		var err error
+		ids[i], err = strconv.ParseInt(strings.Split(sum, ":")[0], 0, 64)
+		if err != nil {
+			return nil, slog.Wrap(err)
+		}
+	}
+	return ids, nil
+
 }
 
 func (d *dataAccess) incidentMultiGet(conn redis.Conn, ids []int64) ([]*models.IncidentState, error) {

--- a/cmd/bosun/main.go
+++ b/cmd/bosun/main.go
@@ -265,15 +265,17 @@ func quit() {
 }
 
 func initDataAccess(systemConf conf.SystemConfProvider) (database.DataAccess, error) {
+	var da database.DataAccess
 	if systemConf.GetRedisHost() != "" {
-		return database.NewDataAccess(systemConf.GetRedisHost(), true, systemConf.GetRedisDb(), systemConf.GetRedisPassword()), nil
+		da = database.NewDataAccess(systemConf.GetRedisHost(), true, systemConf.GetRedisDb(), systemConf.GetRedisPassword())
+	} else {
+		_, err := database.StartLedis(systemConf.GetLedisDir(), systemConf.GetLedisBindAddr())
+		if err != nil {
+			return nil, err
+		}
+		da = database.NewDataAccess(systemConf.GetLedisBindAddr(), false, 0, "")
 	}
-	_, err := database.StartLedis(systemConf.GetLedisDir(), systemConf.GetLedisBindAddr())
-	if err != nil {
-		return nil, err
-	}
-	da := database.NewDataAccess(systemConf.GetLedisBindAddr(), false, 0, "")
-	err = da.Migrate()
+	err := da.Migrate()
 	return da, err
 }
 

--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -118,9 +118,16 @@ func (s *Schedule) runHistory(r *RunHistory, ak models.AlertKey, event *models.E
 	// get existing open incident if exists
 	var incident *models.IncidentState
 	rt := &models.RenderedTemplates{}
+	
 	incident, err = data.GetOpenIncident(ak)
 	if err != nil {
 		return
+	}
+	if incident != nil {
+		rt, err = data.GetRenderedTemplates(incident.Id)
+		if err != nil {
+			return
+		}
 	}
 	defer func() {
 		// save unless incident is new and closed (log alert)

--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -118,7 +118,7 @@ func (s *Schedule) runHistory(r *RunHistory, ak models.AlertKey, event *models.E
 	// get existing open incident if exists
 	var incident *models.IncidentState
 	rt := &models.RenderedTemplates{}
-	
+
 	incident, err = data.GetOpenIncident(ak)
 	if err != nil {
 		return

--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -126,13 +126,7 @@ func (s *Schedule) runHistory(r *RunHistory, ak models.AlertKey, event *models.E
 		// save unless incident is new and closed (log alert)
 		if incident != nil && (incident.Id != 0 || incident.Open) {
 			_, err = data.UpdateIncidentState(incident)
-			if err != nil {
-				return
-			}
 			err = data.SetRenderedTemplates(incident.Id, rt)
-			if err != nil {
-				return
-			}
 		} else {
 			err = data.SetUnevaluated(ak, event.Unevaluated) // if nothing to save, at least store the unevaluated state
 			if err != nil {
@@ -195,7 +189,6 @@ func (s *Schedule) runHistory(r *RunHistory, ak models.AlertKey, event *models.E
 	//render templates and open alert key if abnormal
 	if event.Status > models.StNormal {
 		s.executeTemplates(incident, rt, event, a, r)
-		s.DataAccess.State().SetRenderedTemplates(incident.Id, rt)
 		incident.Open = true
 		if a.Log {
 			incident.Open = false

--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -329,7 +329,6 @@ func (s *Schedule) executeTemplates(state *models.IncidentState, rt *models.Rend
 			attachments = nil
 		}
 		state.Subject = string(subject)
-		//state.Body = string(body)
 		rt.Body = string(body)
 		//don't save email seperately if they are identical
 		if string(rt.EmailBody) != rt.Body {

--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -117,7 +117,7 @@ func (s *Schedule) runHistory(r *RunHistory, ak models.AlertKey, event *models.E
 
 	// get existing open incident if exists
 	var incident *models.IncidentState
-	var rt *models.RenderedTemplates
+	rt := &models.RenderedTemplates{}
 	incident, err = data.GetOpenIncident(ak)
 	if err != nil {
 		return
@@ -236,40 +236,40 @@ func (s *Schedule) runHistory(r *RunHistory, ak models.AlertKey, event *models.E
 	}
 
 	// lock while we change notifications.
-	s.Lock("RunHistory")
-	if shouldNotify {
-		incident.NeedAck = false
-		if err = s.DataAccess.Notifications().ClearNotifications(ak); err != nil {
-			return
-		}
-		notifyCurrent()
-	}
-
-	// finally close an open alert with silence once it goes back to normal.
-	if si := silenced(ak); si != nil && event.Status == models.StNormal {
-		go func(ak models.AlertKey) {
-			slog.Infof("auto close %s because was silenced", ak)
-			err := s.ActionByAlertKey("bosun", "Auto close because was silenced.", models.ActionClose, ak)
-			if err != nil {
-				slog.Errorln(err)
+		s.Lock("RunHistory")
+		if shouldNotify {
+			incident.NeedAck = false
+			if err = s.DataAccess.Notifications().ClearNotifications(ak); err != nil {
+				return
 			}
-		}(ak)
-	}
-	s.Unlock()
-	return checkNotify, nil
-}
+			notifyCurrent()
+		}
 
-func silencedOrIgnored(a *conf.Alert, event *models.Event, si *models.Silence) bool {
-	if a.IgnoreUnknown && event.Status == models.StUnknown {
-		return true
+		// finally close an open alert with silence once it goes back to normal.
+		if si := silenced(ak); si != nil && event.Status == models.StNormal {
+			go func(ak models.AlertKey) {
+				slog.Infof("auto close %s because was silenced", ak)
+				err := s.ActionByAlertKey("bosun", "Auto close because was silenced.", models.ActionClose, ak)
+				if err != nil {
+					slog.Errorln(err)
+				}
+			}(ak)
+		}
+		s.Unlock()
+		return checkNotify, nil
 	}
-	if si != nil && si.Forget && event.Status == models.StUnknown {
-		return true
+
+	func silencedOrIgnored(a *conf.Alert, event *models.Event, si *models.Silence) bool {
+		if a.IgnoreUnknown && event.Status == models.StUnknown {
+			return true
+		}
+		if si != nil && si.Forget && event.Status == models.StUnknown {
+			return true
+		}
+		return false
 	}
-	return false
-}
-func (s *Schedule) executeTemplates(state *models.IncidentState, rt *models.RenderedTemplates, event *models.Event, a *conf.Alert, r *RunHistory) {
-	if event.Status != models.StUnknown {
+	func (s *Schedule) executeTemplates(state *models.IncidentState, rt *models.RenderedTemplates, event *models.Event, a *conf.Alert, r *RunHistory) {
+		if event.Status != models.StUnknown {
 		var errs []error
 		metric := "template.render"
 		//Render subject

--- a/cmd/bosun/sched/notify.go
+++ b/cmd/bosun/sched/notify.go
@@ -37,11 +37,19 @@ func (s *Schedule) dispatchNotifications() {
 
 }
 
-func (s *Schedule) Notify(st *models.IncidentState, n *conf.Notification) {
+type IncidentWithTemplates struct {
+	*models.IncidentState
+	*models.RenderedTemplates
+}
+
+func (s *Schedule) Notify(st *models.IncidentState, rt *models.RenderedTemplates, n *conf.Notification) {
+	it := &IncidentWithTemplates{}
+	it.IncidentState = st
+	it.RenderedTemplates = rt
 	if s.pendingNotifications == nil {
-		s.pendingNotifications = make(map[*conf.Notification][]*models.IncidentState)
+		s.pendingNotifications = make(map[*conf.Notification][]*IncidentWithTemplates)
 	}
-	s.pendingNotifications[n] = append(s.pendingNotifications[n], st)
+	s.pendingNotifications[n] = append(s.pendingNotifications[n], it)
 }
 
 // CheckNotifications processes past notification events. It returns the next time a notification is needed.
@@ -80,6 +88,7 @@ func (s *Schedule) CheckNotifications() time.Time {
 				continue
 			}
 			st, err := s.DataAccess.State().GetLatestIncident(ak)
+			
 			if err != nil {
 				slog.Error(err)
 				continue
@@ -87,7 +96,12 @@ func (s *Schedule) CheckNotifications() time.Time {
 			if st == nil {
 				continue
 			}
-			s.Notify(st, n)
+			rt, err := s.DataAccess.State().GetRenderedTemplates(st.Id)
+			if err != nil {
+				slog.Error(err)
+				continue
+			}
+			s.Notify(st, rt, n)
 		}
 	}
 	s.sendNotifications(silenced)
@@ -123,7 +137,7 @@ func (s *Schedule) sendNotifications(silenced SilenceTester) {
 					slog.Infoln("silencing unknown", ak)
 					continue
 				}
-				s.pendingUnknowns[n] = append(s.pendingUnknowns[n], st)
+				s.pendingUnknowns[n] = append(s.pendingUnknowns[n], st.IncidentState)
 			} else if silenced {
 				slog.Infof("silencing %s", ak)
 				continue
@@ -134,7 +148,7 @@ func (s *Schedule) sendNotifications(silenced SilenceTester) {
 				}
 				continue
 			} else {
-				s.notify(st, n)
+				s.notify(st.IncidentState, st.RenderedTemplates, n)
 			}
 			if n.Next != nil {
 				s.QueueNotification(ak, n.Next, utcNow())
@@ -193,14 +207,14 @@ var unknownMultiGroup = ttemplate.Must(ttemplate.New("unknownMultiGroup").Parse(
 	</ul>
 	`))
 
-func (s *Schedule) notify(st *models.IncidentState, n *conf.Notification) {
-	if len(st.EmailSubject) == 0 {
-		st.EmailSubject = []byte(st.Subject)
+func (s *Schedule) notify(st *models.IncidentState, rt *models.RenderedTemplates, n *conf.Notification) {
+	if len(rt.EmailSubject) == 0 {
+		rt.EmailSubject = []byte(st.Subject)
 	}
-	if len(st.EmailBody) == 0 {
-		st.EmailBody = []byte(st.Body)
+	if len(rt.EmailBody) == 0 {
+		rt.EmailBody = []byte(rt.Body)
 	}
-	n.Notify(st.Subject, st.Body, st.EmailSubject, st.EmailBody, s.SystemConf, string(st.AlertKey), st.Attachments...)
+	n.Notify(st.Subject, rt.Body, rt.EmailSubject, rt.EmailBody, s.SystemConf, string(st.AlertKey), rt.Attachments...)
 }
 
 // utnotify is single notification for N unknown groups into a single notification

--- a/cmd/bosun/sched/notify.go
+++ b/cmd/bosun/sched/notify.go
@@ -88,7 +88,7 @@ func (s *Schedule) CheckNotifications() time.Time {
 				continue
 			}
 			st, err := s.DataAccess.State().GetLatestIncident(ak)
-			
+
 			if err != nil {
 				slog.Error(err)
 				continue

--- a/cmd/bosun/sched/sched.go
+++ b/cmd/bosun/sched/sched.go
@@ -26,8 +26,6 @@ func utcNow() time.Time {
 	return time.Now().UTC()
 }
 
-
-
 type Schedule struct {
 	mutex         sync.Mutex
 	mutexHolder   string

--- a/cmd/bosun/sched/sched.go
+++ b/cmd/bosun/sched/sched.go
@@ -26,6 +26,8 @@ func utcNow() time.Time {
 	return time.Now().UTC()
 }
 
+
+
 type Schedule struct {
 	mutex         sync.Mutex
 	mutexHolder   string
@@ -44,7 +46,7 @@ type Schedule struct {
 	//channel signals an alert has added notifications, and notifications should be processed.
 	nc chan interface{}
 	//notifications to be sent immediately
-	pendingNotifications map[*conf.Notification][]*models.IncidentState
+	pendingNotifications map[*conf.Notification][]*IncidentWithTemplates
 
 	//unknown states that need to be notified about. Collected and sent in batches.
 	pendingUnknowns map[*conf.Notification][]*models.IncidentState
@@ -435,9 +437,6 @@ func (s *Schedule) MarshalGroups(T miniprofiler.Timer, filter string) (*StateGro
 					}
 					for _, ak := range group {
 						st := status[ak]
-						st.Body = ""
-						st.EmailBody = nil
-						st.Attachments = nil
 						g.Children = append(g.Children, &StateGroup{
 							Active:   tuple.Active,
 							Status:   tuple.Status,

--- a/cmd/bosun/sched/sched.go
+++ b/cmd/bosun/sched/sched.go
@@ -66,7 +66,7 @@ type Schedule struct {
 	checksRunning sync.WaitGroup
 }
 
-func (s *Schedule) Init(systemConf conf.SystemConfProvider, ruleConf conf.RuleConfProvider, skipLast, quiet bool) error {
+func (s *Schedule) Init(systemConf conf.SystemConfProvider, ruleConf conf.RuleConfProvider, dataAccess database.DataAccess, skipLast, quiet bool) error {
 	//initialize all variables and collections so they are ready to use.
 	//this will be called once at app start, and also every time the rule
 	//page runs, so be careful not to spawn long running processes that can't
@@ -81,27 +81,13 @@ func (s *Schedule) Init(systemConf conf.SystemConfProvider, ruleConf conf.RuleCo
 	s.lastLogTimes = make(map[models.AlertKey]time.Time)
 	s.LastCheck = utcNow()
 	s.ctx = &checkContext{utcNow(), cache.New(0)}
-
+	s.DataAccess = dataAccess
 	// Initialize the context and waitgroup used to gracefully shutdown bosun as well as reload
 	s.runnerContext, s.cancelChecks = context.WithCancel(context.Background())
 	s.checksRunning = sync.WaitGroup{}
 
-	if s.DataAccess == nil {
-		if systemConf.GetRedisHost() != "" {
-			s.DataAccess = database.NewDataAccess(systemConf.GetRedisHost(), true, systemConf.GetRedisDb(), systemConf.GetRedisPassword())
-		} else {
-			_, err := database.StartLedis(systemConf.GetLedisDir(), systemConf.GetLedisBindAddr())
-			if err != nil {
-				return err
-			}
-			s.DataAccess = database.NewDataAccess(systemConf.GetLedisBindAddr(), false, 0, "")
-		}
-	}
 	if s.Search == nil {
 		s.Search = search.NewSearch(s.DataAccess, skipLast)
-	}
-	if err := s.DataAccess.Migrate(); err != nil {
-		return err
 	}
 	return nil
 }
@@ -498,8 +484,8 @@ func marshalTime(t time.Time) string {
 var DefaultSched = &Schedule{}
 
 // Load loads a configuration into the default schedule.
-func Load(systemConf conf.SystemConfProvider, ruleConf conf.RuleConfProvider, skipLast, quiet bool) error {
-	return DefaultSched.Init(systemConf, ruleConf, skipLast, quiet)
+func Load(systemConf conf.SystemConfProvider, ruleConf conf.RuleConfProvider, dataAccess database.DataAccess, skipLast, quiet bool) error {
+	return DefaultSched.Init(systemConf, ruleConf, dataAccess, skipLast, quiet)
 }
 
 // Run runs the default schedule.

--- a/cmd/bosun/sched/sched.go
+++ b/cmd/bosun/sched/sched.go
@@ -100,6 +100,9 @@ func (s *Schedule) Init(systemConf conf.SystemConfProvider, ruleConf conf.RuleCo
 	if s.Search == nil {
 		s.Search = search.NewSearch(s.DataAccess, skipLast)
 	}
+	if err := s.DataAccess.Migrate(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/cmd/bosun/sched/sched_test.go
+++ b/cmd/bosun/sched/sched_test.go
@@ -64,8 +64,7 @@ func setup() func() {
 
 func initSched(sc conf.SystemConfProvider, c conf.RuleConfProvider) (*Schedule, error) {
 	s := new(Schedule)
-	s.DataAccess = db
-	err := s.Init(sc, c, false, false)
+	err := s.Init(sc, c, db, false, false)
 	return s, err
 }
 

--- a/cmd/bosun/web/expr.go
+++ b/cmd/bosun/web/expr.go
@@ -136,9 +136,8 @@ type Res struct {
 
 func procRule(t miniprofiler.Timer, ruleConf conf.RuleConfProvider, a *conf.Alert, now time.Time, summary bool, email string, template_group string) (*ruleResult, error) {
 	s := &sched.Schedule{}
-	s.DataAccess = schedule.DataAccess
 	s.Search = schedule.Search
-	if err := s.Init(schedule.SystemConf, ruleConf, false, false); err != nil {
+	if err := s.Init(schedule.SystemConf, ruleConf, schedule.DataAccess, false, false); err != nil {
 		return nil, err
 	}
 	rh := s.NewRunHistory(now, cacheObj)

--- a/cmd/bosun/web/relay_test.go
+++ b/cmd/bosun/web/relay_test.go
@@ -28,8 +28,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestRelay(t *testing.T) {
-	schedule.DataAccess = testData
-	schedule.Init(&conf.SystemConf{}, new(rule.Conf), false, false)
+	schedule.Init(&conf.SystemConf{}, new(rule.Conf), testData, false, false)
 	rs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(204)
 	}))

--- a/cmd/bosun/web/web.go
+++ b/cmd/bosun/web/web.go
@@ -636,7 +636,7 @@ func Status(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (inter
 		}
 		var state *models.IncidentState
 		if r.FormValue("all") != "" {
-			allInc, err := schedule.DataAccess.State().GetAllIncidents(ak)
+			allInc, err := schedule.DataAccess.State().GetAllIncidentsByAlertKey(ak)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/bosun/web/web.go
+++ b/cmd/bosun/web/web.go
@@ -627,6 +627,7 @@ func Status(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (inter
 	type ExtStatus struct {
 		AlertName string
 		*models.IncidentState
+		*models.RenderedTemplates
 	}
 	m := make(map[string]ExtStatus)
 	for _, k := range r.Form["ak"] {
@@ -658,7 +659,11 @@ func Status(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (inter
 				return nil, err
 			}
 		}
-		st := ExtStatus{IncidentState: state}
+		rt, err := schedule.DataAccess.State().GetRenderedTemplates(state.Id)
+		if err != nil {
+			return nil, err
+		}
+		st := ExtStatus{IncidentState: state, RenderedTemplates: rt}
 		if st.IncidentState == nil {
 			return nil, fmt.Errorf("unknown alert key: %v", k)
 		}

--- a/models/incidents.go
+++ b/models/incidents.go
@@ -23,10 +23,10 @@ type IncidentState struct {
 	Actions []Action `json:",omitempty"`
 
 	Subject      string
-	Body         string
-	EmailBody    []byte
-	EmailSubject []byte
-	Attachments  []*Attachment
+	// Body         string
+	// EmailBody    []byte
+	// EmailSubject []byte
+	// Attachments  []*Attachment
 
 	NeedAck bool
 	Open    bool
@@ -38,6 +38,13 @@ type IncidentState struct {
 
 	LastAbnormalStatus Status
 	LastAbnormalTime   int64
+}
+
+type RenderedTemplates struct {
+	Body         string
+	EmailBody    []byte
+	EmailSubject []byte
+	Attachments  []*Attachment
 }
 
 func (s *IncidentState) Group() opentsdb.TagSet {

--- a/models/incidents.go
+++ b/models/incidents.go
@@ -28,6 +28,8 @@ type IncidentState struct {
 	// EmailSubject []byte
 	// Attachments  []*Attachment
 
+	rt *RenderedTemplates
+
 	NeedAck bool
 	Open    bool
 

--- a/models/incidents.go
+++ b/models/incidents.go
@@ -22,11 +22,7 @@ type IncidentState struct {
 	Events  []Event  `json:",omitempty"`
 	Actions []Action `json:",omitempty"`
 
-	Subject      string
-	// Body         string
-	// EmailBody    []byte
-	// EmailSubject []byte
-	// Attachments  []*Attachment
+	Subject string
 
 	rt *RenderedTemplates
 

--- a/models/incidents.go
+++ b/models/incidents.go
@@ -24,8 +24,6 @@ type IncidentState struct {
 
 	Subject string
 
-	rt *RenderedTemplates
-
 	NeedAck bool
 	Open    bool
 


### PR DESCRIPTION
Lots in these changes so need to rest and look at it with a fresh page of eyes.

Problem right now is that when expanding things on the dashboard, sometimes there are templates, and other times there are not.

The following seems not right:

```
$ redis-cli -p 6389 LRANGE allIncidents 0 -1 | wc -l
   71077

# kbrandt at grove in ~/src/bosun.org/cmd/bosun on git:rendTempStore x [16:03:15]
$ redis-cli -p 6389 KEYS incidentById:\* | wc -l
   64492
```

Also maybe something to do with not storing when emailbody == body? 

Anyways, need a break. The dashboard loads much faster though. Even with a handful of alerts the "Setup" phase in marshal groups goes down by a factor of 10 (30 vs 300ms)