### PR TITLE
cmd/tsdbrelay: parse -t -b and -r parameters as URLs and allow filtering of relay data

### DIFF
--- a/cmd/tsdbrelay/doc.go
+++ b/cmd/tsdbrelay/doc.go
@@ -22,15 +22,16 @@ Usage:
 
 The flags are:
 	-b="bosun"
-		Target Bosun server. Can specify port with host:port.
+		Target Bosun server. Can specify as host, host:port, or https://host:port.
 	-t=""
-		Target OpenTSDB server. Can specify port with host:port.
+		Target OpenTSDB server. Can specify as host, host:port or https://host:port.
 	-l=":4242"
 		Listen address.
 	-v=false
 	    Enable verbose logging
 	-r=""
 		Additional relays to send data to, comma seperated. Intended for secondary data center replication. Only response from primary tsdb server wil be relayed to clients.
+		Examples: hostA:port,https://hostB:port,hostC#data-only,https://hostD:8080#metadata-only
 	-redis=""
 		Redis host to store external counter data in
 	-db=0


### PR DESCRIPTION
This is a first try at adding support for HTTPS in -t, -b, and -r parameters in tsdbrelay. I also rigged up the url fragment to allow filtering of what data gets sent to a relay. If you add `#data-only` or `#metadata-only` to the end of a host in the -r parameter section it should filter the relay results sent to that host. This is useful when the remote endpoint is NOT a load balancer or tsdbrelay instance, but instead a native OpenTSDB compatible endpoint

I haven't started testing yet, but let me know if there are any objections/recommended changes