### PR TITLE
Add support for metric prefix

### DIFF
--- a/cmd/scollector/collectors/collectors.go
+++ b/cmd/scollector/collectors/collectors.go
@@ -124,6 +124,8 @@ var (
 
 	//TotalScollectorMemory stores the total memory used by Scollector (including CGO and WMI)
 	TotalScollectorMemoryMB uint64
+
+	Prefix = ""
 )
 
 func init() {
@@ -224,6 +226,9 @@ func registerInit(i initFunc) {
 }
 
 func Init(c *conf.Conf) {
+	if c.Prefix != "" {
+		Prefix = c.Prefix
+	}
 	for _, f := range inits {
 		f(c)
 	}
@@ -296,6 +301,9 @@ func AddTS(md *opentsdb.MultiDataPoint, name string, ts int64, value interface{}
 // automatically added. If the value of the host key is the empty string, it
 // will be removed (use this to prevent the normal auto-adding of the host tag).
 func Add(md *opentsdb.MultiDataPoint, name string, value interface{}, t opentsdb.TagSet, rate metadata.RateType, unit metadata.Unit, desc string) {
+	if Prefix != "" {
+		name = Prefix + "." + name 
+	}
 	AddTS(md, name, now(), value, t, rate, unit, desc)
 }
 

--- a/cmd/scollector/collectors/collectors.go
+++ b/cmd/scollector/collectors/collectors.go
@@ -125,7 +125,7 @@ var (
 	//TotalScollectorMemory stores the total memory used by Scollector (including CGO and WMI)
 	TotalScollectorMemoryMB uint64
 
-	Prefix = ""
+	MetricPrefix = ""
 )
 
 func init() {
@@ -226,8 +226,8 @@ func registerInit(i initFunc) {
 }
 
 func Init(c *conf.Conf) {
-	if c.Prefix != "" {
-		Prefix = c.Prefix
+	if c.MetricPrefix != "" {
+		MetricPrefix = c.MetricPrefix
 	}
 	for _, f := range inits {
 		f(c)
@@ -247,6 +247,10 @@ func AddTS(md *opentsdb.MultiDataPoint, name string, ts int64, value interface{}
 	// Check if we really want that metric
 	if skipMetric(name) {
 		return
+	}
+	// Add Prefix
+	if MetricPrefix != "" {
+		name = MetricPrefix + "." + name
 	}
 
 	tags := t.Copy()
@@ -301,9 +305,6 @@ func AddTS(md *opentsdb.MultiDataPoint, name string, ts int64, value interface{}
 // automatically added. If the value of the host key is the empty string, it
 // will be removed (use this to prevent the normal auto-adding of the host tag).
 func Add(md *opentsdb.MultiDataPoint, name string, value interface{}, t opentsdb.TagSet, rate metadata.RateType, unit metadata.Unit, desc string) {
-	if Prefix != "" {
-		name = Prefix + "." + name 
-	}
 	AddTS(md, name, now(), value, t, rate, unit, desc)
 }
 

--- a/cmd/scollector/conf/conf.go
+++ b/cmd/scollector/conf/conf.go
@@ -63,6 +63,9 @@ type Conf struct {
 	// UseSWbemServicesClient specifies if the wmi package should use SWbemServices.
 	UseSWbemServicesClient bool
 
+	// Prefix prepended to all metrics path
+	Prefix string
+
 	HAProxy        []HAProxy
 	SNMP           []SNMP
 	MIBS           map[string]MIB

--- a/cmd/scollector/conf/conf.go
+++ b/cmd/scollector/conf/conf.go
@@ -63,8 +63,8 @@ type Conf struct {
 	// UseSWbemServicesClient specifies if the wmi package should use SWbemServices.
 	UseSWbemServicesClient bool
 
-	// Prefix prepended to all metrics path
-	Prefix string
+	// MetricPrefix prepended to all metrics path
+	MetricPrefix string
 
 	HAProxy        []HAProxy
 	SNMP           []SNMP

--- a/cmd/scollector/doc.go
+++ b/cmd/scollector/doc.go
@@ -121,6 +121,8 @@ matching on Linux.
 PProf (string): optional IP:Port binding to be used for debugging with pprof.
 Examples: localhost:6060 for loopback or :6060 for all IP addresses.
 
+MetricPrefix (string): optional Prefix prepended to all metrics path.
+
 Collector configuration keys
 
 Following are configurations for collectors that do not autodetect.


### PR DESCRIPTION
Prepend every metrics with a custom prefix set in the toml configuration file.  