### PR TITLE
cmd/bosun: (wip) integrate expr documentation

### DIFF
--- a/cmd/bosun/conf/conf.go
+++ b/cmd/bosun/conf/conf.go
@@ -123,7 +123,7 @@ type RuleConfProvider interface {
 	AlertSquelched(*Alert) func(opentsdb.TagSet) bool
 	Squelched(*Alert, opentsdb.TagSet) bool
 	Expand(string, map[string]string, bool) string
-	GetFuncs(EnabledBackends) map[string]parse.Func
+	GetFuncs(EnabledBackends) parse.FuncMap
 }
 
 // RuleConfWriter is a collection of the methods that are used to manipulate the configuration

--- a/cmd/bosun/conf/rule/rule.go
+++ b/cmd/bosun/conf/rule/rule.go
@@ -862,7 +862,7 @@ func (c *Conf) NewExpr(s string) *expr.Expr {
 	return exp
 }
 
-func (c *Conf) GetFuncs(backends conf.EnabledBackends) map[string]eparse.Func {
+func (c *Conf) GetFuncs(backends conf.EnabledBackends) eparse.FuncMap {
 	lookup := func(e *expr.State, T miniprofiler.Timer, lookup, key string) (results *expr.Results, err error) {
 		results = new(expr.Results)
 		results.IgnoreUnjoined = true

--- a/cmd/bosun/expr/annotate.go
+++ b/cmd/bosun/expr/annotate.go
@@ -16,7 +16,7 @@ import (
 	"github.com/kylebrandt/boolq"
 )
 
-var Annotate = map[string]parse.Func{
+var Annotate = parse.FuncMap{
 	// Funcs for querying elastic
 	"ancounts": {
 		Args:   []models.FuncType{models.TypeString, models.TypeString, models.TypeString},

--- a/cmd/bosun/expr/doc/doc.go
+++ b/cmd/bosun/expr/doc/doc.go
@@ -1,6 +1,7 @@
 package doc
 
 import (
+	"encoding/json"
 	"fmt"
 	"html/template"
 	"reflect"
@@ -27,6 +28,18 @@ type Func struct {
 	Arguments    Arguments
 	Examples     []HTMLString
 	Return       models.FuncType
+}
+
+type ExtFunc Func
+
+func (f Func) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct{
+		ExtFunc
+		Signature string
+	}{
+		ExtFunc: ExtFunc(f),
+		Signature: f.Signature(),
+	})
 }
 
 type Funcs []*Func

--- a/cmd/bosun/expr/doc/doc.go
+++ b/cmd/bosun/expr/doc/doc.go
@@ -128,6 +128,12 @@ var docWikiTemplate = `
 	{{ template "func" $f}}
 {{ end }}
 
+<h1>Filtering Functions</h1>
+{{ range $i, $f := .filter }}
+	<h2 class="exprFunc anchor">{{ $f.Signature }}</h2>
+	{{ template "func" $f}}
+{{ end }}
+
 <h1>Group Functions</h1>
 {{ range $i, $f := .group }}
 	<h2 class="exprFunc anchor">{{ $f.Signature }}</h2>

--- a/cmd/bosun/expr/doc/doc.go
+++ b/cmd/bosun/expr/doc/doc.go
@@ -106,6 +106,9 @@ Argument Details:
 {{ if ne .ExtendedInfo "" }}
 	{{ .ExtendedInfo.HTML }}
 {{ end }}
+{{ range $example := .Examples }}
+	{{ $example.HTML}}
+{{ end }}
 {{ if ne .CodeLink ""}}
 <a href="{{.CodeLink}}">Code</a>
 {{ end }}
@@ -126,6 +129,12 @@ var docWikiTemplate = `
 
 <h1>Group Functions</h1>
 {{ range $i, $f := .group }}
+	<h2 class="exprFunc anchor">{{ $f.Signature }}</h2>
+	{{ template "func" $f}}
+{{ end }}
+
+<h1>Time Functions</h1>
+{{ range $i, $f := .time }}
 	<h2 class="exprFunc anchor">{{ $f.Signature }}</h2>
 	{{ template "func" $f}}
 {{ end }}

--- a/cmd/bosun/expr/doc/doc.go
+++ b/cmd/bosun/expr/doc/doc.go
@@ -20,12 +20,13 @@ func (h HTMLString) HTML() template.HTML {
 
 // Func contains the documentation for an expression function
 type Func struct {
-	Name      string
-	Summary   HTMLString
-	CodeLink  string
-	Arguments Arguments
-	Examples  []HTMLString
-	Return    models.FuncType
+	Name         string
+	Summary      HTMLString
+	ExtendedInfo HTMLString
+	CodeLink     string
+	Arguments    Arguments
+	Examples     []HTMLString
+	Return       models.FuncType
 }
 
 type Funcs []*Func
@@ -92,21 +93,26 @@ func suffixSet(t models.FuncType) string {
 // TODO make series seriesSet, will also probably just makes these HTML
 var funcWikiTemplate = `
 <p>{{ .Summary.HTML }}</p>
-Code: {{ .CodeLink }}
 {{ if .Arguments.HasDescription }}
 Argument Details:
 <ul>
-	{{ range $i, $arg := .Arguments -}}
-		{{- if ne $arg.Desc "" }}
+	{{ range $i, $arg := .Arguments }}
+		{{ if ne $arg.Desc "" }}
 	<li>{{ $arg.Name }} ({{ $arg.Type }}): {{ $arg.Desc.HTML }}</li>
-		{{- end -}}
-	{{- end }}
+		{{ end }}
+	{{ end }}
 </ul>
-{{- end -}}
+{{ end }}
+{{ if ne .ExtendedInfo "" }}
+	{{ .ExtendedInfo.HTML }}
+{{ end }}
+{{ if ne .CodeLink ""}}
+<a href="{{.CodeLink}}">Code</a>
+{{ end }}
 `
 
 var docWikiTemplate = `
-<h1>Builtins</h1>
+<h1>Builtins (all these will be moved into categories)</h1>
 {{ range $f := .builtins }}
 	<h2 class="exprFunc anchor">{{ $f.Signature }}</h2>
 	{{ template "func" $f}}
@@ -114,6 +120,12 @@ var docWikiTemplate = `
 
 <h1>Reduction Functions</h1>
 {{ range $i, $f := .reduction }}
+	<h2 class="exprFunc anchor">{{ $f.Signature }}</h2>
+	{{ template "func" $f}}
+{{ end }}
+
+<h1>Group Functions</h1>
+{{ range $i, $f := .group }}
 	<h2 class="exprFunc anchor">{{ $f.Signature }}</h2>
 	{{ template "func" $f}}
 {{ end }}

--- a/cmd/bosun/expr/doc/doc.go
+++ b/cmd/bosun/expr/doc/doc.go
@@ -1,0 +1,38 @@
+package doc
+
+import (
+	"fmt"
+	"strings"
+
+	"bosun.org/models"
+)
+
+// Func contains the documentation for an expression function
+type Func struct {
+	Name        string
+	Description string
+	Arguments   Arguments
+	Return      models.FuncType
+}
+
+// Arguments is a slice of Arg objects
+type Arguments []Arg
+
+// Arg contains fields that document the arguments to a function
+type Arg struct {
+	Name string
+	Desc string
+	Type models.FuncType
+}
+
+func (a Arg) Signature() string {
+	return fmt.Sprintf("%v %v", a.Name, a.Type)
+}
+
+func (f Func) Signature() string {
+	args := make([]string, len(f.Arguments))
+	for i, arg := range f.Arguments {
+		args[i] = arg.Signature()
+	}
+	return fmt.Sprintf("%v(%v) %v", f.Name, strings.Join(args, ","), f.Return)
+}

--- a/cmd/bosun/expr/doc/doc.go
+++ b/cmd/bosun/expr/doc/doc.go
@@ -107,6 +107,7 @@ Argument Details:
 	{{ .ExtendedInfo.HTML }}
 {{ end }}
 {{ range $example := .Examples }}
+	<p>Example:</p>
 	{{ $example.HTML}}
 {{ end }}
 {{ if ne .CodeLink ""}}

--- a/cmd/bosun/expr/doc/doc.go
+++ b/cmd/bosun/expr/doc/doc.go
@@ -9,10 +9,10 @@ import (
 
 // Func contains the documentation for an expression function
 type Func struct {
-	Name        string
-	Description string
-	Arguments   Arguments
-	Return      models.FuncType
+	Name      string
+	Summary   string
+	Arguments Arguments
+	Return    models.FuncType
 }
 
 // Arguments is a slice of Arg objects
@@ -26,7 +26,7 @@ type Arg struct {
 }
 
 func (a Arg) Signature() string {
-	return fmt.Sprintf("%v %v", a.Name, a.Type)
+	return fmt.Sprintf("%v %v", a.Name, suffixSet(a.Type))
 }
 
 func (f Func) Signature() string {
@@ -34,5 +34,22 @@ func (f Func) Signature() string {
 	for i, arg := range f.Arguments {
 		args[i] = arg.Signature()
 	}
-	return fmt.Sprintf("%v(%v) %v", f.Name, strings.Join(args, ","), f.Return)
+	return fmt.Sprintf("%v(%v) %v", f.Name, strings.Join(args, ","), suffixSet(f.Return))
+}
+
+func (a Arguments) TypeSlice() []models.FuncType {
+	types := make([]models.FuncType, len(a))
+	for i, arg := range a {
+		types[i] = arg.Type
+	}
+	return types
+}
+
+// TODO Just change the String method on models.FuncType
+// Need to make sure all JS stuff (like grafanaplugin and this jscode) understands the change
+func suffixSet(t models.FuncType) string {
+	if strings.HasPrefix(t.String(), "series") || strings.HasPrefix(t.String(), "number") {
+		return fmt.Sprintf("%vSet", t.String())
+	}
+	return t.String()
 }

--- a/cmd/bosun/expr/elastic.go
+++ b/cmd/bosun/expr/elastic.go
@@ -36,7 +36,7 @@ func elasticTagQuery(args []parse.Node) (parse.Tags, error) {
 
 // ElasticFuncs are specific functions that query an elasticsearch instance.
 // They are only loaded when the elastic hosts are set in the config file
-var Elastic = map[string]parse.Func{
+var Elastic = parse.FuncMap {
 	// Funcs for querying elastic
 	"escount": {
 		Args:          []models.FuncType{models.TypeESIndexer, models.TypeString, models.TypeESQuery, models.TypeString, models.TypeString, models.TypeString},

--- a/cmd/bosun/expr/expr.go
+++ b/cmd/bosun/expr/expr.go
@@ -83,7 +83,7 @@ func (e *Expr) MarshalJSON() ([]byte, error) {
 }
 
 // New creates a new expression tree
-func New(expr string, funcs ...map[string]parse.Func) (*Expr, error) {
+func New(expr string, funcs ...parse.FuncMap) (*Expr, error) {
 	funcs = append(funcs, builtins)
 	t, err := parse.Parse(expr, funcs...)
 	if err != nil {

--- a/cmd/bosun/expr/expr.go
+++ b/cmd/bosun/expr/expr.go
@@ -84,7 +84,7 @@ func (e *Expr) MarshalJSON() ([]byte, error) {
 
 // New creates a new expression tree
 func New(expr string, funcs ...parse.FuncMap) (*Expr, error) {
-	funcs = append(funcs, builtins, reductionFuncs)
+	funcs = append(funcs, builtins, reductionFuncs, groupFuncs, timeFuncs, filterFuncs)
 	t, err := parse.Parse(expr, funcs...)
 	if err != nil {
 		return nil, err

--- a/cmd/bosun/expr/expr.go
+++ b/cmd/bosun/expr/expr.go
@@ -84,7 +84,7 @@ func (e *Expr) MarshalJSON() ([]byte, error) {
 
 // New creates a new expression tree
 func New(expr string, funcs ...parse.FuncMap) (*Expr, error) {
-	funcs = append(funcs, builtins)
+	funcs = append(funcs, builtins, reductionFuncs)
 	t, err := parse.Parse(expr, funcs...)
 	if err != nil {
 		return nil, err

--- a/cmd/bosun/expr/funcs.go
+++ b/cmd/bosun/expr/funcs.go
@@ -100,7 +100,7 @@ func tagRename(args []parse.Node) (parse.Tags, error) {
 	return tags, nil
 }
 
-var builtins = map[string]parse.Func{
+var builtins = parse.FuncMap{
 	// Reduction functions
 
 	"avg": {

--- a/cmd/bosun/expr/funcs.go
+++ b/cmd/bosun/expr/funcs.go
@@ -19,6 +19,12 @@ import (
 )
 
 func init() {
+	for _, v := range reductionFuncs {
+		err := v.Doc.SetCodeLink(v.F)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
 	docs := doc.Docs{
 		"reduction": reductionFuncs.DocSlice(),
 		"builtins":  builtins.DocSlice(),

--- a/cmd/bosun/expr/funcs.go
+++ b/cmd/bosun/expr/funcs.go
@@ -101,105 +101,6 @@ func tagRename(args []parse.Node) (parse.Tags, error) {
 }
 
 var builtins = parse.FuncMap{
-	// Reduction functions
-
-	"avg": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
-		Tags:   tagFirst,
-		F:      Avg,
-	},
-	"cCount": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
-		Tags:   tagFirst,
-		F:      CCount,
-	},
-	"dev": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
-		Tags:   tagFirst,
-		F:      Dev,
-	},
-	"diff": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
-		Tags:   tagFirst,
-		F:      Diff,
-	},
-	"first": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
-		Tags:   tagFirst,
-		F:      First,
-	},
-	"forecastlr": {
-		Args:   []models.FuncType{models.TypeSeriesSet, models.TypeNumberSet},
-		Return: models.TypeNumberSet,
-		Tags:   tagFirst,
-		F:      Forecast_lr,
-	},
-	"linelr": {
-		Args:   []models.FuncType{models.TypeSeriesSet, models.TypeString},
-		Return: models.TypeSeriesSet,
-		Tags:   tagFirst,
-		F:      Line_lr,
-	},
-	"last": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
-		Tags:   tagFirst,
-		F:      Last,
-	},
-	"len": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
-		Tags:   tagFirst,
-		F:      Length,
-	},
-	"max": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
-		Tags:   tagFirst,
-		F:      Max,
-	},
-	"median": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
-		Tags:   tagFirst,
-		F:      Median,
-	},
-	"min": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
-		Tags:   tagFirst,
-		F:      Min,
-	},
-	"percentile": {
-		Args:   []models.FuncType{models.TypeSeriesSet, models.TypeNumberSet},
-		Return: models.TypeNumberSet,
-		Tags:   tagFirst,
-		F:      Percentile,
-	},
-	"since": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
-		Tags:   tagFirst,
-		F:      Since,
-	},
-	"sum": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
-		Tags:   tagFirst,
-		F:      Sum,
-	},
-	"streak": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
-		Tags:   tagFirst,
-		F:      Streak,
-	},
-
 	// Group functions
 	"addtags": {
 		Args:   []models.FuncType{models.TypeSeriesSet, models.TypeString},
@@ -819,18 +720,7 @@ func match(f func(res *Results, series *Result, floats []float64) error, series 
 	return &res, nil
 }
 
-func reduce(e *State, T miniprofiler.Timer, series *Results, F func(Series, ...float64) float64, args ...*Results) (*Results, error) {
-	f := func(res *Results, s *Result, floats []float64) error {
-		t := s.Value.(Series)
-		if len(t) == 0 {
-			return nil
-		}
-		s.Value = Number(F(t, floats...))
-		res.Results = append(res.Results, s)
-		return nil
-	}
-	return match(f, series, args...)
-}
+
 
 func Abs(e *State, T miniprofiler.Timer, series *Results) *Results {
 	for _, s := range series.Results {
@@ -847,18 +737,9 @@ func diff(dps Series, args ...float64) float64 {
 	return last(dps) - first(dps)
 }
 
-func Avg(e *State, T miniprofiler.Timer, series *Results) (*Results, error) {
-	return reduce(e, T, series, avg)
-}
 
-// avg returns the mean of x.
-func avg(dps Series, args ...float64) (a float64) {
-	for _, v := range dps {
-		a += float64(v)
-	}
-	a /= float64(len(dps))
-	return
-}
+
+
 
 func CCount(e *State, T miniprofiler.Timer, series *Results) (*Results, error) {
 	return reduce(e, T, series, cCount)

--- a/cmd/bosun/expr/funcs.go
+++ b/cmd/bosun/expr/funcs.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"math"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -24,26 +23,23 @@ func init() {
 			log.Fatal(err)
 		}
 	}
-	docs := doc.Docs{
+	Docs = doc.Docs{
 		"reduction": reductionFuncs.DocSlice(),
 		"group":     groupFuncs.DocSlice(),
 		"time":      timeFuncs.DocSlice(),
 		"filter":    filterFuncs.DocSlice(),
 		"builtins":  builtins.DocSlice(),
 	}
-	b, err := docs.Wiki()
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println(b.String())
-	os.Exit(0)
-	// ds, err := json.Marshal(docs)
+	// b, err := Docs.Wiki()
 	// if err != nil {
 	// 	log.Fatal(err)
 	// }
-	// fmt.Println(string(ds))
+	// fmt.Println(b.String())
 	// os.Exit(0)
+
 }
+
+var Docs doc.Docs
 
 func tagQuery(args []parse.Node) (parse.Tags, error) {
 	n := args[0].(*parse.StringNode)
@@ -241,12 +237,6 @@ func Sort(e *State, T miniprofiler.Timer, series *Results, order string) (*Resul
 	return series, nil
 }
 
-
-
-
-
-
-
 func Merge(e *State, T miniprofiler.Timer, series ...*Results) (*Results, error) {
 	res := &Results{}
 	if len(series) == 0 {
@@ -317,8 +307,6 @@ func LeftJoin(e *State, T miniprofiler.Timer, keysCSV, columnsCSV string, rowDat
 		},
 	}, nil
 }
-
-
 
 func fromScalar(f float64) *Results {
 	return &Results{

--- a/cmd/bosun/expr/funcs.go
+++ b/cmd/bosun/expr/funcs.go
@@ -23,12 +23,18 @@ func init() {
 		"reduction": reductionFuncs.DocSlice(),
 		"builtins":  builtins.DocSlice(),
 	}
-	b, err := docs.WikiText()
+	b, err := docs.Wiki()
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Println(b.String())
+	fmt.Println(b.String())
 	os.Exit(0)
+	// ds, err := json.Marshal(docs)
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
+	// fmt.Println(string(ds))
+	// os.Exit(0)
 }
 
 func tagQuery(args []parse.Node) (parse.Tags, error) {
@@ -629,7 +635,7 @@ var shiftdoc = &doc.Func{
 		doc.Arg{
 			Name: "dur",
 			Type: models.TypeString,
-			Desc: `The amount of time to shift the time series forward by. It is a ([OpenTSDB duration string(http://opentsdb.net/docs/build/html/user_guide/query/dates.html)). This will be added as a tag to each item in the series. The tag key is "shift" and the value will be this argument.`,
+			Desc: `The amount of time to shift the time series forward by. It is a <a href="http://opentsdb.net/docs/build/html/user_guide/query/dates.html">OpenTSDB duration string</a>. This will be added as a tag to each item in the series. The tag key is "shift" and the value will be this argument.`,
 		},
 	},
 	Return: models.TypeNumberSet,

--- a/cmd/bosun/expr/funcs_fltr.go
+++ b/cmd/bosun/expr/funcs_fltr.go
@@ -1,0 +1,380 @@
+package expr
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"bosun.org/cmd/bosun/expr/doc"
+	"bosun.org/cmd/bosun/expr/parse"
+	"bosun.org/models"
+	"github.com/MiniProfiler/go/miniprofiler"
+)
+
+var filterFuncs = parse.FuncMap{
+	"crop": {
+		Args:   cropDoc.Arguments.TypeSlice(),
+		Return: cropDoc.Return,
+		Tags:   tagFirst,
+		F:      Crop,
+		Doc:    cropDoc,
+	},
+	"dropge": {
+		Args:   dropGeDoc.Arguments.TypeSlice(),
+		Return: dropGeDoc.Return,
+		Tags:   tagFirst,
+		F:      DropGe,
+		Doc:    dropGeDoc,
+	},
+	"dropg": {
+		Args:   dropGDoc.Arguments.TypeSlice(),
+		Return: dropGDoc.Return,
+		Tags:   tagFirst,
+		F:      DropG,
+		Doc:    dropGDoc,
+	},
+	"drople": {
+		Args:   dropLeDoc.Arguments.TypeSlice(),
+		Return: dropLeDoc.Return,
+		Tags:   tagFirst,
+		F:      DropLe,
+		Doc:    dropLeDoc,
+	},
+	"dropl": {
+		Args:   dropLDoc.Arguments.TypeSlice(),
+		Return: dropLDoc.Return,
+		Tags:   tagFirst,
+		F:      DropL,
+		Doc:    dropLDoc,
+	},
+	"dropna": {
+		Args:   dropNADoc.Arguments.TypeSlice(),
+		Return: dropNADoc.Return,
+		Tags:   tagFirst,
+		F:      DropNA,
+		Doc:    dropNADoc,
+	},
+	"dropbool": {
+		Args:   dropBoolDoc.Arguments.TypeSlice(),
+		Return: dropBoolDoc.Return,
+		Tags:   tagFirst,
+		F:      DropBool,
+		Doc:    dropBoolDoc,
+	},
+	"filter": {
+		Args:   filterDoc.Arguments.TypeSlice(),
+		Return: filterDoc.Return,
+		Tags:   tagFirst,
+		F:      Filter,
+		Doc:    filterDoc,
+	},
+	"limit": {
+		Args:   limitDoc.Arguments.TypeSlice(),
+		Return: limitDoc.Return,
+		Tags:   tagFirst,
+		F:      Limit,
+		Doc:    limitDoc,
+	},
+	"tail": {
+		Args:   tailDoc.Arguments.TypeSlice(),
+		Return: tailDoc.Return,
+		Tags:   tagFirst,
+		F:      Tail,
+		Doc:    tailDoc,
+	},
+}
+
+var cropDoc = &doc.Func{
+	Name:    "crop",
+	Summary: "Returns a seriesSet where each series is has datapoints removed if the datapoint is before start (from now, in seconds) or after end (also from now, in seconds). This is useful if you want to alert on different timespans for different items in a set.",
+	Arguments: doc.Arguments{
+		sSeriesSetArg,
+		doc.Arg{
+			Name: "start",
+			Type: models.TypeNumberSet,
+		},
+		doc.Arg{
+			Name: "end",
+			Type: models.TypeNumberSet,
+		},
+	},
+	Return:   models.TypeSeriesSet,
+	Examples: []doc.HTMLString{doc.HTMLString(cropExampleOne)},
+}
+
+func Crop(e *State, T miniprofiler.Timer, sSet *Results, startSet *Results, endSet *Results) (*Results, error) {
+	results := Results{}
+INNER:
+	for _, seriesResult := range sSet.Results {
+		for _, startResult := range startSet.Results {
+			for _, endResult := range endSet.Results {
+				startHasNoGroup := len(startResult.Group) == 0
+				endHasNoGroup := len(endResult.Group) == 0
+				startOverlapsSeries := seriesResult.Group.Overlaps(startResult.Group)
+				endOverlapsSeries := seriesResult.Group.Overlaps(endResult.Group)
+				if (startHasNoGroup || startOverlapsSeries) && (endHasNoGroup || endOverlapsSeries) {
+					res := crop(e, seriesResult, startResult, endResult)
+					results.Results = append(results.Results, res)
+					continue INNER
+				}
+			}
+		}
+	}
+	return &results, nil
+}
+
+func crop(e *State, seriesResult *Result, startResult *Result, endResult *Result) *Result {
+	startNumber := startResult.Value.(Number)
+	endNumber := endResult.Value.(Number)
+	start := e.now.Add(-time.Duration(time.Duration(startNumber) * time.Second))
+	end := e.now.Add(-time.Duration(time.Duration(endNumber) * time.Second))
+	series := seriesResult.Value.(Series)
+	for timeStamp := range series {
+		if timeStamp.Before(start) || timeStamp.After(end) {
+			delete(series, timeStamp)
+		}
+	}
+	return seriesResult
+}
+
+var dropArgs = doc.Arguments{
+	sSeriesSetArg,
+	doc.Arg{
+		Name: "threshold",
+		Type: models.TypeNumberSet,
+	},
+}
+
+func dropValues(e *State, T miniprofiler.Timer, series *Results, threshold *Results, dropFunction func(float64, float64) bool) (*Results, error) {
+	f := func(res *Results, s *Result, floats []float64) error {
+		nv := make(Series)
+		for k, v := range s.Value.Value().(Series) {
+			if !dropFunction(float64(v), floats[0]) {
+				//preserve values which should not be discarded
+				nv[k] = v
+			}
+		}
+		if len(nv) == 0 {
+			return fmt.Errorf("series %s is empty", s.Group)
+		}
+		s.Value = nv
+		res.Results = append(res.Results, s)
+		return nil
+	}
+	return match(f, series, threshold)
+}
+
+var dropGeDoc = &doc.Func{
+	Name:      "dropge",
+	Summary:   "dropge removes any values greater than or equal to threshold from each series in s. Will error if this operation results in an empty series.",
+	Arguments: dropArgs,
+	Return:    models.TypeSeriesSet,
+}
+
+func DropGe(e *State, T miniprofiler.Timer, series *Results, threshold *Results) (*Results, error) {
+	dropFunction := func(value float64, threshold float64) bool { return value >= threshold }
+	return dropValues(e, T, series, threshold, dropFunction)
+}
+
+var dropGDoc = &doc.Func{
+	Name:      "dropg",
+	Summary:   "dropg removes any values greater than threshold from each series in s. Will error if this operation results in an empty series.",
+	Arguments: dropArgs,
+	Return:    models.TypeSeriesSet,
+}
+
+func DropG(e *State, T miniprofiler.Timer, series *Results, threshold *Results) (*Results, error) {
+	dropFunction := func(value float64, threshold float64) bool { return value > threshold }
+	return dropValues(e, T, series, threshold, dropFunction)
+}
+
+var dropLeDoc = &doc.Func{
+	Name:      "drople",
+	Summary:   "drople removes any values less than or equal to threshold from each series in s. Will error if this operation results in an empty series.",
+	Arguments: dropArgs,
+	Return:    models.TypeSeriesSet,
+}
+
+func DropLe(e *State, T miniprofiler.Timer, series *Results, threshold *Results) (*Results, error) {
+	dropFunction := func(value float64, threshold float64) bool { return value <= threshold }
+	return dropValues(e, T, series, threshold, dropFunction)
+}
+
+var dropLDoc = &doc.Func{
+	Name:      "dropl",
+	Summary:   "dropl removes any values less than threshold from each series in s. Will error if this operation results in an empty series.",
+	Arguments: dropArgs,
+	Return:    models.TypeSeriesSet,
+}
+
+func DropL(e *State, T miniprofiler.Timer, series *Results, threshold *Results) (*Results, error) {
+	dropFunction := func(value float64, threshold float64) bool { return value < threshold }
+	return dropValues(e, T, series, threshold, dropFunction)
+}
+
+var dropNADoc = &doc.Func{
+	Name:      "dropna",
+	Summary:   "dropna removes any NaN or Inf values from each series in s. Will error if this operation results in an empty series.",
+	Arguments: doc.Arguments{sSeriesSetArg},
+	Return:    models.TypeSeriesSet,
+}
+
+func DropNA(e *State, T miniprofiler.Timer, series *Results) (*Results, error) {
+	dropFunction := func(value float64, threshold float64) bool {
+		return math.IsNaN(float64(value)) || math.IsInf(float64(value), 0)
+	}
+	return dropValues(e, T, series, fromScalar(0), dropFunction)
+}
+
+var dropBoolDoc = &doc.Func{
+	Name:    "dropbool",
+	Summary: "dropbool drops datapoints from s where the corresponding value in the condition set is non-zero. (See Series Operations for what corresponding means).",
+	Arguments: doc.Arguments{
+		sSeriesSetArg,
+		doc.Arg{
+			Name: "condition",
+			Type: models.TypeSeriesSet,
+		},
+	},
+	Return:   models.TypeSeriesSet,
+	Examples: []doc.HTMLString{doc.HTMLString(dropBoolExampleOne)},
+}
+
+func DropBool(e *State, T miniprofiler.Timer, target *Results, filter *Results) (*Results, error) {
+	res := Results{}
+	unions := e.union(target, filter, "dropbool union")
+	for _, union := range unions {
+		aSeries := union.A.Value().(Series)
+		bSeries := union.B.Value().(Series)
+		newSeries := make(Series)
+		for k, v := range aSeries {
+			if bv, ok := bSeries[k]; ok {
+				if bv != float64(0) {
+					newSeries[k] = v
+				}
+			}
+		}
+		if len(newSeries) > 0 {
+			res.Results = append(res.Results, &Result{Group: union.Group, Value: newSeries})
+		}
+	}
+	return &res, nil
+}
+
+var filterDoc = &doc.Func{
+	Name:    "filter",
+	Summary: "filter returns all results in s that are a subset of n and have a non-zero value. Useful with the limit and sort functions to return the top X results of a query.",
+	Arguments: doc.Arguments{
+		sSeriesSetArg,
+		nNumberSetArg,
+	},
+	Return: models.TypeSeriesSet,
+}
+
+func Filter(e *State, T miniprofiler.Timer, series *Results, number *Results) (*Results, error) {
+	var ns ResultSlice
+	for _, sr := range series.Results {
+		for _, nr := range number.Results {
+			if sr.Group.Subset(nr.Group) || nr.Group.Subset(sr.Group) {
+				if nr.Value.Value().(Number) != 0 {
+					ns = append(ns, sr)
+				}
+			}
+		}
+	}
+	series.Results = ns
+	return series, nil
+}
+
+var limitDoc = &doc.Func{
+	Name:    "limit",
+	Summary: "limit returns the first count results (set items) from s.",
+	Arguments: doc.Arguments{
+		sSeriesSetArg,
+		doc.Arg{
+			Name: "count",
+			Type: models.TypeScalar,
+		},
+	},
+	Return: models.TypeNumberSet,
+}
+
+func Limit(e *State, T miniprofiler.Timer, series *Results, v float64) (*Results, error) {
+	i := int(v)
+	if len(series.Results) > i {
+		series.Results = series.Results[:i]
+	}
+	return series, nil
+}
+
+var tailDoc = &doc.Func{
+	Name:    "tail",
+	Summary: "tail shortens the number of datapoints for each series in s to length n. If the series is shorter than the number of requested points the series is unchanged as all points are in the requested window.",
+	Arguments: doc.Arguments{
+		sSeriesSetArg,
+		nNumberSetArg,
+	},
+	Return: models.TypeSeriesSet,
+}
+
+func Tail(e *State, T miniprofiler.Timer, series *Results, number *Results) (*Results, error) {
+	f := func(res *Results, s *Result, floats []float64) error {
+		tailLength := int(floats[0])
+
+		// if there are fewer points than the requested tail
+		// short circut and just return current series
+		if len(s.Value.Value().(Series)) <= tailLength {
+			res.Results = append(res.Results, s)
+			return nil
+		}
+
+		// create new sorted series
+		// not going to do quick select
+		// see https://github.com/bosun-monitor/bosun/pull/1802
+		// for details
+		oldSr := s.Value.Value().(Series)
+		sorted := NewSortedSeries(oldSr)
+
+		// create new series keep a reference
+		// and point sr.Value interface at reference
+		// as we don't need old series any more
+		newSeries := make(Series)
+		s.Value = newSeries
+
+		// load up new series with desired
+		// number of points
+		// we already checked len so this is safe
+		for _, item := range sorted[len(sorted)-tailLength:] {
+			newSeries[item.T] = item.V
+		}
+		res.Results = append(res.Results, s)
+		return nil
+	}
+
+	return match(f, series, number)
+}
+
+var cropExampleOne = `<pre><code>lookup test {
+    entry host=ny-bosun01 {
+        start = 30
+    }
+    entry host=* {
+        start = 60
+    }
+}
+
+alert test {
+    template = test
+    $q = q("avg:rate:os.cpu{host=ny-bosun*}", "5m", "")
+    $c = crop($q, lookup("test", "start") , 0)
+    crit = avg($c)
+}
+</code></pre>`
+
+var dropBoolExampleOne = `<p>Drop tr_avg (avg response time per bucket) datapoints if the count in that bucket was + or - 100 from the average count over the time period.</p>
+<pre><code>
+$count = q("sum:traffic.haproxy.route_tr_count{host=literal_or(ny-logsql01),route=Questions/Show}", "30m", "")
+$avg = q("sum:traffic.haproxy.route_tr_avg{host=literal_or(ny-logsql01),route=Questions/Show}", "30m", "")
+$avgCount = avg($count)
+dropbool($avg, !($count < $avgCount-100 || $count > $avgCount+100))
+</code></pre>`

--- a/cmd/bosun/expr/funcs_grp.go
+++ b/cmd/bosun/expr/funcs_grp.go
@@ -1,0 +1,340 @@
+package expr
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"bosun.org/cmd/bosun/expr/doc"
+	"bosun.org/cmd/bosun/expr/parse"
+	"bosun.org/models"
+	"bosun.org/opentsdb"
+	"github.com/MiniProfiler/go/miniprofiler"
+)
+
+var groupFuncs = parse.FuncMap{
+	"addtags": {
+		Args:   addTagsDoc.Arguments.TypeSlice(),
+		Return: addTagsDoc.Return,
+		Tags:   tagRename,
+		F:      AddTags,
+		Doc:    addTagsDoc,
+	},
+	"remove": {
+		Args:   removeDoc.Arguments.TypeSlice(),
+		Return: removeDoc.Return,
+		Tags:   tagRemove,
+		F:      Remove,
+		Doc:    removeDoc,
+	},
+	"rename": {
+		Args:   renameDoc.Arguments.TypeSlice(),
+		Return: renameDoc.Return,
+		Tags:   tagRename,
+		F:      Rename,
+		Doc:    renameDoc,
+	},
+	"t": {
+		Args:   tDoc.Arguments.TypeSlice(),
+		Return: tDoc.Return,
+		Tags:   tagTranspose,
+		F:      Transpose,
+		Doc:    tDoc,
+	},
+	"ungroup": {
+		Args:   []models.FuncType{models.TypeNumberSet},
+		Return: models.TypeScalar,
+		F:      Ungroup,
+	},
+}
+
+var addTagsDoc = &doc.Func{
+	Name:    "addtags",
+	Summary: "addtags adds the tags specified in t to each series in s. This function will error if one of the tag keys specified in t is already in s.",
+	Arguments: doc.Arguments{
+		sSeriesSetArg,
+		doc.Arg{
+			Name: "t",
+			Desc: "tags to add in the format of <code>tagK=tagV,tagK=tagV</code>.",
+			Type: models.TypeString,
+		},
+	},
+	Return: models.TypeSeriesSet,
+}
+
+func AddTags(e *State, T miniprofiler.Timer, series *Results, s string) (*Results, error) {
+	if s == "" {
+		return series, nil
+	}
+	tagSetToAdd, err := opentsdb.ParseTags(s)
+	if err != nil {
+		return nil, err
+	}
+	for tagKey, tagValue := range tagSetToAdd {
+		for _, res := range series.Results {
+			if res.Group == nil {
+				res.Group = make(opentsdb.TagSet)
+			}
+			if _, ok := res.Group[tagKey]; ok {
+				return nil, fmt.Errorf("%s key already in group", tagKey)
+			}
+			res.Group[tagKey] = tagValue
+		}
+	}
+	return series, nil
+}
+
+func tagRemove(args []parse.Node) (parse.Tags, error) {
+	tags, err := tagFirst(args)
+	if err != nil {
+		return nil, err
+	}
+	key := args[1].(*parse.StringNode).Text
+	delete(tags, key)
+	return tags, nil
+}
+
+var removeDoc = &doc.Func{
+	Name:    "remove",
+	Summary: "remove removes the tag key specified in t for each series in s. This function will error if removing the tag key would result in duplicate items in set s or if the tag in t does not exist in s.",
+	Arguments: doc.Arguments{
+		sSeriesSetArg,
+		doc.Arg{
+			Name: "t",
+			Desc: "tagkey to remove from the set.",
+			Type: models.TypeString,
+		},
+	},
+	Return: models.TypeSeriesSet,
+}
+
+func Remove(e *State, T miniprofiler.Timer, seriesSet *Results, tagKey string) (*Results, error) {
+	seen := make(map[string]bool)
+	for _, r := range seriesSet.Results {
+		if _, ok := r.Group[tagKey]; ok {
+			delete(r.Group, tagKey)
+			if _, ok := seen[r.Group.String()]; ok {
+				return seriesSet, fmt.Errorf("duplicate group would result from removing tag key: %v", tagKey)
+			}
+			seen[r.Group.String()] = true
+		} else {
+			return seriesSet, fmt.Errorf("tag key %v not found in result", tagKey)
+		}
+	}
+	return seriesSet, nil
+}
+
+func tagRename(args []parse.Node) (parse.Tags, error) {
+	tags, err := tagFirst(args)
+	if err != nil {
+		return nil, err
+	}
+	for _, section := range strings.Split(args[1].(*parse.StringNode).Text, ",") {
+		kv := strings.Split(section, "=")
+		if len(kv) != 2 {
+			return nil, fmt.Errorf("error passing groups")
+		}
+		for oldTagKey := range tags {
+			if kv[0] == oldTagKey {
+				if _, ok := tags[kv[1]]; ok {
+					return nil, fmt.Errorf("%s already in group", kv[1])
+				}
+				delete(tags, kv[0])
+				tags[kv[1]] = struct{}{}
+			}
+		}
+	}
+	return tags, nil
+}
+
+var renameDoc = &doc.Func{
+	Name:    "rename",
+	Summary: "rename renames tag keys for each series in s based the the tags specificed in t. If the new tag key already exists the function will error. This can be useful for combining results from separate queries that have similar tagsets with different tag keys.",
+	Arguments: doc.Arguments{
+		sSeriesSetArg,
+		doc.Arg{
+			Name: "t",
+			Desc: "tag keys to rename in the format of <code>tagK1=newTagKey,tagK2=newTagKey2</code>. These are processed in the order listed so tags can be swapped.",
+			Type: models.TypeString,
+		},
+	},
+	Return: models.TypeSeriesSet,
+	// TODO: Add an example of tag "swapping" since this is a bit hard to describe.
+}
+
+func Rename(e *State, T miniprofiler.Timer, series *Results, s string) (*Results, error) {
+	for _, section := range strings.Split(s, ",") {
+		kv := strings.Split(section, "=")
+		if len(kv) != 2 {
+			return nil, fmt.Errorf("error passing groups")
+		}
+		oldKey, newKey := kv[0], kv[1]
+		for _, res := range series.Results {
+			for tag, v := range res.Group {
+				if oldKey == tag {
+					if _, ok := res.Group[newKey]; ok {
+						return nil, fmt.Errorf("%s already in group", newKey)
+					}
+					delete(res.Group, oldKey)
+					res.Group[newKey] = v
+				}
+
+			}
+		}
+	}
+	return series, nil
+}
+
+func tagTranspose(args []parse.Node) (parse.Tags, error) {
+	tags := make(parse.Tags)
+	sp := strings.Split(args[1].(*parse.StringNode).Text, ",")
+	if sp[0] != "" {
+		for _, t := range sp {
+			tags[t] = struct{}{}
+		}
+	}
+	if atags, err := args[0].Tags(); err != nil {
+		return nil, err
+	} else if !tags.Subset(atags) {
+		return nil, fmt.Errorf("transpose tags (%v) must be a subset of first argument's tags (%v)", tags, atags)
+	}
+	return tags, nil
+}
+
+var tDoc = &doc.Func{
+	Name:    "t",
+	Summary: "TODO ... something better than what exists, it is confusing as all hell.",
+	Arguments: doc.Arguments{
+		nNumberSetArg,
+		doc.Arg{
+			Name: "tagKeys",
+			Desc: "a csv of tag keys that will be the keys of the resulting seriesSet. The keys must be part of n. This can also be an empty string.",
+			Type: models.TypeString,
+		},
+	},
+	Return:       models.TypeSeriesSet,
+	ExtendedInfo: doc.HTMLString(tExtendedInfo),
+}
+
+func Transpose(e *State, T miniprofiler.Timer, d *Results, gp string) (*Results, error) {
+	gps := strings.Split(gp, ",")
+	m := make(map[string]*Result)
+	for _, v := range d.Results {
+		ts := make(opentsdb.TagSet)
+		for k, v := range v.Group {
+			for _, b := range gps {
+				if k == b {
+					ts[k] = v
+				}
+			}
+		}
+		if _, ok := m[ts.String()]; !ok {
+			m[ts.String()] = &Result{
+				Group: ts,
+				Value: make(Series),
+			}
+		}
+		switch t := v.Value.(type) {
+		case Number:
+			r := m[ts.String()]
+			i := int64(len(r.Value.(Series)))
+			r.Value.(Series)[time.Unix(i, 0).UTC()] = float64(t)
+			r.Computations = append(r.Computations, v.Computations...)
+		default:
+			panic(fmt.Errorf("expr: expected a number"))
+		}
+	}
+	var r Results
+	for _, res := range m {
+		r.Results = append(r.Results, res)
+	}
+	return &r, nil
+}
+
+var tExtendedInfo = `<p>How transpose works conceptually</p>
+
+<p>Transpose Grouped results into a Single Result</p>
+
+<p>Before Transpose (Value Type is NumberSet):</p>
+<table class="table">
+    <thead>
+        <tr>
+            <th>Group</th>
+            <th>Value</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>{host=web01}</td>
+            <td>1</td>
+        </tr>
+        <tr>
+            <td>{host=web02}</td>
+            <td>7</td>
+        </tr>
+        <tr>
+            <td>{host=web03}</td>
+            <td>4</td>
+        </tr>
+    </tbody>
+</table>
+
+<p>After Transpose (Value Type is SeriesSet):</p>
+<table class="table">
+    <thead>
+        <tr>
+            <th>Group</th>
+            <th>Value</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>{}</td>
+            <td>1,7,4</td>
+        </tr>
+    </tbody>
+</table>
+<p>Transpose Groups results into Multiple Results:</p>
+<p>Before Transpose by host (Value Type is NumberSet)</p>
+<table class="table">
+    <thead>
+        <tr>
+            <th>Group</th>
+            <th>Value</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>{host=web01,disk=c}</td>
+            <td>1</td>
+        </tr>
+        <tr>
+            <td>{host=web01,disc=d}</td>
+            <td>3</td>
+        </tr>
+        <tr>
+            <td>{host=web02,disc=c}</td>
+            <td>4</td>
+        </tr>
+    </tbody>
+</table>
+<p>After Transpose by “host” (Value type is SeriesSet)</p>
+<table class="table">
+    <thead>
+        <tr>
+            <th>Group</th>
+            <th>Value</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>{host=web01}</td>
+            <td>1,3</td>
+        </tr>
+        <tr>
+            <td>{host=web02}</td>
+            <td>4</td>
+        </tr>
+    </tbody>
+</table>
+`

--- a/cmd/bosun/expr/funcs_red.go
+++ b/cmd/bosun/expr/funcs_red.go
@@ -1,19 +1,11 @@
 package expr
 
 import (
-	"fmt"
-	"os"
-
 	"bosun.org/cmd/bosun/expr/doc"
 	"bosun.org/cmd/bosun/expr/parse"
 	"bosun.org/models"
 	"github.com/MiniProfiler/go/miniprofiler"
 )
-
-func init() {
-	fmt.Println(reductionFuncs["avg"].Doc.Signature())
-	os.Exit(0)
-}
 
 // Reduction functions
 var reductionFuncs = parse.FuncMap{

--- a/cmd/bosun/expr/funcs_red.go
+++ b/cmd/bosun/expr/funcs_red.go
@@ -1,110 +1,123 @@
 package expr
 
 import (
+	"math"
+	"sort"
+	"time"
+
 	"bosun.org/cmd/bosun/expr/doc"
 	"bosun.org/cmd/bosun/expr/parse"
 	"bosun.org/models"
+	"github.com/GaryBoone/GoStats/stats"
 	"github.com/MiniProfiler/go/miniprofiler"
 )
 
 // Reduction functions
 var reductionFuncs = parse.FuncMap{
 	"avg": {
-		Args:   avgdoc.Arguments.TypeSlice(),
-		Return: avgdoc.Return,
+		Args:   avgDoc.Arguments.TypeSlice(),
+		Return: avgDoc.Return,
 		Tags:   tagFirst,
 		F:      Avg,
-		Doc:    avgdoc,
+		Doc:    avgDoc,
 	},
 	"cCount": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
+		Args:   cCountDoc.Arguments.TypeSlice(),
+		Return: cCountDoc.Return,
 		Tags:   tagFirst,
 		F:      CCount,
+		Doc:    cCountDoc,
 	},
 	"dev": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
+		Args:   devDoc.Arguments.TypeSlice(),
+		Return: devDoc.Return,
 		Tags:   tagFirst,
 		F:      Dev,
+		Doc:    devDoc,
 	},
 	"diff": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
+		Args:   diffDoc.Arguments.TypeSlice(),
+		Return: diffDoc.Return,
 		Tags:   tagFirst,
 		F:      Diff,
+		Doc:    diffDoc,
 	},
 	"first": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
+		Args:   firstDoc.Arguments.TypeSlice(),
+		Return: firstDoc.Return,
 		Tags:   tagFirst,
 		F:      First,
+		Doc:    firstDoc,
 	},
 	"forecastlr": {
-		Args:   []models.FuncType{models.TypeSeriesSet, models.TypeNumberSet},
-		Return: models.TypeNumberSet,
+		Args:   forecastlrDoc.Arguments.TypeSlice(),
+		Return: forecastlrDoc.Return,
 		Tags:   tagFirst,
 		F:      Forecast_lr,
-	},
-	"linelr": {
-		Args:   []models.FuncType{models.TypeSeriesSet, models.TypeString},
-		Return: models.TypeSeriesSet,
-		Tags:   tagFirst,
-		F:      Line_lr,
+		Doc:    forecastlrDoc,
 	},
 	"last": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
+		Args:   lastDoc.Arguments.TypeSlice(),
+		Return: lastDoc.Return,
 		Tags:   tagFirst,
 		F:      Last,
+		Doc:    lastDoc,
 	},
 	"len": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
+		Args:   lenDoc.Arguments.TypeSlice(),
+		Return: lenDoc.Return,
 		Tags:   tagFirst,
 		F:      Length,
+		Doc:    lenDoc,
 	},
 	"max": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
+		Args:   maxDoc.Arguments.TypeSlice(),
+		Return: maxDoc.Return,
 		Tags:   tagFirst,
 		F:      Max,
+		Doc:    maxDoc,
 	},
 	"median": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
+		Args:   medianDoc.Arguments.TypeSlice(),
+		Return: medianDoc.Return,
 		Tags:   tagFirst,
 		F:      Median,
+		Doc:    medianDoc,
 	},
 	"min": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
+		Args:   minDoc.Arguments.TypeSlice(),
+		Return: minDoc.Return,
 		Tags:   tagFirst,
 		F:      Min,
+		Doc:    minDoc,
 	},
 	"percentile": {
-		Args:   []models.FuncType{models.TypeSeriesSet, models.TypeNumberSet},
-		Return: models.TypeNumberSet,
+		Args:   percentileDoc.Arguments.TypeSlice(),
+		Return: percentileDoc.Return,
 		Tags:   tagFirst,
 		F:      Percentile,
+		Doc:    percentileDoc,
 	},
 	"since": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
+		Args:   sinceDoc.Arguments.TypeSlice(),
+		Return: sinceDoc.Return,
 		Tags:   tagFirst,
 		F:      Since,
+		Doc:    sinceDoc,
 	},
 	"sum": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
+		Args:   sumDoc.Arguments.TypeSlice(),
+		Return: sumDoc.Return,
 		Tags:   tagFirst,
 		F:      Sum,
+		Doc:    sumDoc,
 	},
 	"streak": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeNumberSet,
+		Args:   streakDoc.Arguments.TypeSlice(),
+		Return: streakDoc.Return,
 		Tags:   tagFirst,
 		F:      Streak,
+		Doc:    streakDoc,
 	},
 }
 
@@ -121,9 +134,9 @@ func reduce(e *State, T miniprofiler.Timer, series *Results, F func(Series, ...f
 	return match(f, series, args...)
 }
 
-var avgdoc = &doc.Func{
+var avgDoc = &doc.Func{
 	Name:    "avg",
-	Summary: "Returns the arithmetic mean for each series in set s.",
+	Summary: "avg returns the arithmetic mean for each series in set s.",
 	Arguments: doc.Arguments{
 		doc.Arg{
 			Name: "s",
@@ -144,4 +157,324 @@ func avg(dps Series, args ...float64) (a float64) {
 	}
 	a /= float64(len(dps))
 	return
+}
+
+var cCountDoc = &doc.Func{
+	Name:      "cCount",
+	Summary:   "cCount returns the change count for each series in the set s. The change count is the number of times in the series a value was not equal to the immediate previous value. Useful for checking if things that should be at a steady value are “flapping”. For example, a series with values [0, 1, 0, 1] would return 3.",
+	Arguments: doc.Arguments{sSeriesSetArg},
+	Return:    models.TypeNumberSet,
+}
+
+func CCount(e *State, T miniprofiler.Timer, series *Results) (*Results, error) {
+	return reduce(e, T, series, cCount)
+}
+
+func cCount(dps Series, args ...float64) (a float64) {
+	if len(dps) < 2 {
+		return float64(0)
+	}
+	series := NewSortedSeries(dps)
+	count := 0
+	last := series[0].V
+	for _, p := range series[1:] {
+		if p.V != last {
+			count++
+		}
+		last = p.V
+	}
+	return float64(count)
+}
+
+var devDoc = &doc.Func{
+	Name:      "dev",
+	Summary:   "dev returns the standard deviation for each series in set s.",
+	Arguments: doc.Arguments{sSeriesSetArg},
+	Return:    models.TypeNumberSet,
+}
+
+func Dev(e *State, T miniprofiler.Timer, series *Results) (*Results, error) {
+	return reduce(e, T, series, dev)
+}
+
+// dev returns the sample standard deviation of x.
+func dev(dps Series, args ...float64) (d float64) {
+	if len(dps) == 1 {
+		return 0
+	}
+	a := avg(dps)
+	for _, v := range dps {
+		d += math.Pow(float64(v)-a, 2)
+	}
+	d /= float64(len(dps) - 1)
+	return math.Sqrt(d)
+}
+
+var diffDoc = &doc.Func{
+	Name:      "diff",
+	Summary:   "diff returns the last value minus the first value for each series in set s.",
+	Arguments: doc.Arguments{sSeriesSetArg},
+	Return:    models.TypeNumberSet,
+}
+
+func Diff(e *State, T miniprofiler.Timer, series *Results) (r *Results, err error) {
+	return reduce(e, T, series, diff)
+}
+
+func diff(dps Series, args ...float64) float64 {
+	return last(dps) - first(dps)
+}
+
+var firstDoc = &doc.Func{
+	Name:      "first",
+	Summary:   "first returns the first value (oldest) for each series in set s.",
+	Arguments: doc.Arguments{sSeriesSetArg},
+	Return:    models.TypeNumberSet,
+}
+
+func First(e *State, T miniprofiler.Timer, series *Results) (*Results, error) {
+	return reduce(e, T, series, first)
+}
+
+func first(dps Series, args ...float64) (a float64) {
+	var first time.Time
+	for k, v := range dps {
+		if k.Before(first) || first.IsZero() {
+			a = v
+			first = k
+		}
+	}
+	return
+}
+
+func Forecast_lr(e *State, T miniprofiler.Timer, series *Results, y *Results) (r *Results, err error) {
+	return reduce(e, T, series, e.forecast_lr, y)
+}
+
+var forecastlrDoc = &doc.Func{
+	Name:    "forecastlr",
+	Summary: "forecastlr returns the number of seconds until a linear regression of each series in set s will reach y_val.",
+	Arguments: doc.Arguments{sSeriesSetArg, doc.Arg{
+		Name: "y_val",
+		Type: models.TypeNumberSet,
+	}},
+	Return: models.TypeNumberSet,
+}
+
+// forecast_lr returns the number of seconds a linear regression predicts the
+// series will take to reach y_val.
+func (e *State) forecast_lr(dps Series, args ...float64) float64 {
+	const tenYears = time.Hour * 24 * 365 * 10
+	yVal := args[0]
+	var x []float64
+	var y []float64
+	for k, v := range dps {
+		x = append(x, float64(k.Unix()))
+		y = append(y, v)
+	}
+	var slope, intercept, _, _, _, _ = stats.LinearRegression(x, y)
+	it := (yVal - intercept) / slope
+	var i64 int64
+	if it < math.MinInt64 {
+		i64 = math.MinInt64
+	} else if it > math.MaxInt64 {
+		i64 = math.MaxInt64
+	} else if math.IsNaN(it) {
+		i64 = e.now.Unix()
+	} else {
+		i64 = int64(it)
+	}
+	t := time.Unix(i64, 0)
+	s := -e.now.Sub(t)
+	if s < -tenYears {
+		s = -tenYears
+	} else if s > tenYears {
+		s = tenYears
+	}
+	return s.Seconds()
+}
+
+var lastDoc = &doc.Func{
+	Name:      "last",
+	Summary:   "last returns the last value (newest) for each series in set s.",
+	Arguments: doc.Arguments{sSeriesSetArg},
+	Return:    models.TypeNumberSet,
+}
+
+func Last(e *State, T miniprofiler.Timer, series *Results) (*Results, error) {
+	return reduce(e, T, series, last)
+}
+
+func last(dps Series, args ...float64) (a float64) {
+	var last time.Time
+	for k, v := range dps {
+		if k.After(last) {
+			a = v
+			last = k
+		}
+	}
+	return
+}
+
+var lenDoc = &doc.Func{
+	Name:      "len",
+	Summary:   "len returns the the number of values (length) for each series in set s.",
+	Arguments: doc.Arguments{sSeriesSetArg},
+	Return:    models.TypeNumberSet,
+}
+
+func Length(e *State, T miniprofiler.Timer, series *Results) (*Results, error) {
+	return reduce(e, T, series, length)
+}
+
+func length(dps Series, args ...float64) (a float64) {
+	return float64(len(dps))
+}
+
+var maxDoc = &doc.Func{
+	Name:      "max",
+	Summary:   "max returns the the max value of each series in set s. It is the same as calling <code>percentile(s, 1)</code>.",
+	Arguments: doc.Arguments{sSeriesSetArg},
+	Return:    models.TypeNumberSet,
+}
+
+func Max(e *State, T miniprofiler.Timer, series *Results) (r *Results, err error) {
+	return reduce(e, T, series, percentile, fromScalar(1))
+}
+
+var medianDoc = &doc.Func{
+	Name:      "median",
+	Summary:   "median returns the median value of each series in set s. It is the same as calling <code>percentile(s, .5)</code>.",
+	Arguments: doc.Arguments{sSeriesSetArg},
+	Return:    models.TypeNumberSet,
+}
+
+func Median(e *State, T miniprofiler.Timer, series *Results) (r *Results, err error) {
+	return reduce(e, T, series, percentile, fromScalar(.5))
+}
+
+var minDoc = &doc.Func{
+	Name:      "min",
+	Summary:   "min returns the minimum value of each series in set s. It is the same as calling <code>percentile(s, 0)</code>.",
+	Arguments: doc.Arguments{sSeriesSetArg},
+	Return:    models.TypeNumberSet,
+}
+
+func Min(e *State, T miniprofiler.Timer, series *Results) (r *Results, err error) {
+	return reduce(e, T, series, percentile, fromScalar(0))
+}
+
+var percentileDoc = &doc.Func{
+	Name:    "percentile",
+	Summary: "percentile returns the value at percentile p of each series at in set s. min and max can be simulated using p <= 0 and p >= 1, respectively.",
+	Arguments: doc.Arguments{sSeriesSetArg, doc.Arg{
+		Name: "p",
+		Type: models.TypeNumberSet,
+	}},
+	Return: models.TypeNumberSet,
+}
+
+func Percentile(e *State, T miniprofiler.Timer, series *Results, p *Results) (r *Results, err error) {
+	return reduce(e, T, series, percentile, p)
+}
+
+// percentile returns the value at the corresponding percentile between 0 and 1.
+// Min and Max can be simulated using p <= 0 and p >= 1, respectively.
+func percentile(dps Series, args ...float64) (a float64) {
+	p := args[0]
+	var x []float64
+	for _, v := range dps {
+		x = append(x, float64(v))
+	}
+	sort.Float64s(x)
+	if p <= 0 {
+		return x[0]
+	}
+	if p >= 1 {
+		return x[len(x)-1]
+	}
+	i := p * float64(len(x)-1)
+	i = math.Ceil(i)
+	return x[int(i)]
+}
+
+var sinceDoc = &doc.Func{
+	Name:      "since",
+	Summary:   "since returns the number of seconds since the most recent datapoint of each series in set s.",
+	Arguments: doc.Arguments{sSeriesSetArg},
+	Return:    models.TypeNumberSet,
+}
+
+func Since(e *State, T miniprofiler.Timer, series *Results) (*Results, error) {
+	return reduce(e, T, series, e.since)
+}
+
+func (e *State) since(dps Series, args ...float64) (a float64) {
+	var last time.Time
+	for k, v := range dps {
+		if k.After(last) {
+			a = v
+			last = k
+		}
+	}
+	s := e.now.Sub(last)
+	return s.Seconds()
+}
+
+var streakDoc = &doc.Func{
+	Name:      "streak",
+	Summary:   "streak returns the length of the longest streak of values that evaluate to true (i.e. max amount of contiguous non-zero values found) for each series in set s.",
+	Arguments: doc.Arguments{sSeriesSetArg},
+	Return:    models.TypeNumberSet,
+}
+
+func Streak(e *State, T miniprofiler.Timer, series *Results) (*Results, error) {
+	return reduce(e, T, series, streak)
+}
+
+func streak(dps Series, args ...float64) (a float64) {
+	max := func(a, b int) int {
+		if a > b {
+			return a
+		}
+		return b
+	}
+
+	series := NewSortedSeries(dps)
+
+	current := 0
+	longest := 0
+	for _, p := range series {
+		if p.V != 0 {
+			current++
+		} else {
+			longest = max(current, longest)
+			current = 0
+		}
+	}
+	longest = max(current, longest)
+	return float64(longest)
+}
+
+var sumDoc = &doc.Func{
+	Name:      "sum",
+	Summary:   "sum returns the sum of values for each series in set s.",
+	Arguments: doc.Arguments{sSeriesSetArg},
+	Return:    models.TypeNumberSet,
+}
+
+func Sum(e *State, T miniprofiler.Timer, series *Results) (*Results, error) {
+	return reduce(e, T, series, sum)
+}
+
+func sum(dps Series, args ...float64) (a float64) {
+	for _, v := range dps {
+		a += float64(v)
+	}
+	return
+}
+
+var sSeriesSetArg = doc.Arg{
+	Name: "s",
+	Type: models.TypeSeriesSet,
 }

--- a/cmd/bosun/expr/funcs_red.go
+++ b/cmd/bosun/expr/funcs_red.go
@@ -1,0 +1,155 @@
+package expr
+
+import (
+	"fmt"
+	"os"
+
+	"bosun.org/cmd/bosun/expr/doc"
+	"bosun.org/cmd/bosun/expr/parse"
+	"bosun.org/models"
+	"github.com/MiniProfiler/go/miniprofiler"
+)
+
+func init() {
+	fmt.Println(reductionFuncs["avg"].Doc.Signature())
+	os.Exit(0)
+}
+
+// Reduction functions
+var reductionFuncs = parse.FuncMap{
+	"avg": {
+		Args:   avgdoc.Arguments.TypeSlice(),
+		Return: avgdoc.Return,
+		Tags:   tagFirst,
+		F:      Avg,
+		Doc:    avgdoc,
+	},
+	"cCount": {
+		Args:   []models.FuncType{models.TypeSeriesSet},
+		Return: models.TypeNumberSet,
+		Tags:   tagFirst,
+		F:      CCount,
+	},
+	"dev": {
+		Args:   []models.FuncType{models.TypeSeriesSet},
+		Return: models.TypeNumberSet,
+		Tags:   tagFirst,
+		F:      Dev,
+	},
+	"diff": {
+		Args:   []models.FuncType{models.TypeSeriesSet},
+		Return: models.TypeNumberSet,
+		Tags:   tagFirst,
+		F:      Diff,
+	},
+	"first": {
+		Args:   []models.FuncType{models.TypeSeriesSet},
+		Return: models.TypeNumberSet,
+		Tags:   tagFirst,
+		F:      First,
+	},
+	"forecastlr": {
+		Args:   []models.FuncType{models.TypeSeriesSet, models.TypeNumberSet},
+		Return: models.TypeNumberSet,
+		Tags:   tagFirst,
+		F:      Forecast_lr,
+	},
+	"linelr": {
+		Args:   []models.FuncType{models.TypeSeriesSet, models.TypeString},
+		Return: models.TypeSeriesSet,
+		Tags:   tagFirst,
+		F:      Line_lr,
+	},
+	"last": {
+		Args:   []models.FuncType{models.TypeSeriesSet},
+		Return: models.TypeNumberSet,
+		Tags:   tagFirst,
+		F:      Last,
+	},
+	"len": {
+		Args:   []models.FuncType{models.TypeSeriesSet},
+		Return: models.TypeNumberSet,
+		Tags:   tagFirst,
+		F:      Length,
+	},
+	"max": {
+		Args:   []models.FuncType{models.TypeSeriesSet},
+		Return: models.TypeNumberSet,
+		Tags:   tagFirst,
+		F:      Max,
+	},
+	"median": {
+		Args:   []models.FuncType{models.TypeSeriesSet},
+		Return: models.TypeNumberSet,
+		Tags:   tagFirst,
+		F:      Median,
+	},
+	"min": {
+		Args:   []models.FuncType{models.TypeSeriesSet},
+		Return: models.TypeNumberSet,
+		Tags:   tagFirst,
+		F:      Min,
+	},
+	"percentile": {
+		Args:   []models.FuncType{models.TypeSeriesSet, models.TypeNumberSet},
+		Return: models.TypeNumberSet,
+		Tags:   tagFirst,
+		F:      Percentile,
+	},
+	"since": {
+		Args:   []models.FuncType{models.TypeSeriesSet},
+		Return: models.TypeNumberSet,
+		Tags:   tagFirst,
+		F:      Since,
+	},
+	"sum": {
+		Args:   []models.FuncType{models.TypeSeriesSet},
+		Return: models.TypeNumberSet,
+		Tags:   tagFirst,
+		F:      Sum,
+	},
+	"streak": {
+		Args:   []models.FuncType{models.TypeSeriesSet},
+		Return: models.TypeNumberSet,
+		Tags:   tagFirst,
+		F:      Streak,
+	},
+}
+
+func reduce(e *State, T miniprofiler.Timer, series *Results, F func(Series, ...float64) float64, args ...*Results) (*Results, error) {
+	f := func(res *Results, s *Result, floats []float64) error {
+		t := s.Value.(Series)
+		if len(t) == 0 {
+			return nil
+		}
+		s.Value = Number(F(t, floats...))
+		res.Results = append(res.Results, s)
+		return nil
+	}
+	return match(f, series, args...)
+}
+
+var avgdoc = &doc.Func{
+	Name:    "avg",
+	Summary: "Returns the arithmetic mean for each series in set s.",
+	Arguments: doc.Arguments{
+		doc.Arg{
+			Name: "s",
+			Type: models.TypeSeriesSet,
+		},
+	},
+	Return: models.TypeNumberSet,
+}
+
+func Avg(e *State, T miniprofiler.Timer, series *Results) (*Results, error) {
+	return reduce(e, T, series, avg)
+}
+
+// avg returns the mean of x.
+func avg(dps Series, args ...float64) (a float64) {
+	for _, v := range dps {
+		a += float64(v)
+	}
+	a /= float64(len(dps))
+	return
+}

--- a/cmd/bosun/expr/funcs_red.go
+++ b/cmd/bosun/expr/funcs_red.go
@@ -474,7 +474,3 @@ func sum(dps Series, args ...float64) (a float64) {
 	return
 }
 
-var sSeriesSetArg = doc.Arg{
-	Name: "s",
-	Type: models.TypeSeriesSet,
-}

--- a/cmd/bosun/expr/funcs_time.go
+++ b/cmd/bosun/expr/funcs_time.go
@@ -1,0 +1,105 @@
+package expr
+
+import (
+	"time"
+
+	"bosun.org/cmd/bosun/expr/doc"
+	"bosun.org/cmd/bosun/expr/parse"
+	"bosun.org/models"
+	"bosun.org/opentsdb"
+	"github.com/MiniProfiler/go/miniprofiler"
+)
+
+var timeFuncs = parse.FuncMap{
+	"d": {
+		Args:   dDoc.Arguments.TypeSlice(),
+		Return: dDoc.Return,
+		F:      Duration,
+		Doc:    dDoc,
+	},
+	"epoch": {
+		Args:   []models.FuncType{},
+		Return: models.TypeScalar,
+		F:      Epoch,
+	},
+	"month": {
+		Args:   []models.FuncType{models.TypeScalar, models.TypeString},
+		Return: models.TypeScalar,
+		F:      Month,
+	},
+	"shift": {
+		Args:   []models.FuncType{models.TypeSeriesSet, models.TypeString},
+		Return: models.TypeSeriesSet,
+		Tags:   tagFirst,
+		F:      Shift,
+		Doc:    shiftdoc,
+	},
+	"timedelta": {
+		Args:   []models.FuncType{models.TypeSeriesSet},
+		Return: models.TypeSeriesSet,
+		Tags:   tagFirst,
+		F:      TimeDelta,
+	},
+	"tod": {
+		Args:   []models.FuncType{models.TypeScalar},
+		Return: models.TypeString,
+		F:      ToDuration,
+	},
+}
+
+var dDoc = &doc.Func{
+	Name:    "d",
+	Summary: `d Returns the number of seconds of the <a href="http://opentsdb.net/docs/build/html/user_guide/query/dates.html">OpenTSDB duration string</a> s.`,
+	Arguments: doc.Arguments{
+		doc.Arg{
+			Name: "s",
+			Type: models.TypeString,
+		},
+	},
+	Return: models.TypeScalar,
+}
+
+func Duration(e *State, T miniprofiler.Timer, d string) (*Results, error) {
+	duration, err := opentsdb.ParseDuration(d)
+	if err != nil {
+		return nil, err
+	}
+	return &Results{
+		Results: []*Result{
+			{Value: Scalar(duration.Seconds())},
+		},
+	}, nil
+}
+
+var shiftdoc = &doc.Func{
+	Name:    "shift",
+	Summary: `Shift changes the timestamp of each datapoint in s to be the specified duration in the future. It also adds a tag representing the shift duration. This is meant so you can overlay times visually in a graph.`,
+	Arguments: doc.Arguments{
+		doc.Arg{
+			Name: "s",
+			Type: models.TypeSeriesSet,
+		},
+		doc.Arg{
+			Name: "dur",
+			Type: models.TypeString,
+			Desc: `The amount of time to shift the time series forward by. It is a <a href="http://opentsdb.net/docs/build/html/user_guide/query/dates.html">OpenTSDB duration string</a>. This will be added as a tag to each item in the series. The tag key is "shift" and the value will be this argument.`,
+		},
+	},
+	Return: models.TypeNumberSet,
+}
+
+func Shift(e *State, T miniprofiler.Timer, series *Results, d string) (*Results, error) {
+	dur, err := opentsdb.ParseDuration(d)
+	if err != nil {
+		return series, err
+	}
+	for _, result := range series.Results {
+		newSeries := make(Series)
+		for t, v := range result.Value.Value().(Series) {
+			newSeries[t.Add(time.Duration(dur))] = v
+		}
+		result.Group["shift"] = d
+		result.Value = newSeries
+	}
+	return series, nil
+}

--- a/cmd/bosun/expr/funcs_time.go
+++ b/cmd/bosun/expr/funcs_time.go
@@ -1,6 +1,7 @@
 package expr
 
 import (
+	"fmt"
 	"time"
 
 	"bosun.org/cmd/bosun/expr/doc"
@@ -8,6 +9,7 @@ import (
 	"bosun.org/models"
 	"bosun.org/opentsdb"
 	"github.com/MiniProfiler/go/miniprofiler"
+	"github.com/jinzhu/now"
 )
 
 var timeFuncs = parse.FuncMap{
@@ -18,38 +20,42 @@ var timeFuncs = parse.FuncMap{
 		Doc:    dDoc,
 	},
 	"epoch": {
-		Args:   []models.FuncType{},
-		Return: models.TypeScalar,
+		Args:   epochDoc.Arguments.TypeSlice(),
+		Return: epochDoc.Return,
 		F:      Epoch,
+		Doc:    epochDoc,
 	},
 	"month": {
-		Args:   []models.FuncType{models.TypeScalar, models.TypeString},
-		Return: models.TypeScalar,
+		Args:   monthDoc.Arguments.TypeSlice(),
+		Return: monthDoc.Return,
 		F:      Month,
+		Doc:    monthDoc,
 	},
 	"shift": {
-		Args:   []models.FuncType{models.TypeSeriesSet, models.TypeString},
-		Return: models.TypeSeriesSet,
+		Args:   shiftDoc.Arguments.TypeSlice(),
+		Return: shiftDoc.Return,
 		Tags:   tagFirst,
 		F:      Shift,
-		Doc:    shiftdoc,
+		Doc:    shiftDoc,
 	},
 	"timedelta": {
-		Args:   []models.FuncType{models.TypeSeriesSet},
-		Return: models.TypeSeriesSet,
+		Args:   timeDeltaDoc.Arguments.TypeSlice(),
+		Return: timeDeltaDoc.Return,
 		Tags:   tagFirst,
 		F:      TimeDelta,
+		Doc:    timeDeltaDoc,
 	},
 	"tod": {
-		Args:   []models.FuncType{models.TypeScalar},
-		Return: models.TypeString,
+		Args:   todDoc.Arguments.TypeSlice(),
+		Return: todDoc.Return,
 		F:      ToDuration,
+		Doc:    todDoc,
 	},
 }
 
 var dDoc = &doc.Func{
 	Name:    "d",
-	Summary: `d Returns the number of seconds of the <a href="http://opentsdb.net/docs/build/html/user_guide/query/dates.html">OpenTSDB duration string</a> s.`,
+	Summary: `d Returns the number of seconds of the <a href="http://opentsdb.net/docs/build/html/user_guide/query/dates.html">OpenTSDB duration string</a> s. This is the inverse of the <code>tod()</code> function`,
 	Arguments: doc.Arguments{
 		doc.Arg{
 			Name: "s",
@@ -71,7 +77,60 @@ func Duration(e *State, T miniprofiler.Timer, d string) (*Results, error) {
 	}, nil
 }
 
-var shiftdoc = &doc.Func{
+var epochDoc = &doc.Func{
+	Name:    "epoch",
+	Summary: "epoch returns the Unix epoch in seconds.",
+	Return:  models.TypeScalar,
+}
+
+func Epoch(e *State, T miniprofiler.Timer) (*Results, error) {
+	return &Results{
+		Results: []*Result{
+			{Value: Scalar(float64(e.now.Unix()))},
+		},
+	}, nil
+}
+
+var monthDoc = &doc.Func{
+	Name:    "month",
+	Summary: "Returns the epoch of either the start or end of the month. The epoch value will be UTC. Useful for things like monthly billing",
+	Arguments: doc.Arguments{
+		doc.Arg{
+			Name: "offset",
+			Desc: "the timezone offset from UTC that the month starts/ends at.",
+			Type: models.TypeScalar,
+		},
+		doc.Arg{
+			Name: "startEnd",
+			Desc: `must be either "start" or "end"`,
+			Type: models.TypeString,
+		},
+	},
+	Return:   models.TypeScalar,
+	Examples: []doc.HTMLString{doc.HTMLString(monthExampleOne)},
+}
+
+func Month(e *State, T miniprofiler.Timer, offset float64, startEnd string) (*Results, error) {
+	if startEnd != "start" && startEnd != "end" {
+		return nil, fmt.Errorf("last parameter for mtod must be 'start' or 'end'")
+	}
+	offsetInt := int(offset)
+	location := time.FixedZone(fmt.Sprintf("%v", offsetInt), offsetInt*60*60)
+	timeZoned := e.now.In(location)
+	var mtod float64
+	if startEnd == "start" {
+		mtod = float64(now.New(timeZoned).BeginningOfMonth().Unix())
+	} else {
+		mtod = float64(now.New(timeZoned).EndOfMonth().Unix())
+	}
+	return &Results{
+		Results: []*Result{
+			{Value: Scalar(float64(mtod))},
+		},
+	}, nil
+}
+
+var shiftDoc = &doc.Func{
 	Name:    "shift",
 	Summary: `Shift changes the timestamp of each datapoint in s to be the specified duration in the future. It also adds a tag representing the shift duration. This is meant so you can overlay times visually in a graph.`,
 	Arguments: doc.Arguments{
@@ -103,3 +162,75 @@ func Shift(e *State, T miniprofiler.Timer, series *Results, d string) (*Results,
 	}
 	return series, nil
 }
+
+var timeDeltaDoc = &doc.Func{
+	Name:      "timedelta",
+	Summary:   "timedelta creates a new series where the values are the difference between successive timestamps as seconds for each series in s.",
+	Arguments: doc.Arguments{sSeriesSetArg},
+	Return:    models.TypeSeriesSet,
+	Examples:  []doc.HTMLString{doc.HTMLString(timeDeltaExampleOne)},
+}
+
+func TimeDelta(e *State, T miniprofiler.Timer, series *Results) (*Results, error) {
+	for _, res := range series.Results {
+		sorted := NewSortedSeries(res.Value.Value().(Series))
+		newSeries := make(Series)
+		if len(sorted) < 2 {
+			newSeries[sorted[0].T] = 0
+			res.Value = newSeries
+			continue
+		}
+		lastTime := sorted[0].T.Unix()
+		for _, dp := range sorted[1:] {
+			unixTime := dp.T.Unix()
+			diff := unixTime - lastTime
+			newSeries[dp.T] = float64(diff)
+			lastTime = unixTime
+		}
+		res.Value = newSeries
+	}
+	return series, nil
+}
+
+var todDoc = &doc.Func{
+	Name:    "tod",
+	Summary: `tod returns a <a href="http://opentsdb.net/docs/build/html/user_guide/query/dates.html">OpenTSDB duration string</a> that represents the number of seconds in sec. This lets you do math on durations and then pass it to the duration arguments in functions like <code>q()</code>. This is the inverse of the <code>d()</code> function.`,
+	Arguments: doc.Arguments{
+		doc.Arg{
+			Name: "sec",
+			Type: models.TypeScalar,
+		},
+	},
+	Return: models.TypeString,
+}
+
+func ToDuration(e *State, T miniprofiler.Timer, sec float64) (*Results, error) {
+	d := opentsdb.Duration(time.Duration(int64(sec)) * time.Second)
+	return &Results{
+		Results: []*Result{
+			{Value: String(d.HumanString())},
+		},
+	}, nil
+}
+
+var monthExampleOne = `<pre><code>$hostInt = host=ny-nexus01,iname=Ethernet1/46
+$inMetric = "sum:5m-avg:rate{counter,,1}:__ny-nexus01.os.net.bytes{$hostInt,direction=in}"
+$outMetric = "sum:5m-avg:rate{counter,,1}:__ny-nexus01.os.net.bytes{$hostInt,direction=in}"
+$commit = 100
+$monthStart = month(-4, "start")
+$monthEnd = month(-4, "end")
+$monthLength = $monthEnd - $monthStart
+$burstTime = ($monthLength)*.05
+$burstableObservations = $burstTime / d("5m")
+$in = q($inMetric, tod(epoch()-$monthStart), "") * 8 / 1e6
+$out = q($inMetric, tod(epoch()-$monthStart), "") * 8 / 1e6
+$inOverCount = sum($in > $commit)
+$outOverCount = sum($out > $commit)
+$inOverCount > $burstableObservations || $outOverCount > $burstableObservations
+</code></pre>`
+
+var timeDeltaExampleOne = `<pre><code>timedelta(series("foo=bar", 1466133600, 1, 1466133610, 1, 1466133710, 1))</code></pre>
+
+<p>Will return a seriesSet equal to the what the following expression returns:</p>
+<pre><code>series("foo=bar", 1466133610, 10, 1466133710, 100)</code></pre>
+`

--- a/cmd/bosun/expr/graphite.go
+++ b/cmd/bosun/expr/graphite.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Graphite defines functions for use with a Graphite backend.
-var Graphite = map[string]parse.Func{
+var Graphite = parse.FuncMap{
 	"graphiteBand": {
 		Args:   []models.FuncType{models.TypeString, models.TypeString, models.TypeString, models.TypeString, models.TypeScalar},
 		Return: models.TypeSeriesSet,

--- a/cmd/bosun/expr/influx.go
+++ b/cmd/bosun/expr/influx.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Influx is a map of functions to query InfluxDB.
-var Influx = map[string]parse.Func{
+var Influx = parse.FuncMap{
 	"influx": {
 		Args:   []models.FuncType{models.TypeString, models.TypeString, models.TypeString, models.TypeString, models.TypeString},
 		Return: models.TypeSeriesSet,

--- a/cmd/bosun/expr/logstash.go
+++ b/cmd/bosun/expr/logstash.go
@@ -19,7 +19,7 @@ var lsClient *elastic.Client
 
 // The following are specific functions that query an elastic instance populated by
 // logstash. They are only loaded when the elastic hosts are set in the config file
-var LogstashElastic = map[string]parse.Func{
+var LogstashElastic = parse.FuncMap{
 	"lscount": {
 		Args:   []models.FuncType{models.TypeString, models.TypeString, models.TypeString, models.TypeString, models.TypeString, models.TypeString},
 		Return: models.TypeSeriesSet,

--- a/cmd/bosun/expr/parse/parse.go
+++ b/cmd/bosun/expr/parse/parse.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 
+	"bosun.org/cmd/bosun/expr/doc"
 	"bosun.org/models"
 )
 
@@ -43,6 +44,7 @@ type Func struct {
 	PrefixEnabled bool
 	PrefixKey     bool
 	Check         func(*Tree, *FuncNode) error
+	Doc           *doc.Func
 }
 
 type FuncMap map[string]Func

--- a/cmd/bosun/expr/parse/parse.go
+++ b/cmd/bosun/expr/parse/parse.go
@@ -49,6 +49,16 @@ type Func struct {
 
 type FuncMap map[string]Func
 
+func (fm FuncMap) DocSlice() doc.Funcs {
+	funcDocs := doc.Funcs{}
+	for _, f := range fm {
+		if f.Doc != nil {
+			funcDocs = append(funcDocs, f.Doc)
+		}
+	}
+	return funcDocs
+}
+
 type FuncMaps []FuncMap
 
 type Tags map[string]struct{}

--- a/cmd/bosun/expr/parse/parse.go
+++ b/cmd/bosun/expr/parse/parse.go
@@ -22,7 +22,7 @@ type Tree struct {
 	Text string // text parsed to create the expression.
 	Root Node   // top-level root of the tree, returns a number.
 
-	funcs   []map[string]Func
+	funcs   FuncMaps
 	mapExpr bool
 
 	// Parsing only; cleared after parse.
@@ -44,6 +44,10 @@ type Func struct {
 	PrefixKey     bool
 	Check         func(*Tree, *FuncNode) error
 }
+
+type FuncMap map[string]Func
+
+type FuncMaps []FuncMap
 
 type Tags map[string]struct{}
 
@@ -92,14 +96,14 @@ func (t Tags) Intersection(o Tags) Tags {
 // Parse returns a Tree, created by parsing the expression described in the
 // argument string. If an error is encountered, parsing stops and an empty Tree
 // is returned with the error.
-func Parse(text string, funcs ...map[string]Func) (t *Tree, err error) {
+func Parse(text string, funcs ...FuncMap) (t *Tree, err error) {
 	t = New()
 	t.Text = text
 	err = t.Parse(text, funcs...)
 	return
 }
 
-func ParseSub(text string, funcs ...map[string]Func) (t *Tree, err error) {
+func ParseSub(text string, funcs ...FuncMap) (t *Tree, err error) {
 	t = New()
 	t.mapExpr = true
 	t.Text = text
@@ -135,7 +139,7 @@ func (t *Tree) peek() item {
 // Parsing.
 
 // New allocates a new parse tree with the given name.
-func New(funcs ...map[string]Func) *Tree {
+func New(funcs ...FuncMap) *Tree {
 	return &Tree{
 		funcs: funcs,
 	}
@@ -192,7 +196,7 @@ func (t *Tree) recover(errp *error) {
 }
 
 // startParse initializes the parser, using the lexer.
-func (t *Tree) startParse(funcs []map[string]Func, lex *lexer) {
+func (t *Tree) startParse(funcs FuncMaps, lex *lexer) {
 	t.Root = nil
 	t.lex = lex
 	t.funcs = funcs
@@ -219,7 +223,7 @@ func (t *Tree) stopParse() {
 
 // Parse parses the expression definition string to construct a representation
 // of the expression for execution.
-func (t *Tree) Parse(text string, funcs ...map[string]Func) (err error) {
+func (t *Tree) Parse(text string, funcs ...FuncMap) (err error) {
 	defer t.recover(&err)
 	t.startParse(funcs, lex(text))
 	t.Text = text

--- a/cmd/bosun/expr/tsdb.go
+++ b/cmd/bosun/expr/tsdb.go
@@ -16,7 +16,7 @@ import (
 )
 
 // TSDB defines functions for use with an OpenTSDB backend.
-var TSDB = map[string]parse.Func{
+var TSDB = parse.FuncMap{
 	"band": {
 		Args:   []models.FuncType{models.TypeString, models.TypeString, models.TypeString, models.TypeScalar},
 		Return: models.TypeSeriesSet,

--- a/cmd/bosun/web/static/js/bosun.js
+++ b/cmd/bosun/web/static/js/bosun.js
@@ -1004,6 +1004,28 @@ bosunControllers.controller('ConfigCtrl', ['$scope', '$http', '$location', '$rou
                 });
             }
         }
+        function updateToolTip(position, token) {
+            //example with container creation via JS
+            var div = document.getElementById('tooltip_0');
+            if (div === null) {
+                div = document.createElement('div');
+                div.setAttribute('id', 'tooltip_0');
+                div.setAttribute('class', 'ace_tooltip');
+                document.body.appendChild(div);
+            }
+            var aDiv = angular.element('#tooltip_0');
+            div.style.left = position.pageX + 'px';
+            div.style.top = position.pageY + 'px';
+            if (token && token.type == "support.function") {
+                div.style.display = "block";
+                var selectedDoc = $scope.docs[token.value];
+                aDiv.html("<p>" + selectedDoc.Signature + "</p><p>" + selectedDoc.Summary + "</p>");
+            }
+            else {
+                div.style.display = "none";
+                div.innerText = "";
+            }
+        }
         $scope.aceLoaded = function (_editor) {
             editor = _editor;
             $scope.editor = editor;
@@ -1013,6 +1035,23 @@ bosunControllers.controller('ConfigCtrl', ['$scope', '$http', '$location', '$rou
                 $scope.$apply(function () {
                     $scope.items = parseItems();
                 });
+            });
+            // https://github.com/devuxd/SeeCodeRun/wiki/Ace-code-editor
+            editor.on("mousemove", function (e) {
+                var position = e.getDocumentPosition();
+                if (position) {
+                    var wordRange = editor.getSession().getWordRange(position.row, position.column);
+                    var text = editor.session.getTextRange(wordRange);
+                    var token = editor.session.getTokenAt(position.row, position.column);
+                    if (text.length > 0) {
+                        var pixelPosition = editor.renderer.textToScreenCoordinates(position);
+                        pixelPosition.pageY += editor.renderer.lineHeight;
+                        updateToolTip(pixelPosition, token);
+                    }
+                    else {
+                        updateToolTip(editor.renderer.textToScreenCoordinates(position), token);
+                    }
+                }
             });
             editor.commands.addCommand({
                 name: "funcHelp",

--- a/cmd/bosun/web/static/js/config.ts
+++ b/cmd/bosun/web/static/js/config.ts
@@ -233,6 +233,29 @@ bosunControllers.controller('ConfigCtrl', ['$scope', '$http', '$location', '$rou
 		}
 	}
 
+	function updateToolTip(position, token) {
+		//example with container creation via JS
+		var div = document.getElementById('tooltip_0');
+		if (div === null) {
+			div = document.createElement('div');
+			div.setAttribute('id', 'tooltip_0');
+			div.setAttribute('class', 'ace_tooltip');
+			document.body.appendChild(div);
+		}
+		var aDiv = angular.element('#tooltip_0')
+		div.style.left = position.pageX + 'px';
+		div.style.top = position.pageY + 'px';
+		if (token && token.type == "support.function") {
+			div.style.display = "block";
+			var selectedDoc = $scope.docs[token.value];
+			aDiv.html(`<p>${selectedDoc.Signature}</p><p>${selectedDoc.Summary}</p>`)
+		} else {
+			div.style.display = "none";
+			div.innerText = "";
+		}
+	}
+
+
 	$scope.aceLoaded = function (_editor) {
 		editor = _editor;
 		$scope.editor = editor;
@@ -242,6 +265,22 @@ bosunControllers.controller('ConfigCtrl', ['$scope', '$http', '$location', '$rou
 			$scope.$apply(function () {
 				$scope.items = parseItems();
 			});
+		});
+		// https://github.com/devuxd/SeeCodeRun/wiki/Ace-code-editor
+		editor.on("mousemove", function (e) {
+			var position = e.getDocumentPosition();
+			if (position) {
+				var wordRange = editor.getSession().getWordRange(position.row, position.column);
+				var text = editor.session.getTextRange(wordRange);
+				var token = editor.session.getTokenAt(position.row, position.column)
+				if (text.length > 0) {
+					var pixelPosition = editor.renderer.textToScreenCoordinates(position);
+					pixelPosition.pageY += editor.renderer.lineHeight;
+					updateToolTip(pixelPosition, token);
+				} else {
+					updateToolTip(editor.renderer.textToScreenCoordinates(position), token);
+				}
+			}
 		});
 		editor.commands.addCommand({
 			name: "funcHelp",

--- a/cmd/bosun/web/static/partials/config.html
+++ b/cmd/bosun/web/static/partials/config.html
@@ -48,6 +48,29 @@
 		outline: none !important;
 	}
 
+	.ace_tooltip {
+		background-color: #FFF;
+		background-image: -webkit-linear-gradient(top, transparent, rgba(0, 0, 0, 0.1));
+		background-image: linear-gradient(to bottom, transparent, rgba(0, 0, 0, 0.1));
+		border: 1px solid gray;
+		border-radius: 1px;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+		color: black;
+		max-width: 100%;
+		padding: 3px 4px;
+		position: absolute;
+		z-index: 999999;
+		-moz-box-sizing: border-box;
+		-webkit-box-sizing: border-box;
+		box-sizing: border-box;
+		cursor: default;
+		word-wrap: break-word;
+		font-style: normal;
+		font-weight: normal;
+		letter-spacing: normal;
+		pointer-events: none;
+	}
+
 </style>
 <label class="selectorDropdown" style="margin-right:15px;">Jump to:</label>
 <div class="row">

--- a/cmd/bosun/web/web.go
+++ b/cmd/bosun/web/web.go
@@ -36,6 +36,7 @@ import (
 	"github.com/captncraig/easyauth"
 	"github.com/gorilla/mux"
 	"github.com/justinas/alice"
+	"bosun.org/cmd/bosun/expr"
 )
 
 var (
@@ -152,6 +153,7 @@ func Listen(httpAddr, httpsAddr, certFile, keyFile string, devMode bool, tsdbHos
 	handle("/api/egraph/{bs}.{format:svg|png}", JSON(ExprGraph), canRunTests).Name("expr_graph")
 	handle("/api/errors", JSON(ErrorHistory), canViewDash).Name("errors").Methods(GET, POST)
 	handle("/api/expr", JSON(Expr), canRunTests).Name("expr").Methods(POST)
+	handle("/api/expr/docs", JSON(ExprDocs), fullyOpen).Name("expr_doc").Methods(GET)
 	handle("/api/graph", JSON(Graph), canViewDash).Name("graph").Methods(GET)
 
 	handle("/api/health", JSON(HealthCheck), fullyOpen).Name("health_check").Methods(GET)
@@ -932,4 +934,8 @@ func ErrorHistory(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) 
 		}
 	}
 	return nil, nil
+}
+
+func ExprDocs(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (interface{}, error) {
+	return expr.Docs, nil
 }

--- a/models/incidents.go
+++ b/models/incidents.go
@@ -138,6 +138,10 @@ func (f FuncType) String() string {
 	}
 }
 
+func (f FuncType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(f.String())
+}
+
 const (
 	TypeString FuncType = iota
 	TypePrefix


### PR DESCRIPTION
This will move the expression documentation into structured objects in Go. The main goals are:

 1. More uniformity in the documentation
 2. Auto Gen the list of functions for the Ace mode (currently syntax highlighting)
 3. Auto Gen the expression documentation on bosun.org
 4. Make function help available in the ace editor (i.e. mouse over on token shows popup with function documentation)