### PR TITLE
Clean millisecond timestamps

### DIFF
--- a/opentsdb/tsdb.go
+++ b/opentsdb/tsdb.go
@@ -274,6 +274,10 @@ func (d *DataPoint) Clean() error {
 			}
 		}
 	}
+	// if timestamp bigger than 32 bits, likely in milliseconds
+	if d.Timestamp > 0xffffffff {
+		d.Timestamp /= 1000
+	}
 	if !d.Valid() {
 		return fmt.Errorf("datapoint is invalid")
 	}


### PR DESCRIPTION
Assumes if it overflows uint32, we are dealing with ms. Seems safe enough until 2106.