### PR TITLE
Check to ensure no two consecutive check runs share a timestamp.

### DIFF
--- a/cmd/bosun/sched/alertRunner.go
+++ b/cmd/bosun/sched/alertRunner.go
@@ -66,6 +66,8 @@ func (s *Schedule) RunAlert(a *conf.Alert) {
 				lastCheckID = ctx.id
 				break
 			}
+			//if the timing is just wrong, we could hit this twice in the same interval. One second wait should be enough
+			//to desync us from the context changing routine.
 			collect.Add("check.context_not_changed", opentsdb.TagSet{"alert": a.Name}, 1)
 			time.Sleep(time.Second)
 		}

--- a/cmd/bosun/sched/alertRunner.go
+++ b/cmd/bosun/sched/alertRunner.go
@@ -2,10 +2,13 @@ package sched
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"bosun.org/cmd/bosun/cache"
 	"bosun.org/cmd/bosun/conf"
+	"bosun.org/collect"
+	"bosun.org/opentsdb"
 	"bosun.org/slog"
 )
 
@@ -23,10 +26,16 @@ func (s *Schedule) Run() error {
 	return nil
 }
 
+var checkContextLock = sync.RWMutex{}
+
 func (s *Schedule) updateCheckContext() {
+	var checkID int64
 	for {
-		ctx := &checkContext{utcNow(), cache.New(0)}
+		ctx := &checkContext{utcNow(), cache.New(0), checkID}
+		checkID++
+		checkContextLock.Lock()
 		s.ctx = ctx
+		checkContextLock.Unlock()
 		time.Sleep(s.SystemConf.GetCheckFrequency())
 		s.Lock("CollectStates")
 		s.CollectStates()
@@ -39,15 +48,30 @@ func (s *Schedule) RunAlert(a *conf.Alert) {
 	s.checksRunning.Add(1)
 	// ensure when an alert is done it is removed from the wait group
 	defer s.checksRunning.Done()
+	var lastCheckID int64 = -1
+	// Calcaulate runEvery based on system default and override if an alert has a
+	// custom runEvery
+	runEvery := s.SystemConf.GetDefaultRunEvery()
+	if a.RunEvery != 0 {
+		runEvery = a.RunEvery
+	}
 	for {
-		// Calcaulate runEvery based on system default and override if an alert has a
-		// custom runEvery
-		runEvery := s.SystemConf.GetDefaultRunEvery()
-		if a.RunEvery != 0 {
-			runEvery = a.RunEvery
+		var ctx *checkContext
+		for {
+			checkContextLock.RLock()
+			ctx = s.ctx
+			checkContextLock.RUnlock()
+			//make sure the context has actually changed
+			if ctx.id != lastCheckID {
+				lastCheckID = ctx.id
+				break
+			}
+			collect.Add("check.context_not_changed", opentsdb.TagSet{"alert": a.Name}, 1)
+			time.Sleep(time.Second)
 		}
+
 		wait := time.After(s.SystemConf.GetCheckFrequency() * time.Duration(runEvery))
-		s.checkAlert(a)
+		s.checkAlert(a, ctx)
 		s.LastCheck = utcNow()
 		select {
 		case <-wait:
@@ -59,10 +83,8 @@ func (s *Schedule) RunAlert(a *conf.Alert) {
 	}
 }
 
-func (s *Schedule) checkAlert(a *conf.Alert) {
-	checkTime := s.ctx.runTime
-	checkCache := s.ctx.checkCache
-	rh := s.NewRunHistory(checkTime, checkCache)
+func (s *Schedule) checkAlert(a *conf.Alert, ctx *checkContext) {
+	rh := s.NewRunHistory(ctx.runTime, ctx.checkCache)
 	// s.CheckAlert will return early if the schedule has been closed
 	cancelled := s.CheckAlert(nil, rh, a)
 	if cancelled {

--- a/cmd/bosun/sched/sched.go
+++ b/cmd/bosun/sched/sched.go
@@ -80,7 +80,7 @@ func (s *Schedule) Init(systemConf conf.SystemConfProvider, ruleConf conf.RuleCo
 	s.pendingUnknowns = make(map[*conf.Notification][]*models.IncidentState)
 	s.lastLogTimes = make(map[models.AlertKey]time.Time)
 	s.LastCheck = utcNow()
-	s.ctx = &checkContext{utcNow(), cache.New(0)}
+	s.ctx = &checkContext{utcNow(), cache.New(0), 0}
 	s.DataAccess = dataAccess
 	// Initialize the context and waitgroup used to gracefully shutdown bosun as well as reload
 	s.runnerContext, s.cancelChecks = context.WithCancel(context.Background())

--- a/cmd/bosun/sched/sched.go
+++ b/cmd/bosun/sched/sched.go
@@ -95,6 +95,7 @@ func (s *Schedule) Init(systemConf conf.SystemConfProvider, ruleConf conf.RuleCo
 type checkContext struct {
 	runTime    time.Time
 	checkCache *cache.Cache
+	id         int64
 }
 
 func init() {

--- a/cmd/bosun/sched/sched.go
+++ b/cmd/bosun/sched/sched.go
@@ -80,7 +80,7 @@ func (s *Schedule) Init(systemConf conf.SystemConfProvider, ruleConf conf.RuleCo
 	s.pendingUnknowns = make(map[*conf.Notification][]*models.IncidentState)
 	s.lastLogTimes = make(map[models.AlertKey]time.Time)
 	s.LastCheck = utcNow()
-	s.ctx = &checkContext{utcNow(), cache.New(0), 0}
+	s.ctx = &checkContext{utcNow(), cache.New(0)}
 	s.DataAccess = dataAccess
 	// Initialize the context and waitgroup used to gracefully shutdown bosun as well as reload
 	s.runnerContext, s.cancelChecks = context.WithCancel(context.Background())
@@ -95,7 +95,6 @@ func (s *Schedule) Init(systemConf conf.SystemConfProvider, ruleConf conf.RuleCo
 type checkContext struct {
 	runTime    time.Time
 	checkCache *cache.Cache
-	id         int64
 }
 
 func init() {

--- a/cmd/bosun/sched/sched_test.go
+++ b/cmd/bosun/sched/sched_test.go
@@ -50,7 +50,7 @@ func check(s *Schedule, t time.Time) {
 	for _, n := range names {
 		a := s.RuleConf.GetAlerts()[n]
 		s.ctx.runTime = t
-		s.checkAlert(a)
+		s.checkAlert(a, s.ctx)
 	}
 }
 


### PR DESCRIPTION
Uses a simple counter that gets incremented every time we make a new check context. When a check runs, if the context has not changed since last time, we wait a second and look again. 

Also fixes race condition.

Fixes #2023 