### PR TITLE
cmd/scollector: haproxy user/password per instance

### DIFF
--- a/cmd/scollector/collectors/haproxy_unix.go
+++ b/cmd/scollector/collectors/haproxy_unix.go
@@ -19,7 +19,7 @@ func init() {
 				ii := i
 				collectors = append(collectors, &IntervalCollector{
 					F: func() (opentsdb.MultiDataPoint, error) {
-						if (ii.User != "") {
+						if ii.User != "" {
 							return haproxyFetch(ii.User, ii.Password, ii.Tier, ii.URL)
 						} else {
 							return haproxyFetch(h.User, h.Password, ii.Tier, ii.URL)

--- a/cmd/scollector/collectors/haproxy_unix.go
+++ b/cmd/scollector/collectors/haproxy_unix.go
@@ -19,8 +19,11 @@ func init() {
 				ii := i
 				collectors = append(collectors, &IntervalCollector{
 					F: func() (opentsdb.MultiDataPoint, error) {
-
-						return haproxyFetch(h.User, h.Password, ii.Tier, ii.URL)
+						if (ii.User != "") {
+							return haproxyFetch(ii.User, ii.Password, ii.Tier, ii.URL)
+						} else {
+							return haproxyFetch(h.User, h.Password, ii.Tier, ii.URL)
+						}
 					},
 					name: fmt.Sprintf("haproxy-%s-%s", ii.Tier, ii.URL),
 				})

--- a/cmd/scollector/conf/conf.go
+++ b/cmd/scollector/conf/conf.go
@@ -105,8 +105,10 @@ type HAProxy struct {
 }
 
 type HAProxyInstance struct {
-	Tier string
-	URL  string
+	User     string
+	Password string
+	Tier     string
+	URL      string
 }
 
 type Nexpose struct {

--- a/cmd/scollector/doc.go
+++ b/cmd/scollector/doc.go
@@ -133,7 +133,9 @@ with the specified community.
 	KeepalivedCommunity = "keepalivedcom"
 
 HAProxy (array of table, keys are User, Password, Instances): HAProxy instances
-to poll. The Instances key is an array of table with keys Tier and URL.
+to poll. The Instances key is an array of table with keys User, Password, Tier,
+and URL. If User is specified for an instance, User and Password override the
+common ones.
 
 	[[HAProxy]]
 	  User = "hauser"
@@ -147,6 +149,11 @@ to poll. The Instances key is an array of table with keys Tier and URL.
 	  [[HAProxy.Instances]]
 	    Tier = "3"
 	    URL = "http://ny-host01:40/haproxy\;csv"
+	  [[HAProxy.Instances]]
+	    User = "hauser2"
+	    Pass = "hapass2"
+	    Tier = "1"
+	    URL = "http://ny-host01:80/haproxy\;csv"
 
 SNMP (array of table, keys are Community and Host): SNMP hosts to connect
 to at a 5 minute poll interval.

--- a/cmd/scollector/doc.go
+++ b/cmd/scollector/doc.go
@@ -151,7 +151,7 @@ common ones.
 	    URL = "http://ny-host01:40/haproxy\;csv"
 	  [[HAProxy.Instances]]
 	    User = "hauser2"
-	    Pass = "hapass2"
+	    Password = "hapass2"
 	    Tier = "1"
 	    URL = "http://ny-host01:80/haproxy\;csv"
 


### PR DESCRIPTION
Adds support for instance-specific haproxy user/password pairs.
If specified at the HAProxy.Instance level, username/password
override those provided at the HAProxy level.