### PR TITLE
misc: Drain body responses so that connection is eligible for reuse

### DIFF
--- a/cmd/backfill/main.go
+++ b/cmd/backfill/main.go
@@ -6,6 +6,8 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"log"
 	"net/url"
 	"strconv"
@@ -114,6 +116,8 @@ func main() {
 				return err
 			}
 			defer putResp.Body.Close()
+			// Drain up to 512 bytes and close the body to let the Transport reuse the connection
+			io.CopyN(ioutil.Discard, putResp.Body, 512)
 
 			if putResp.StatusCode != 204 {
 				return fmt.Errorf("Non 204 status code from opentsdb: %d", putResp.StatusCode)

--- a/cmd/bosun/conf/notify.go
+++ b/cmd/bosun/conf/notify.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"crypto/tls"
 	"errors"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/mail"
 	"net/smtp"
@@ -68,6 +70,8 @@ func (n *Notification) DoPost(payload []byte, ak string) {
 	}
 	resp, err := http.Post(n.Post.String(), n.ContentType, bytes.NewBuffer(payload))
 	if resp != nil && resp.Body != nil {
+		// Drain up to 512 bytes and close the body to let the Transport reuse the connection
+		io.CopyN(ioutil.Discard, resp.Body, 512)
 		defer resp.Body.Close()
 	}
 	if err != nil {

--- a/cmd/bosun/sched/template.go
+++ b/cmd/bosun/sched/template.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"io"
 	"io/ioutil"
 	"math"
 	"net/http"
@@ -461,6 +462,8 @@ func (c *Context) HTTPGet(url string) string {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 300 {
+		// Drain up to 512 bytes and close the body to let the Transport reuse the connection
+		io.CopyN(ioutil.Discard, resp.Body, 512)
 		err := fmt.Errorf("%v: returned %v", url, resp.Status)
 		c.addError(err)
 		return err.Error()
@@ -512,6 +515,8 @@ func (c *Context) HTTPPost(url, bodyType, data string) string {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 300 {
+		// Drain up to 512 bytes and close the body to let the Transport reuse the connection
+		io.CopyN(ioutil.Discard, resp.Body, 512)
 		return fmt.Sprintf("%v: returned %v", url, resp.Status)
 	}
 	body, err := ioutil.ReadAll(resp.Body)

--- a/cmd/scollector/collectors/elasticsearch.go
+++ b/cmd/scollector/collectors/elasticsearch.go
@@ -2,6 +2,8 @@ package collectors
 
 import (
 	"encoding/json"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -247,6 +249,8 @@ func esReq(path, query string, v interface{}) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
+		// Drain up to 512 bytes and close the body to let the Transport reuse the connection
+		io.CopyN(ioutil.Discard, resp.Body, 512)
 		return nil
 	}
 	j := json.NewDecoder(resp.Body)

--- a/collect/queue.go
+++ b/collect/queue.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -138,6 +139,8 @@ func sendBatch(batch []*opentsdb.DataPoint) {
 		time.Sleep(d)
 		return
 	}
+	// Drain up to 512 bytes so the Transport can reuse the connection when it is closed
+	io.CopyN(ioutil.Discard, resp.Body, 512)
 	recordSent(len(batch))
 }
 

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -4,6 +4,8 @@ package metadata // import "bosun.org/metadata"
 import (
 	"bytes"
 	"encoding/json"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -296,6 +298,8 @@ func postMetadata(ms []Metasend) {
 		return
 	}
 	defer resp.Body.Close()
+	// Drain up to 512 bytes and close the body to let the Transport reuse the connection
+	io.CopyN(ioutil.Discard, resp.Body, 512)
 	if resp.StatusCode != 204 {
 		slog.Errorln("bad metadata return:", resp.Status)
 		return


### PR DESCRIPTION
After Jason updated tsdbrelay I did an audit of the various places we use Body.Close but don't read any bytes. This should allow connection reuse in those cases. Testing on ny-gbraylx01 but would like someone to review @captncraig @alienth @kylebrandt 