### PR TITLE
cmd/scollector: enable SWbemServices worker for better WMI performance in Windows

### DIFF
--- a/cmd/scollector/conf/conf.go
+++ b/cmd/scollector/conf/conf.go
@@ -32,7 +32,8 @@ type Conf struct {
 	MaxMem uint64
 	// Filter filters collectors matching these terms.
 	Filter []string
-	// PProf is an IP:Port binding to be used for debugging with pprof package.
+	// PProf is an IP:Port binding to be used for debugging with pprof and expvar package.
+	// When enabled data is exposed via http://host:port/debug/pprof or /debug/vars
 	// Examples: localhost:6060 for loopback or :6060 for all IP addresses.
 	PProf string
 	// MetricFilters takes regular expressions and includes only indicies that
@@ -54,6 +55,9 @@ type Conf struct {
 
 	// SNMPTimeout is the number of seconds to wait for SNMP responses (default 30)
 	SNMPTimeout int
+
+	// UseSWbemServicesClient specifies if the wmi package should use SWbemServices.
+	UseSWbemServicesClient bool
 
 	HAProxy        []HAProxy
 	SNMP           []SNMP

--- a/cmd/scollector/conf/conf_darwin.go
+++ b/cmd/scollector/conf/conf_darwin.go
@@ -6,3 +6,5 @@ type ServiceParams struct {
 	Name      string
 	WatchProc bool
 }
+
+func (c *Conf) InitializeSWbemServices() {}

--- a/cmd/scollector/conf/conf_linux.go
+++ b/cmd/scollector/conf/conf_linux.go
@@ -11,3 +11,5 @@ type ServiceParams struct {
 	Name      string
 	WatchProc bool
 }
+
+func (c *Conf) InitializeSWbemServices() {}

--- a/cmd/scollector/conf/conf_windows.go
+++ b/cmd/scollector/conf/conf_windows.go
@@ -1,5 +1,10 @@
 package conf
 
+import (
+	"bosun.org/slog"
+	"github.com/StackExchange/wmi"
+)
+
 type ProcessParams struct {
 	Name string
 }
@@ -7,4 +12,13 @@ type ProcessParams struct {
 type ServiceParams struct {
 	Name      string
 	WatchProc bool
+}
+
+func (c *Conf) InitializeSWbemServices() {
+	slog.Infof("Initializing SWbemServices")
+	s, err := wmi.InitializeSWbemServices(wmi.DefaultClient)
+	if err != nil {
+		slog.Fatal(err)
+	}
+	wmi.DefaultClient.SWbemServicesClient = s
 }

--- a/cmd/scollector/main.go
+++ b/cmd/scollector/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	_ "expvar"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -126,6 +127,9 @@ func main() {
 	}
 	if conf.SNMPTimeout > 0 {
 		snmp.Timeout = conf.SNMPTimeout
+	}
+	if conf.UseSWbemServicesClient {
+		conf.InitializeSWbemServices()
 	}
 	var err error
 	check := func(e error) {

--- a/vendor/github.com/StackExchange/mof/node.go
+++ b/vendor/github.com/StackExchange/mof/node.go
@@ -51,6 +51,7 @@ const (
 	nodeString
 	nodeNumber
 	nodeBool
+	nodeNil
 )
 
 // Nodes.
@@ -124,6 +125,19 @@ func newBool(pos pos, val bool) *boolNode {
 
 func (b *boolNode) Value() interface{} {
 	return b.Val
+}
+
+type nilNode struct {
+	nodeType
+	pos
+}
+
+func newNil(pos pos) *nilNode {
+	return &nilNode{nodeType: nodeNil, pos: pos}
+}
+
+func (b *nilNode) Value() interface{} {
+	return nil
 }
 
 type classNode struct {

--- a/vendor/github.com/StackExchange/mof/parse.go
+++ b/vendor/github.com/StackExchange/mof/parse.go
@@ -292,6 +292,8 @@ func (t *tree) parseValue() node {
 		case "instance":
 			t.backup()
 			n = t.parseInstance()
+		case "NULL":
+			n = newNil(token.pos)
 		default:
 			t.unexpected(token, context)
 		}

--- a/vendor/github.com/StackExchange/wmi/LICENSE
+++ b/vendor/github.com/StackExchange/wmi/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Stack Exchange
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/StackExchange/wmi/README.md
+++ b/vendor/github.com/StackExchange/wmi/README.md
@@ -1,0 +1,4 @@
+wmi
+===
+
+Package wmi provides a WQL interface for WMI on Windows.

--- a/vendor/github.com/StackExchange/wmi/swbemservices.go
+++ b/vendor/github.com/StackExchange/wmi/swbemservices.go
@@ -1,0 +1,260 @@
+// +build windows
+
+package wmi
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"sync"
+
+	"github.com/go-ole/go-ole"
+	"github.com/go-ole/go-ole/oleutil"
+)
+
+// SWbemServices is used to access wmi. See https://msdn.microsoft.com/en-us/library/aa393719(v=vs.85).aspx
+type SWbemServices struct {
+	//TODO: track namespace. Not sure if we can re connect to a different namespace using the same instance
+	cWMIClient            *Client //This could also be an embedded struct, but then we would need to branch on Client vs SWbemServices in the Query method
+	sWbemLocatorIUnknown  *ole.IUnknown
+	sWbemLocatorIDispatch *ole.IDispatch
+	queries               chan *queryRequest
+	closeError            chan error
+	lQueryorClose         sync.Mutex
+}
+
+type queryRequest struct {
+	query    string
+	dst      interface{}
+	args     []interface{}
+	finished chan error
+}
+
+// InitializeSWbemServices will return a new SWbemServices object that can be used to query WMI
+func InitializeSWbemServices(c *Client, connectServerArgs ...interface{}) (*SWbemServices, error) {
+	//fmt.Println("InitializeSWbemServices: Starting")
+	//TODO: implement connectServerArgs as optional argument for init with connectServer call
+	s := new(SWbemServices)
+	s.cWMIClient = c
+	s.queries = make(chan *queryRequest)
+	initError := make(chan error)
+	go s.process(initError)
+
+	err, ok := <-initError
+	if ok {
+		return nil, err //Send error to caller
+	}
+	//fmt.Println("InitializeSWbemServices: Finished")
+	return s, nil
+}
+
+// Close will clear and release all of the SWbemServices resources
+func (s *SWbemServices) Close() error {
+	s.lQueryorClose.Lock()
+	if s == nil || s.sWbemLocatorIDispatch == nil {
+		s.lQueryorClose.Unlock()
+		return fmt.Errorf("SWbemServices is not Initialized")
+	}
+	if s.queries == nil {
+		s.lQueryorClose.Unlock()
+		return fmt.Errorf("SWbemServices has been closed")
+	}
+	//fmt.Println("Close: sending close request")
+	var result error
+	ce := make(chan error)
+	s.closeError = ce //Race condition if multiple callers to close. May need to lock here
+	close(s.queries)  //Tell background to shut things down
+	s.lQueryorClose.Unlock()
+	err, ok := <-ce
+	if ok {
+		result = err
+	}
+	//fmt.Println("Close: finished")
+	return result
+}
+
+func (s *SWbemServices) process(initError chan error) {
+	//fmt.Println("process: starting background thread initialization")
+	//All OLE/WMI calls must happen on the same initialized thead, so lock this goroutine
+	runtime.LockOSThread()
+	defer runtime.LockOSThread()
+
+	err := ole.CoInitializeEx(0, ole.COINIT_MULTITHREADED)
+	if err != nil {
+		oleCode := err.(*ole.OleError).Code()
+		if oleCode != ole.S_OK && oleCode != S_FALSE {
+			initError <- fmt.Errorf("ole.CoInitializeEx error: %v", err)
+			return
+		}
+	}
+	defer ole.CoUninitialize()
+
+	unknown, err := oleutil.CreateObject("WbemScripting.SWbemLocator")
+	if err != nil {
+		initError <- fmt.Errorf("CreateObject SWbemLocator error: %v", err)
+		return
+	} else if unknown == nil {
+		initError <- ErrNilCreateObject
+		return
+	}
+	defer unknown.Release()
+	s.sWbemLocatorIUnknown = unknown
+
+	dispatch, err := s.sWbemLocatorIUnknown.QueryInterface(ole.IID_IDispatch)
+	if err != nil {
+		initError <- fmt.Errorf("SWbemLocator QueryInterface error: %v", err)
+		return
+	}
+	defer dispatch.Release()
+	s.sWbemLocatorIDispatch = dispatch
+
+	// we can't do the ConnectServer call outside the loop unless we find a way to track and re-init the connectServerArgs
+	//fmt.Println("process: initialized. closing initError")
+	close(initError)
+	//fmt.Println("process: waiting for queries")
+	for q := range s.queries {
+		//fmt.Printf("process: new query: len(query)=%d\n", len(q.query))
+		errQuery := s.queryBackground(q)
+		//fmt.Println("process: s.queryBackground finished")
+		if errQuery != nil {
+			q.finished <- errQuery
+		}
+		close(q.finished)
+	}
+	//fmt.Println("process: queries channel closed")
+	s.queries = nil //set channel to nil so we know it is closed
+	//TODO: I think the Release/Clear calls can panic if things are in a bad state.
+	//TODO: May need to recover from panics and send error to method caller instead.
+	close(s.closeError)
+}
+
+// Query runs the WQL query using a SWbemServices instance and appends the values to dst.
+//
+// dst must have type *[]S or *[]*S, for some struct type S. Fields selected in
+// the query must have the same name in dst. Supported types are all signed and
+// unsigned integers, time.Time, string, bool, or a pointer to one of those.
+// Array types are not supported.
+//
+// By default, the local machine and default namespace are used. These can be
+// changed using connectServerArgs. See
+// http://msdn.microsoft.com/en-us/library/aa393720.aspx for details.
+func (s *SWbemServices) Query(query string, dst interface{}, connectServerArgs ...interface{}) error {
+	s.lQueryorClose.Lock()
+	if s == nil || s.sWbemLocatorIDispatch == nil {
+		s.lQueryorClose.Unlock()
+		return fmt.Errorf("SWbemServices is not Initialized")
+	}
+	if s.queries == nil {
+		s.lQueryorClose.Unlock()
+		return fmt.Errorf("SWbemServices has been closed")
+	}
+
+	//fmt.Println("Query: Sending query request")
+	qr := queryRequest{
+		query:    query,
+		dst:      dst,
+		args:     connectServerArgs,
+		finished: make(chan error),
+	}
+	s.queries <- &qr
+	s.lQueryorClose.Unlock()
+	err, ok := <-qr.finished
+	if ok {
+		//fmt.Println("Query: Finished with error")
+		return err //Send error to caller
+	}
+	//fmt.Println("Query: Finished")
+	return nil
+}
+
+func (s *SWbemServices) queryBackground(q *queryRequest) error {
+	if s == nil || s.sWbemLocatorIDispatch == nil {
+		return fmt.Errorf("SWbemServices is not Initialized")
+	}
+	wmi := s.sWbemLocatorIDispatch //Should just rename in the code, but this will help as we break things apart
+	//fmt.Println("queryBackground: Starting")
+
+	dv := reflect.ValueOf(q.dst)
+	if dv.Kind() != reflect.Ptr || dv.IsNil() {
+		return ErrInvalidEntityType
+	}
+	dv = dv.Elem()
+	mat, elemType := checkMultiArg(dv)
+	if mat == multiArgTypeInvalid {
+		return ErrInvalidEntityType
+	}
+
+	// service is a SWbemServices
+	serviceRaw, err := oleutil.CallMethod(wmi, "ConnectServer", q.args...)
+	if err != nil {
+		return err
+	}
+	service := serviceRaw.ToIDispatch()
+	defer serviceRaw.Clear()
+
+	// result is a SWBemObjectSet
+	resultRaw, err := oleutil.CallMethod(service, "ExecQuery", q.query)
+	if err != nil {
+		return err
+	}
+	result := resultRaw.ToIDispatch()
+	defer resultRaw.Clear()
+
+	count, err := oleInt64(result, "Count")
+	if err != nil {
+		return err
+	}
+
+	enumProperty, err := result.GetProperty("_NewEnum")
+	if err != nil {
+		return err
+	}
+	defer enumProperty.Clear()
+
+	enum, err := enumProperty.ToIUnknown().IEnumVARIANT(ole.IID_IEnumVariant)
+	if err != nil {
+		return err
+	}
+	if enum == nil {
+		return fmt.Errorf("can't get IEnumVARIANT, enum is nil")
+	}
+	defer enum.Release()
+
+	// Initialize a slice with Count capacity
+	dv.Set(reflect.MakeSlice(dv.Type(), 0, int(count)))
+
+	var errFieldMismatch error
+	for itemRaw, length, err := enum.Next(1); length > 0; itemRaw, length, err = enum.Next(1) {
+		if err != nil {
+			return err
+		}
+
+		err := func() error {
+			// item is a SWbemObject, but really a Win32_Process
+			item := itemRaw.ToIDispatch()
+			defer item.Release()
+
+			ev := reflect.New(elemType)
+			if err = s.cWMIClient.loadEntity(ev.Interface(), item); err != nil {
+				if _, ok := err.(*ErrFieldMismatch); ok {
+					// We continue loading entities even in the face of field mismatch errors.
+					// If we encounter any other error, that other error is returned. Otherwise,
+					// an ErrFieldMismatch is returned.
+					errFieldMismatch = err
+				} else {
+					return err
+				}
+			}
+			if mat != multiArgTypeStructPtr {
+				ev = ev.Elem()
+			}
+			dv.Set(reflect.Append(dv, ev))
+			return nil
+		}()
+		if err != nil {
+			return err
+		}
+	}
+	//fmt.Println("queryBackground: Finished")
+	return errFieldMismatch
+}

--- a/vendor/github.com/StackExchange/wmi/wmi.go
+++ b/vendor/github.com/StackExchange/wmi/wmi.go
@@ -72,7 +72,10 @@ func QueryNamespace(query string, dst interface{}, namespace string) error {
 //
 // Query is a wrapper around DefaultClient.Query.
 func Query(query string, dst interface{}, connectServerArgs ...interface{}) error {
-	return DefaultClient.Query(query, dst, connectServerArgs...)
+	if DefaultClient.SWbemServicesClient == nil {
+		return DefaultClient.Query(query, dst, connectServerArgs...)
+	}
+	return DefaultClient.SWbemServicesClient.Query(query, dst, connectServerArgs...)
 }
 
 // A Client is an WMI query client.
@@ -99,6 +102,11 @@ type Client struct {
 	// Setting this to true allows custom queries to be used with full
 	// struct definitions instead of having to define multiple structs.
 	AllowMissingFields bool
+
+	// SWbemServiceClient is an optional SWbemServices object that can be
+	// initialized and then reused across multiple queries. If it is null
+	// then the method will initialize a new temporary client each time.
+	SWbemServicesClient *SWbemServices
 }
 
 // DefaultClient is the default Client and is used by Query, QueryNamespace

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -46,8 +46,8 @@
 		},
 		{
 			"path": "github.com/StackExchange/wmi",
-			"revision": "f4452b3678eaa14aafb0b058fcd60645a304ea8c",
-			"revisionTime": "2016-10-07T09:40:34-05:00"
+			"revision": "9f32b5905fd6ce7384093f9d048437e79f7b4d85",
+			"revisionTime": "2017-02-20T14:12:21-07:00"
 		},
 		{
 			"path": "github.com/ajstarks/svgo",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -41,8 +41,8 @@
 		},
 		{
 			"path": "github.com/StackExchange/mof",
-			"revision": "2bb66392c0273ed914c2b83442e8a61effa42678",
-			"revisionTime": "2015-06-18T18:52:08-04:00"
+			"revision": "cfc83d4047d1c05c81d9c54ac1eaedb076582114",
+			"revisionTime": "2017-02-27T16:04:56-07:00"
 		},
 		{
 			"path": "github.com/StackExchange/wmi",


### PR DESCRIPTION
This updates the WMI package to include the SWbemServices updates from https://github.com/StackExchange/wmi/pull/23

I plan on testing this in our environment to make sure things are stable. Shouldn't cause any issues as everything is behind the UseSWbemServicesClient = true value in scollector.toml