### PR TITLE
scollector: support haproxy 1.7

### DIFF
--- a/cmd/scollector/collectors/haproxy_unix.go
+++ b/cmd/scollector/collectors/haproxy_unix.go
@@ -122,6 +122,8 @@ func haproxyFetch(user, pwd, tier, url string) (opentsdb.MultiDataPoint, error) 
 				if value == "" {
 					continue
 				}
+				// A star is added if the check is in progress.
+				value = strings.Trim(value, "* ")
 				v, ok := haproxyCheckStatus[value]
 				if !ok {
 					return nil, fmt.Errorf("unknown check status %v", value)


### PR DESCRIPTION
The haproxy collector uses the numerical position of the fields for collecting statistics. This breaks when the order of the fields changes, which is the case for the CSV format in haproxy 1.7.

The name of the fields provided in the CSV header is now used for fetching the right values.