### PR TITLE
WIP: Prometheus backend

### DIFF
--- a/cmd/bosun/bosun.example.toml
+++ b/cmd/bosun/bosun.example.toml
@@ -41,7 +41,7 @@ SearchSince = "72h"
 
 # Path to a command that will be executed on save of the rule configuration. This command is passed a filename, username, message, and vargs
 # If the command does not execute save operations will be canceled and the rule file will be restored
-CommandHookPath = "/Users/kbrandt/src/hook/hook"
+#CommandHookPath = "/Users/kbrandt/src/hook/hook"
 
 # Configuration to enable the OpenTSDB Backend
 [OpenTSDBConf]
@@ -116,3 +116,6 @@ CommandHookPath = "/Users/kbrandt/src/hook/hook"
 	URL = "https://myInfluxServer:1234"
 	Timeout = "5m"
 	UnsafeSSL = true
+
+[PromConf]
+        URL = "http://127.0.0.1:9090"

--- a/cmd/bosun/conf/conf.go
+++ b/cmd/bosun/conf/conf.go
@@ -78,6 +78,7 @@ type SystemConfProvider interface {
 	GetInfluxContext() client.HTTPConfig
 	GetLogstashContext() expr.LogstashElasticHosts
 	GetElasticContext() expr.ElasticHosts
+	GetPromContext() expr.PromConfig
 	AnnotateEnabled() bool
 
 	MakeLink(string, *url.Values) string

--- a/cmd/bosun/conf/rule/rule.go
+++ b/cmd/bosun/conf/rule/rule.go
@@ -1021,6 +1021,9 @@ func (c *Conf) GetFuncs(backends conf.EnabledBackends) map[string]eparse.Func {
 	if backends.Annotate {
 		merge(expr.Annotate)
 	}
+	if backends.Prom {
+		merge(expr.Prom)
+	}
 	return funcs
 }
 

--- a/cmd/bosun/conf/system.go
+++ b/cmd/bosun/conf/system.go
@@ -45,6 +45,7 @@ type SystemConf struct {
 	OpenTSDBConf OpenTSDBConf
 	GraphiteConf GraphiteConf
 	InfluxConf   InfluxConf
+	PromConf     PromConf
 	ElasticConf  map[string]ElasticConf
 	LogStashConf LogStashConf
 
@@ -69,6 +70,7 @@ type EnabledBackends struct {
 	Influx   bool
 	Elastic  bool
 	Logstash bool
+	Prom     bool
 	Annotate bool
 }
 
@@ -79,6 +81,7 @@ func (sc *SystemConf) EnabledBackends() EnabledBackends {
 	b.OpenTSDB = sc.OpenTSDBConf.Host != ""
 	b.Graphite = sc.GraphiteConf.Host != ""
 	b.Influx = sc.InfluxConf.URL != ""
+	b.Prom = sc.PromConf.URL != ""
 	b.Logstash = len(sc.LogStashConf.Hosts) != 0
 	b.Elastic = len(sc.ElasticConf["default"].Hosts) != 0
 	b.Annotate = len(sc.AnnotateConf.Hosts) != 0
@@ -150,6 +153,10 @@ type InfluxConf struct {
 	Timeout   Duration
 	UnsafeSSL bool
 	Precision string
+}
+
+type PromConf struct {
+	URL string
 }
 
 // DBConf stores the connection information for Bosun's internal storage
@@ -525,6 +532,14 @@ func (sc *SystemConf) GetInfluxContext() client.HTTPConfig {
 	}
 	if sc.md.IsDefined("InfluxConf", "UnsafeSsl") {
 		c.InsecureSkipVerify = sc.InfluxConf.UnsafeSSL
+	}
+	return c
+}
+
+func (sc *SystemConf) GetPromContext() expr.PromConfig {
+	c := expr.PromConfig{}
+	if sc.md.IsDefined("PromConf", "URL") {
+		c.URL = sc.PromConf.URL
 	}
 	return c
 }

--- a/cmd/bosun/dev.sample.conf
+++ b/cmd/bosun/dev.sample.conf
@@ -38,13 +38,6 @@ alert example.opentsdb.os.high.cpu {
 	crit = $q >= 1
 }
 
-alert example.influx.os.high.cpu {
-        $db = "opentsdb"
-        $q = avg(influx($db, '''select derivative(mean(value), 1s) from "os.cpu" GROUP BY host''', "2m", "", "15s"))
-        warn = $q > 20
-        crit = $q >= 1
-}
-
 lookup cpu {
 	entry host=a,remote=b {
 		high = 1

--- a/cmd/bosun/expr/expr.go
+++ b/cmd/bosun/expr/expr.go
@@ -56,6 +56,7 @@ type Backends struct {
 	ElasticHosts    ElasticHosts
 	InfluxConfig    client.HTTPConfig
 	ElasticConfig   ElasticConfig
+	PromConfig      PromConfig
 }
 
 type BosunProviders struct {

--- a/cmd/bosun/expr/prom.go
+++ b/cmd/bosun/expr/prom.go
@@ -1,0 +1,136 @@
+package expr
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"bosun.org/cmd/bosun/expr/parse"
+	"bosun.org/models"
+	"bosun.org/opentsdb"
+	"github.com/MiniProfiler/go/miniprofiler"
+	"github.com/prometheus/client_golang/api"
+	"github.com/prometheus/client_golang/api/prometheus/v1"
+	promModels "github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/promql"
+)
+
+type PromConfig struct {
+	URL string
+}
+
+// Prom is a map of functions to query Prometheus.
+var Prom = map[string]parse.Func{
+	"prom": {
+		Args: []models.FuncType{
+			models.TypeString, // query
+			models.TypeString, // start
+			models.TypeString, // end
+			models.TypeString, // step
+		},
+		Return: models.TypeSeriesSet,
+		Tags:   PromTag,
+		F:      PromQuery,
+	},
+}
+
+func PromTag(args []parse.Node) (parse.Tags, error) {
+	st, err := promql.ParseMetricSelector(args[0].(*parse.StringNode).Text)
+	if err != nil {
+		return nil, err
+	}
+	t := make(parse.Tags)
+	for _, s := range st {
+		if string(s.Name) == "__name__" {
+			continue
+		}
+		t[string(s.Name)] = struct{}{}
+	}
+	return t, nil
+}
+
+func PromQuery(e *State, T miniprofiler.Timer, query, startDuration, endDuration, stepDuration string) (*Results, error) {
+	r := new(Results)
+	sd, err := opentsdb.ParseDuration(startDuration)
+	if err != nil {
+		return nil, err
+	}
+	ed, err := opentsdb.ParseDuration(endDuration)
+	if endDuration == "" {
+		ed = 0
+	} else if err != nil {
+		return nil, err
+	}
+	start := time.Now().Add(-time.Duration(sd))
+	end := time.Now().Add(-time.Duration(ed))
+	st, err := opentsdb.ParseDuration(stepDuration)
+	if err != nil {
+		return nil, err
+	}
+	step := time.Duration(st)
+	qres, err := timePromRequest(e, T, query, start, end, step)
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range qres.(promModels.Matrix) {
+		tags := make(opentsdb.TagSet)
+		for tagk, tagv := range row.Metric {
+			tags[string(tagk)] = string(tagv)
+		}
+		if e.Squelched(tags) {
+			continue
+		}
+		values := make(Series, len(row.Values))
+		for _, v := range row.Values {
+			values[v.Timestamp.Time()] = float64(v.Value)
+		}
+		r.Results = append(r.Results, &Result{
+			Value: values,
+			Group: tags,
+		})
+	}
+	return r, nil
+}
+
+func timePromRequest(e *State, T miniprofiler.Timer, query string, start, end time.Time, step time.Duration) (s promModels.Value, err error) {
+	//spew.Dump(os.Stderr, e)
+	client, err := api.NewClient(api.Config{Address: e.PromConfig.URL})
+	if err != nil {
+		return nil, err
+	}
+	conn := v1.NewAPI(client)
+	if err != nil {
+		return nil, err
+	}
+	r := v1.Range{Start: start, End: end, Step: step}
+	key := struct {
+		Query string
+		Range v1.Range
+	}{
+		query,
+		r,
+	}
+	b, _ := json.MarshalIndent(key, "", "  ")
+	T.StepCustomTiming("prom", "query", query, func() {
+		getFn := func() (interface{}, error) {
+			res, err := conn.QueryRange(context.Background(), query,
+				r)
+			if err != nil {
+				return nil, err
+			}
+			m, ok := res.(promModels.Matrix)
+			if !ok {
+				return nil, fmt.Errorf("prom: expected matrix result")
+			}
+			return m, nil
+		}
+		var val interface{}
+		var ok bool
+		val, err = e.Cache.Get(string(b), getFn)
+		if s, ok = val.(promModels.Matrix); !ok {
+			err = fmt.Errorf("prom: did not get valid result from prometheus, %v", err)
+		}
+	})
+	return
+}

--- a/cmd/bosun/web/expr.go
+++ b/cmd/bosun/web/expr.go
@@ -79,6 +79,7 @@ func Expr(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (v inter
 		InfluxConfig:    schedule.SystemConf.GetInfluxContext(),
 		LogstashHosts:   schedule.SystemConf.GetLogstashContext(),
 		ElasticHosts:    schedule.SystemConf.GetElasticContext(),
+		PromConfig:      schedule.SystemConf.GetPromContext(),
 	}
 	providers := &expr.BosunProviders{
 		Cache:     cacheObj,


### PR DESCRIPTION
To test
```
docker run --rm --name prometheus -p 9090:9090 prom/prometheus
```
and run `prom("up", "5m", "", "30s")` in expression tab.

Current problems:

1.  Prometheus shows all tags when doing metric query, it'll probably break Bosun alert keys There's a way to aggregate on particular tags like `avg(metric_name) by (tag_name)` ( see https://prometheus.io/docs/querying/operators/#aggregation-operators ), but that requires more sophisticated `expr.PromTag()` function and I haven't yet figured out how to deal with `promql.ParseExpr()` output.

Todo

- [ ] vendor
- [ ] tests
- [ ] TagQuery function
- [ ] filter tags in response
