### PR TITLE
cmd/tsdbrelay: Drain relay response so that connection is eligible for reuse.

### DIFF
--- a/cmd/tsdbrelay/main.go
+++ b/cmd/tsdbrelay/main.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -249,6 +250,8 @@ func (rp *relayProxy) relayPut(responseWriter http.ResponseWriter, r *http.Reque
 			verbose("bosun relay error: %v", err)
 			return
 		}
+		// Drain up to 512 bytes and close the body to let the Transport reuse the connection
+		io.CopyN(ioutil.Discard, resp.Body, 512)
 		resp.Body.Close()
 		verbose("bosun relay success")
 	}()
@@ -283,6 +286,8 @@ func (rp *relayProxy) relayPut(responseWriter http.ResponseWriter, r *http.Reque
 					collect.Add("additional.puts.error", tags, 1)
 					continue
 				}
+				// Drain up to 512 bytes and close the body to let the Transport reuse the connection
+				io.CopyN(ioutil.Discard, resp.Body, 512)
 				resp.Body.Close()
 				verbose("secondary relay success")
 				collect.Add("additional.puts.relayed", tags, 1)
@@ -383,6 +388,8 @@ func (rp *relayProxy) relayMetadata(responseWriter http.ResponseWriter, r *http.
 					verbose("secondary relay metadata error: %v", err)
 					continue
 				}
+				// Drain up to 512 bytes and close the body to let the Transport reuse the connection
+				io.CopyN(ioutil.Discard, resp.Body, 512)
 				resp.Body.Close()
 				verbose("secondary relay metadata success")
 			}


### PR DESCRIPTION
tsdbrelay is not reusing connections for its relay calls. `DefaultTransport` will not allow a connection to be reused unless the [body has been read](https://golang.org/src/net/http/transport.go?h=bodyEOFSignal#L2002). This change will use the common pattern of reading 512 bytes from the `resp.Body` to try and ensure the connection is available for reuse. This is intentionally capped at 512 bytes to avoid waiting for cases of large responses.

Some discussion on this if curious: https://groups.google.com/forum/#!search/golang$20json$20decode$20$20io.Copy/golang-nuts/4Rr8BYVKrAI/ZrJJFTNleekJ


Confirmed in testing that this addresses lack of connection reuse.

Partially addresses #2018.

@kylebrandt @captncraig @gbrayut 

