### PR TITLE
cmd/scollector: more cadvisor metrics

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -100,6 +100,7 @@ const (
 	Packet               = "packets"
 	Page                 = "pages"
 	Pct                  = "percent" // Range of 0-100.
+	Period               = "period"
 	PerSecond            = "per second"
 	Process              = "processes"
 	Priority             = "priority"
@@ -121,6 +122,7 @@ const (
 	Server               = "servers"
 	Session              = "sessions"
 	Shard                = "shards"
+	Share                = "share"
 	Slave                = "slaves"
 	Socket               = "sockets"
 	Suggest              = "suggests"

--- a/vendor/github.com/google/cadvisor/client/client_test.go
+++ b/vendor/github.com/google/cadvisor/client/client_test.go
@@ -1,0 +1,189 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	info "github.com/google/cadvisor/info/v1"
+	itest "github.com/google/cadvisor/info/v1/test"
+
+	"github.com/kr/pretty"
+)
+
+func testGetJsonData(
+	expected interface{},
+	f func() (interface{}, error),
+) error {
+	reply, err := f()
+	if err != nil {
+		return fmt.Errorf("unable to retrieve data: %v", err)
+	}
+	if !reflect.DeepEqual(reply, expected) {
+		return pretty.Errorf("retrieved wrong data: %# v != %# v", reply, expected)
+	}
+	return nil
+}
+
+func cadvisorTestClient(path string, expectedPostObj *info.ContainerInfoRequest, replyObj interface{}, t *testing.T) (*Client, *httptest.Server, error) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == path {
+			if expectedPostObj != nil {
+				expectedPostObjEmpty := new(info.ContainerInfoRequest)
+				decoder := json.NewDecoder(r.Body)
+				if err := decoder.Decode(expectedPostObjEmpty); err != nil {
+					t.Errorf("Received invalid object: %v", err)
+				}
+				if expectedPostObj.NumStats != expectedPostObjEmpty.NumStats ||
+					expectedPostObj.Start.Unix() != expectedPostObjEmpty.Start.Unix() ||
+					expectedPostObj.End.Unix() != expectedPostObjEmpty.End.Unix() {
+					t.Errorf("Received unexpected object: %+v, expected: %+v", expectedPostObjEmpty, expectedPostObj)
+				}
+			}
+			encoder := json.NewEncoder(w)
+			encoder.Encode(replyObj)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprintf(w, "Page not found.")
+		}
+	}))
+	client, err := NewClient(ts.URL)
+	if err != nil {
+		ts.Close()
+		return nil, nil, err
+	}
+	return client, ts, err
+}
+
+// TestGetMachineInfo performs one test to check if MachineInfo()
+// in a cAdvisor client returns the correct result.
+func TestGetMachineinfo(t *testing.T) {
+	minfo := &info.MachineInfo{
+		NumCores:       8,
+		MemoryCapacity: 31625871360,
+		DiskMap: map[string]info.DiskInfo{
+			"8:0": {
+				Name:  "sda",
+				Major: 8,
+				Minor: 0,
+				Size:  10737418240,
+			},
+		},
+	}
+	client, server, err := cadvisorTestClient("/api/v1.3/machine", nil, minfo, t)
+	if err != nil {
+		t.Fatalf("unable to get a client %v", err)
+	}
+	defer server.Close()
+	returned, err := client.MachineInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(returned, minfo) {
+		t.Fatalf("received unexpected machine info")
+	}
+}
+
+// TestGetContainerInfo generates a random container information object
+// and then checks that ContainerInfo returns the expected result.
+func TestGetContainerInfo(t *testing.T) {
+	query := &info.ContainerInfoRequest{
+		NumStats: 3,
+	}
+	containerName := "/some/container"
+	cinfo := itest.GenerateRandomContainerInfo(containerName, 4, query, 1*time.Second)
+	client, server, err := cadvisorTestClient(fmt.Sprintf("/api/v1.3/containers%v", containerName), query, cinfo, t)
+	if err != nil {
+		t.Fatalf("unable to get a client %v", err)
+	}
+	defer server.Close()
+	returned, err := client.ContainerInfo(containerName, query)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !returned.Eq(cinfo) {
+		t.Error("received unexpected ContainerInfo")
+	}
+}
+
+// Test a request failing
+func TestRequestFails(t *testing.T) {
+	errorText := "there was an error"
+	// Setup a server that simply fails.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, errorText, 500)
+	}))
+	client, err := NewClient(ts.URL)
+	if err != nil {
+		ts.Close()
+		t.Fatal(err)
+	}
+	defer ts.Close()
+
+	_, err = client.ContainerInfo("/", &info.ContainerInfoRequest{NumStats: 3})
+	if err == nil {
+		t.Fatalf("Expected non-nil error")
+	}
+	expectedError := fmt.Sprintf("request failed with error: %q", errorText)
+	if strings.Contains(err.Error(), expectedError) {
+		t.Fatalf("Expected error %q but received %q", expectedError, err)
+	}
+}
+
+func TestGetSubcontainersInfo(t *testing.T) {
+	query := &info.ContainerInfoRequest{
+		NumStats: 3,
+	}
+	containerName := "/some/container"
+	cinfo := itest.GenerateRandomContainerInfo(containerName, 4, query, 1*time.Second)
+	cinfo1 := itest.GenerateRandomContainerInfo(path.Join(containerName, "sub1"), 4, query, 1*time.Second)
+	cinfo2 := itest.GenerateRandomContainerInfo(path.Join(containerName, "sub2"), 4, query, 1*time.Second)
+	response := []info.ContainerInfo{
+		*cinfo,
+		*cinfo1,
+		*cinfo2,
+	}
+	client, server, err := cadvisorTestClient(fmt.Sprintf("/api/v1.3/subcontainers%v", containerName), query, response, t)
+	if err != nil {
+		t.Fatalf("unable to get a client %v", err)
+	}
+	defer server.Close()
+	returned, err := client.SubcontainersInfo(containerName, query)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(returned) != 3 {
+		t.Errorf("unexpected number of results: got %d, expected 3", len(returned))
+	}
+	if !returned[0].Eq(cinfo) {
+		t.Error("received unexpected ContainerInfo")
+	}
+	if !returned[1].Eq(cinfo1) {
+		t.Error("received unexpected ContainerInfo")
+	}
+	if !returned[2].Eq(cinfo2) {
+		t.Error("received unexpected ContainerInfo")
+	}
+}

