### PR TITLE
Add option to store SNMP IfAlias as a tag

### DIFF
--- a/cmd/scollector/conf/conf.go
+++ b/cmd/scollector/conf/conf.go
@@ -156,9 +156,10 @@ type AzureEA struct {
 }
 
 type SNMP struct {
-	Community string
-	Host      string
-	MIBs      []string
+	Community  string
+	Host       string
+	MIBs       []string
+	TagIfAlias bool
 }
 
 type MIB struct {

--- a/cmd/scollector/doc.go
+++ b/cmd/scollector/doc.go
@@ -147,7 +147,9 @@ to poll. The Instances key is an array of table with keys Tier and URL.
 	    URL = "http://ny-host01:40/haproxy\;csv"
 
 SNMP (array of table, keys are Community and Host): SNMP hosts to connect
-to at a 5 minute poll interval.
+to at a 5 minute poll interval. Optional TagIfAlias flag will record IfAlias
+(Cisco interface "description") as a tag for OpenTSDB installations
+that don't support metadata.
 
 	[[SNMP]]
 	  Community = "com"
@@ -158,6 +160,7 @@ to at a 5 minute poll interval.
 	  Host = "host2"
 	  # List of mibs to run for this host. Default is built-in set of ["ifaces","cisco"]
 	  MIBs = ["custom", "ifaces"]
+	  TagIfAlias = true
 
 MIBs (map of string to table): Allows user-specified, custom SNMP configurations.
 


### PR DESCRIPTION
This PR adds an option to scollector SNMP interface statistics, to add an additional tag for ifAlias. This can be useful for OpenTSDB installations that don't have metadata enabled, to allow interface "descriptions" to still be utilized in charts.

This also changes ifAlias sanitization by replacing (invalid) spaces with (valid) underscores, to improve readability.