### PR TITLE
Add rs-collector to resources web page

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -62,11 +62,14 @@ title: Resources
 ### [ekg-bosun](https://hackage.haskell.org/package/ekg-bosun)
 > Send [ekg](https://github.com/tibbe/ekg) metrics from Haskell applications to Bosun.
 
-### [bosun_emitter](https://github.com/lukaspustina/bosun_emitter)
+### [bosun_emitter](https://github.com/lukaspustina/bosun_emitter) by Lukas Pustina
 > bosun_emitter is a Rust library and CLI standalone binary called `emit_bosun` that may be used on the command line or from any shell script to send a single metric datum to Bosun.
 
 ### [opsgenie-bosun](https://github.com/TrentScholl/opsgenie-bosun)
 > OpsGenie Marid integration for Bosun.
+
+### [rs-collector](https://github.com/lukaspustina/rs-collector) by Lukas Pustina
+> rs-collector is a Rust based, scollector compatible telemetry collector for services currently not covered by scollector. It collects selected metrics for Galera, JVM, MongoDB, Postfix etc.
 
 _See also the list of built-in collectors included with [scollector](http://bosun.org/scollector/)_
 


### PR DESCRIPTION
_rs-collector_ is a [Bosun](https://bosun.org) compatible collector for various services that are not covered by [scollector](https://bosun.org/scollector/), and that we use at [CenterDevice](https://www.centerdevice.de/en/).