--- a/vendor/github.com/google/cadvisor/info/v1/container.go
+++ b/vendor/github.com/google/cadvisor/info/v1/container.go
@@ -266,7 +266,7 @@ type LoadStats struct {
 // CPU usage time statistics.
 type CpuUsage struct {
 	// Total CPU usage.
-	// Units: nanoseconds
+	// Unit: nanoseconds.
 	Total uint64 `json:"total"`
 
 	// Per CPU/core usage of the container.
@@ -274,17 +274,31 @@ type CpuUsage struct {
 	PerCpu []uint64 `json:"per_cpu_usage,omitempty"`
 
 	// Time spent in user space.
-	// Unit: nanoseconds
+	// Unit: nanoseconds.
 	User uint64 `json:"user"`
 
 	// Time spent in kernel space.
-	// Unit: nanoseconds
+	// Unit: nanoseconds.
 	System uint64 `json:"system"`
+}
+
+// Cpu Completely Fair Scheduler statistics.
+type CpuCFS struct {
+	// Total number of elapsed enforcement intervals.
+	Periods uint64 `json:"periods"`
+
+	// Total number of times tasks in the cgroup have been throttled.
+	ThrottledPeriods uint64 `json:"throttled_periods"`
+
+	// Total time duration for which tasks in the cgroup have been throttled.
+	// Unit: nanoseconds.
+	ThrottledTime uint64 `json:"throttled_time"`
 }
 
 // All CPU usage metrics are cumulative from the creation of the container
 type CpuStats struct {
 	Usage CpuUsage `json:"usage"`
+	CFS   CpuCFS   `json:"cfs"`
 	// Smoothed average of number of runnable threads x 1000.
 	// We multiply by thousand to avoid using floats, but preserving precision.
 	// Load is smoothed over the last 10 seconds. Instantaneous value can be read
@@ -323,6 +337,10 @@ type MemoryStats struct {
 	// hugepages).
 	// Units: Bytes.
 	RSS uint64 `json:"rss"`
+
+	// The amount of swap currently used by the processes in this cgroup
+	// Units: Bytes.
+	Swap uint64 `json:"swap"`
 
 	// The amount of working set memory, this includes recently accessed memory,
 	// dirty memory, and kernel memory. Working set is <= "usage".
@@ -371,33 +389,36 @@ type NetworkStats struct {
 }
 
 type TcpStat struct {
-	//Count of TCP connections in state "Established"
+	// Count of TCP connections in state "Established"
 	Established uint64
-	//Count of TCP connections in state "Syn_Sent"
+	// Count of TCP connections in state "Syn_Sent"
 	SynSent uint64
-	//Count of TCP connections in state "Syn_Recv"
+	// Count of TCP connections in state "Syn_Recv"
 	SynRecv uint64
-	//Count of TCP connections in state "Fin_Wait1"
+	// Count of TCP connections in state "Fin_Wait1"
 	FinWait1 uint64
-	//Count of TCP connections in state "Fin_Wait2"
+	// Count of TCP connections in state "Fin_Wait2"
 	FinWait2 uint64
-	//Count of TCP connections in state "Time_Wait
+	// Count of TCP connections in state "Time_Wait
 	TimeWait uint64
-	//Count of TCP connections in state "Close"
+	// Count of TCP connections in state "Close"
 	Close uint64
-	//Count of TCP connections in state "Close_Wait"
+	// Count of TCP connections in state "Close_Wait"
 	CloseWait uint64
-	//Count of TCP connections in state "Listen_Ack"
+	// Count of TCP connections in state "Listen_Ack"
 	LastAck uint64
-	//Count of TCP connections in state "Listen"
+	// Count of TCP connections in state "Listen"
 	Listen uint64
-	//Count of TCP connections in state "Closing"
+	// Count of TCP connections in state "Closing"
 	Closing uint64
 }
 
 type FsStats struct {
 	// The block device name associated with the filesystem.
 	Device string `json:"device,omitempty"`
+
+	// Type of the filesytem.
+	Type string `json:"type"`
 
 	// Number of bytes that can be consumed by the container on this filesystem.
 	Limit uint64 `json:"capacity"`
@@ -411,6 +432,15 @@ type FsStats struct {
 
 	// Number of bytes available for non-root user.
 	Available uint64 `json:"available"`
+
+	// HasInodes when true, indicates that Inodes info will be available.
+	HasInodes bool `json:"has_inodes"`
+
+	// Number of Inodes
+	Inodes uint64 `json:"inodes"`
+
+	// Number of available Inodes
+	InodesFree uint64 `json:"inodes_free"`
 
 	// Number of reads completed
 	// This is the total number of reads completed successfully.
@@ -481,7 +511,7 @@ type ContainerStats struct {
 	// Task load stats
 	TaskStats LoadStats `json:"task_stats,omitempty"`
 
-	//Custom metrics from all collectors
+	// Custom metrics from all collectors
 	CustomMetrics map[string][]MetricVal `json:"custom_metrics,omitempty"`
 }
 

--- a/vendor/github.com/google/cadvisor/info/v1/container_test.go
+++ b/vendor/github.com/google/cadvisor/info/v1/container_test.go
@@ -1,0 +1,79 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStatsStartTime(t *testing.T) {
+	N := 10
+	stats := make([]*ContainerStats, 0, N)
+	ct := time.Now()
+	for i := 0; i < N; i++ {
+		s := &ContainerStats{
+			Timestamp: ct.Add(time.Duration(i) * time.Second),
+		}
+		stats = append(stats, s)
+	}
+	cinfo := &ContainerInfo{
+		ContainerReference: ContainerReference{
+			Name: "/some/container",
+		},
+		Stats: stats,
+	}
+	ref := ct.Add(time.Duration(N-1) * time.Second)
+	end := cinfo.StatsEndTime()
+
+	if !ref.Equal(end) {
+		t.Errorf("end time is %v; should be %v", end, ref)
+	}
+}
+
+func TestStatsEndTime(t *testing.T) {
+	N := 10
+	stats := make([]*ContainerStats, 0, N)
+	ct := time.Now()
+	for i := 0; i < N; i++ {
+		s := &ContainerStats{
+			Timestamp: ct.Add(time.Duration(i) * time.Second),
+		}
+		stats = append(stats, s)
+	}
+	cinfo := &ContainerInfo{
+		ContainerReference: ContainerReference{
+			Name: "/some/container",
+		},
+		Stats: stats,
+	}
+	ref := ct
+	start := cinfo.StatsStartTime()
+
+	if !ref.Equal(start) {
+		t.Errorf("start time is %v; should be %v", start, ref)
+	}
+}
+
+func createStats(cpuUsage, memUsage uint64, timestamp time.Time) *ContainerStats {
+	stats := &ContainerStats{}
+	stats.Cpu.Usage.PerCpu = []uint64{cpuUsage}
+	stats.Cpu.Usage.Total = cpuUsage
+	stats.Cpu.Usage.System = 0
+	stats.Cpu.Usage.User = cpuUsage
+	stats.Memory.Usage = memUsage
+	stats.Timestamp = timestamp
+	return stats
+}

--- a/vendor/github.com/google/cadvisor/info/v1/docker.go
+++ b/vendor/github.com/google/cadvisor/info/v1/docker.go
@@ -1,0 +1,38 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Types used for docker containers.
+package v1
+
+type DockerStatus struct {
+	Version       string            `json:"version"`
+	APIVersion    string            `json:"api_version"`
+	KernelVersion string            `json:"kernel_version"`
+	OS            string            `json:"os"`
+	Hostname      string            `json:"hostname"`
+	RootDir       string            `json:"root_dir"`
+	Driver        string            `json:"driver"`
+	DriverStatus  map[string]string `json:"driver_status"`
+	ExecDriver    string            `json:"exec_driver"`
+	NumImages     int               `json:"num_images"`
+	NumContainers int               `json:"num_containers"`
+}
+
+type DockerImage struct {
+	ID          string   `json:"id"`
+	RepoTags    []string `json:"repo_tags"` // repository name and tags.
+	Created     int64    `json:"created"`   // unix time since creation.
+	VirtualSize int64    `json:"virtual_size"`
+	Size        int64    `json:"size"`
+}

--- a/vendor/github.com/google/cadvisor/info/v1/machine.go
+++ b/vendor/github.com/google/cadvisor/info/v1/machine.go
@@ -20,6 +20,15 @@ type FsInfo struct {
 
 	// Total number of bytes available on the filesystem.
 	Capacity uint64 `json:"capacity"`
+
+	// Type of device.
+	Type string `json:"type"`
+
+	// Total number of inodes available on the filesystem.
+	Inodes uint64 `json:"inodes"`
+
+	// HasInodes when true, indicates that Inodes info will be available.
+	HasInodes bool `json:"has_inodes"`
 }
 
 type Node struct {
@@ -115,10 +124,11 @@ type NetInfo struct {
 type CloudProvider string
 
 const (
-	GCE            CloudProvider = "GCE"
-	AWS                          = "AWS"
-	Baremetal                    = "Baremetal"
-	UnkownProvider               = "Unknown"
+	GCE             CloudProvider = "GCE"
+	AWS                           = "AWS"
+	Azure                         = "Azure"
+	Baremetal                     = "Baremetal"
+	UnknownProvider               = "Unknown"
 )
 
 type InstanceType string
@@ -126,6 +136,12 @@ type InstanceType string
 const (
 	NoInstance      InstanceType = "None"
 	UnknownInstance              = "Unknown"
+)
+
+type InstanceID string
+
+const (
+	UnNamedInstance InstanceID = "None"
 )
 
 type MachineInfo struct {
@@ -165,6 +181,9 @@ type MachineInfo struct {
 
 	// Type of cloud instance (e.g. GCE standard) the machine is.
 	InstanceType InstanceType `json:"instance_type"`
+
+	// ID of cloud instance (e.g. instance-1) given to it by the cloud provider.
+	InstanceID InstanceID `json:"instance_id"`
 }
 
 type VersionInfo struct {
@@ -176,6 +195,9 @@ type VersionInfo struct {
 
 	// Docker version.
 	DockerVersion string `json:"docker_version"`
+
+	// Docker API Version
+	DockerAPIVersion string `json:"docker_api_version"`
 
 	// cAdvisor version.
 	CadvisorVersion string `json:"cadvisor_version"`

--- a/vendor/github.com/google/cadvisor/info/v1/metric.go
+++ b/vendor/github.com/google/cadvisor/info/v1/metric.go
@@ -26,10 +26,10 @@ const (
 	MetricGauge MetricType = "gauge"
 
 	// A counter-like value that is only expected to increase.
-	MetricCumulative = "cumulative"
+	MetricCumulative MetricType = "cumulative"
 
 	// Rate over a time period.
-	MetricDelta = "delta"
+	MetricDelta MetricType = "delta"
 )
 
 // DataType for metric being exported.
@@ -37,7 +37,7 @@ type DataType string
 
 const (
 	IntType   DataType = "int"
-	FloatType          = "float"
+	FloatType DataType = "float"
 )
 
 // Spec for custom metric.

--- a/vendor/github.com/google/cadvisor/info/v1/test/datagen.go
+++ b/vendor/github.com/google/cadvisor/info/v1/test/datagen.go
@@ -1,0 +1,81 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	info "github.com/google/cadvisor/info/v1"
+)
+
+func GenerateRandomStats(numStats, numCores int, duration time.Duration) []*info.ContainerStats {
+	ret := make([]*info.ContainerStats, numStats)
+	perCoreUsages := make([]uint64, numCores)
+	currentTime := time.Now()
+	for i := range perCoreUsages {
+		perCoreUsages[i] = uint64(rand.Int63n(1000))
+	}
+	for i := 0; i < numStats; i++ {
+		stats := new(info.ContainerStats)
+		stats.Timestamp = currentTime
+		currentTime = currentTime.Add(duration)
+
+		percore := make([]uint64, numCores)
+		for i := range perCoreUsages {
+			perCoreUsages[i] += uint64(rand.Int63n(1000))
+			percore[i] = perCoreUsages[i]
+			stats.Cpu.Usage.Total += percore[i]
+		}
+		stats.Cpu.Usage.PerCpu = percore
+		stats.Cpu.Usage.User = stats.Cpu.Usage.Total
+		stats.Cpu.Usage.System = 0
+		stats.Memory.Usage = uint64(rand.Int63n(4096))
+		stats.Memory.Cache = uint64(rand.Int63n(4096))
+		stats.Memory.RSS = uint64(rand.Int63n(4096))
+		ret[i] = stats
+	}
+	return ret
+}
+
+func GenerateRandomContainerSpec(numCores int) info.ContainerSpec {
+	ret := info.ContainerSpec{
+		CreationTime: time.Now(),
+		HasCpu:       true,
+		Cpu:          info.CpuSpec{},
+		HasMemory:    true,
+		Memory:       info.MemorySpec{},
+	}
+	ret.Cpu.Limit = uint64(1000 + rand.Int63n(2000))
+	ret.Cpu.MaxLimit = uint64(1000 + rand.Int63n(2000))
+	ret.Cpu.Mask = fmt.Sprintf("0-%d", numCores-1)
+	ret.Memory.Limit = uint64(4096 + rand.Int63n(4096))
+	return ret
+}
+
+func GenerateRandomContainerInfo(containerName string, numCores int, query *info.ContainerInfoRequest, duration time.Duration) *info.ContainerInfo {
+	stats := GenerateRandomStats(query.NumStats, numCores, duration)
+	spec := GenerateRandomContainerSpec(numCores)
+
+	ret := &info.ContainerInfo{
+		ContainerReference: info.ContainerReference{
+			Name: containerName,
+		},
+		Spec:  spec,
+		Stats: stats,
+	}
+	return ret
+}


### PR DESCRIPTION
Adds cfs stats, memory and cpu specs from cadvisor from the newer cadvisor client.