### PR TITLE
cmd/bosun: Add timeouts to http notfications

### DIFF
--- a/cmd/bosun/conf/conf.go
+++ b/cmd/bosun/conf/conf.go
@@ -212,6 +212,7 @@ type Notification struct {
 	Name         string
 	Email        []*mail.Address
 	Post, Get    *url.URL
+	HTTPTimeout  time.Duration
 	Body         *ttemplate.Template
 	Print        bool
 	Next         *Notification

--- a/cmd/bosun/conf/notify.go
+++ b/cmd/bosun/conf/notify.go
@@ -10,6 +10,7 @@ import (
 	"net/mail"
 	"net/smtp"
 	"strings"
+	"time"
 
 	"bosun.org/collect"
 	"bosun.org/metadata"
@@ -27,6 +28,8 @@ func init() {
 		"bosun.email.sent_failed", metadata.Counter, metadata.PerSecond,
 		"The number of email notifications that Bosun failed to send.")
 }
+
+const defaultHTTPTimeout = time.Second * 30
 
 // Notify triggers Email/HTTP/Print actions for the Notification object
 func (n *Notification) Notify(subject, body string, emailsubject, emailbody []byte, c SystemConfProvider, ak string, attachments ...*models.Attachment) {
@@ -69,7 +72,14 @@ func (n *Notification) DoPost(payload []byte, ak string) {
 		}
 		payload = buf.Bytes()
 	}
-	resp, err := http.Post(n.Post.String(), n.ContentType, bytes.NewBuffer(payload))
+	postTimeout := n.HTTPTimeout
+	if postTimeout == 0 {
+		postTimeout = defaultHTTPTimeout
+	}
+	var postClient = &http.Client{
+		Timeout: postTimeout,
+	}
+	resp, err := postClient.Post(n.Post.String(), n.ContentType, bytes.NewBuffer(payload))
 	if resp != nil && resp.Body != nil {
 		// Drain up to 512 bytes and close the body to let the Transport reuse the connection
 		io.CopyN(ioutil.Discard, resp.Body, 512)
@@ -87,7 +97,14 @@ func (n *Notification) DoPost(payload []byte, ak string) {
 }
 
 func (n *Notification) DoGet(ak string) {
-	resp, err := http.Get(n.Get.String())
+	getTimeout := n.HTTPTimeout
+	if getTimeout == 0 {
+		getTimeout = defaultHTTPTimeout
+	}
+	var getClient = &http.Client{
+		Timeout: getTimeout,
+	}
+	resp, err := getClient.Get(n.Get.String())
 	if err != nil {
 		slog.Error(err)
 		return

--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -1514,6 +1514,11 @@ If your body for a POST notification requires a different Content-Type header th
 
 `get` will make an HTTP get call to the url provided as a value.
 
+#### httpTimeout
+{: .keyword}
+
+`httpTimeout` is the duration to wait for the get or post HTTP call. Defaults to 30 seconds.
+
 #### next
 {: .keyword}
 


### PR DESCRIPTION
The default HTTP client doesn't have timeouts.  When using a get or post notification and the target endpoint is have problems this causes bosun to keep a http connection open for each notification and blocks the go routine.