### PR TITLE
Extend cadvisor collector with additional metrics

### DIFF
--- a/cmd/scollector/collectors/cadvisor.go
+++ b/cmd/scollector/collectors/cadvisor.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"regexp"
 
 	"github.com/google/cadvisor/client"
 	"github.com/google/cadvisor/info/v1"
@@ -40,6 +41,21 @@ var cadvisorMeta = map[string]MetricMeta{
 		RateType: metadata.Gauge,
 		Unit:     metadata.Second,
 		Desc:     "Smoothed 10s average of number of runnable threads x 1000",
+	},
+	"container.cpu.quota": {
+		RateType: metadata.Gauge,
+		Unit:     metadata.Microsecond,
+		Desc:     "CPU Quota.",
+	},
+	"container.cpu.shares": {
+		RateType: metadata.Gauge,
+		Unit:     metadata.CPUshare,
+		Desc:     "CPU shares.",
+	},
+	"container.cpu.period": {
+		RateType: metadata.Gauge,
+		Unit:     metadata.Microsecond,
+		Desc:     "CPU period of the container.",
 	},
 	"container.blkio.io_service_bytes.async": {
 		RateType: metadata.Counter,
@@ -260,6 +276,41 @@ var cadvisorMeta = map[string]MetricMeta{
 		Unit:     metadata.Bytes,
 		Desc:     "Current working set.",
 	},
+	"container.memory.cache": {
+		RateType: metadata.Gauge,
+		Unit:     metadata.Bytes,
+		Desc:     "Number of bytes of page cache memory.",
+	},
+	"container.memory.rss": {
+		RateType: metadata.Gauge,
+		Unit:     metadata.Bytes,
+		Desc:     "The amount of anonymous and swap cache memory (includes transparent hugepages).",
+	},
+	"container.memory.swap": {
+		RateType: metadata.Gauge,
+		Unit:     metadata.Bytes,
+		Desc:     "The amount of swap currently used by the processes in this cgroup.",
+	},
+	"container.memory.failcnt": {
+		RateType: metadata.Counter,
+		Unit:     metadata.Fault,
+		Desc:     "The number of times the cgroup limit was exceeded.",
+	},
+	"container.memory.limit": {
+		RateType: metadata.Gauge,
+		Unit:     metadata.Bytes,
+		Desc:     "The amount of memory requested.",
+	},
+	"container.memory.reservation": {
+		RateType: metadata.Gauge,
+		Unit:     metadata.Bytes,
+		Desc:     "The amount of guaranteed memory.",
+	},
+	"container.memory.swap_limit": {
+		RateType: metadata.Gauge,
+		Unit:     metadata.Bytes,
+		Desc:     "The amount of swap space requested.",
+	},
 	"container.net.bytes": {
 		RateType: metadata.Counter,
 		Unit:     metadata.Bytes,
@@ -296,7 +347,7 @@ func cadvisorAdd(md *opentsdb.MultiDataPoint, name string, value interface{}, ts
 	Add(md, name, value, ts, cadvisorMeta[name].RateType, cadvisorMeta[name].Unit, cadvisorMeta[name].Desc)
 }
 
-func containerTagSet(ts opentsdb.TagSet, container *v1.ContainerInfo) opentsdb.TagSet {
+func containerTagSet(ts opentsdb.TagSet, container *v1.ContainerInfo, config *conf.Cadvisor) opentsdb.TagSet {
 	var tags opentsdb.TagSet
 	if container.Namespace == "docker" {
 		tags = opentsdb.TagSet{
@@ -311,6 +362,21 @@ func containerTagSet(ts opentsdb.TagSet, container *v1.ContainerInfo) opentsdb.T
 	}
 	for k, v := range ts {
 		tags[k] = v
+	}
+	re := regexp.MustCompile("\\W")
+	if config.TagsFromLabels != nil {
+		for short_label, label := range config.TagsFromLabels {
+			if val, ok := container.Labels[label]; ok {
+				tags[re.ReplaceAllString(short_label, "_")] = val
+			}
+		}
+	}
+	if config.IgnoreTags != nil {
+		for _,tag := range config.IgnoreTags {
+			if _, ok := tags[tag]; ok {
+				delete(tags, tag)
+			}
+		}
 	}
 	return tags
 }
@@ -335,7 +401,7 @@ func addBlkioStat(md *opentsdb.MultiDataPoint, name string, diskStats v1.PerDisk
 	}
 	for label, val := range diskStats.Stats {
 		if inBlkioWhitelist(label) {
-			cadvisorAdd(md, name+strings.ToLower(label), val, containerTagSet(opentsdb.TagSet{"dev": device}, container))
+			cadvisorAdd(md, name+strings.ToLower(label), val, containerTagSet(opentsdb.TagSet{"dev": device}, container, config))
 		}
 	}
 }
@@ -382,16 +448,19 @@ func statsForContainer(md *opentsdb.MultiDataPoint, container *v1.ContainerInfo,
 	stats := container.Stats[0]
 	var ts opentsdb.TagSet
 	if container.Spec.HasCpu {
-		cadvisorAdd(md, "container.cpu", stats.Cpu.Usage.System, containerTagSet(opentsdb.TagSet{"type": "system"}, container))
-		cadvisorAdd(md, "container.cpu", stats.Cpu.Usage.User, containerTagSet(opentsdb.TagSet{"type": "user"}, container))
+		cadvisorAdd(md, "container.cpu", stats.Cpu.Usage.System, containerTagSet(opentsdb.TagSet{"type": "system"}, container, config))
+		cadvisorAdd(md, "container.cpu", stats.Cpu.Usage.User, containerTagSet(opentsdb.TagSet{"type": "user"}, container, config))
 
-		ts = containerTagSet(ts, container)
+		ts = containerTagSet(ts, container, config)
 		cadvisorAdd(md, "container.cpu.loadavg", stats.Cpu.LoadAverage, ts)
 		cadvisorAdd(md, "container.cpu.usage", stats.Cpu.Usage.Total, ts)
+		cadvisorAdd(md, "container.cpu.quota", container.Spec.Cpu.Quota, ts)
+		cadvisorAdd(md, "container.cpu.period", container.Spec.Cpu.Period, ts)
+		cadvisorAdd(md, "container.cpu.shares", container.Spec.Cpu.Limit, ts)
 
 		if config.PerCpuUsage {
 			for idx := range stats.Cpu.Usage.PerCpu {
-				ts = containerTagSet(opentsdb.TagSet{"cpu": strconv.Itoa(idx)}, container)
+				ts = containerTagSet(opentsdb.TagSet{"cpu": strconv.Itoa(idx)}, container, config)
 				cadvisorAdd(md, "container.cpu.usage.percpu", stats.Cpu.Usage.PerCpu[idx], ts)
 			}
 		}
@@ -400,7 +469,7 @@ func statsForContainer(md *opentsdb.MultiDataPoint, container *v1.ContainerInfo,
 
 	if container.Spec.HasFilesystem {
 		for idx := range stats.Filesystem {
-			ts = containerTagSet(opentsdb.TagSet{"device": stats.Filesystem[idx].Device}, container)
+			ts = containerTagSet(opentsdb.TagSet{"device": stats.Filesystem[idx].Device}, container, config)
 			cadvisorAdd(md, "container.fs.available", stats.Filesystem[idx].Available, ts)
 			cadvisorAdd(md, "container.fs.limit", stats.Filesystem[idx].Limit, ts)
 			cadvisorAdd(md, "container.fs.usage", stats.Filesystem[idx].Usage, ts)
@@ -420,53 +489,60 @@ func statsForContainer(md *opentsdb.MultiDataPoint, container *v1.ContainerInfo,
 
 	if container.Spec.HasMemory {
 		cadvisorAdd(md, "container.memory.failures", stats.Memory.ContainerData.Pgfault,
-			containerTagSet(opentsdb.TagSet{"scope": "container", "type": "pgfault"}, container))
+			containerTagSet(opentsdb.TagSet{"scope": "container", "type": "pgfault"}, container, config))
 		cadvisorAdd(md, "container.memory.failures", stats.Memory.ContainerData.Pgmajfault,
-			containerTagSet(opentsdb.TagSet{"scope": "container", "type": "pgmajfault"}, container))
+			containerTagSet(opentsdb.TagSet{"scope": "container", "type": "pgmajfault"}, container, config))
 		cadvisorAdd(md, "container.memory.failures", stats.Memory.HierarchicalData.Pgfault,
-			containerTagSet(opentsdb.TagSet{"scope": "hierarchy", "type": "pgfault"}, container))
+			containerTagSet(opentsdb.TagSet{"scope": "hierarchy", "type": "pgfault"}, container, config))
 		cadvisorAdd(md, "container.memory.failures", stats.Memory.HierarchicalData.Pgmajfault,
-			containerTagSet(opentsdb.TagSet{"scope": "hierarchy", "type": "pgmajfault"}, container))
-		cadvisorAdd(md, "container.memory.working_set", stats.Memory.WorkingSet, containerTagSet(nil, container))
-		cadvisorAdd(md, "container.memory.usage", stats.Memory.Usage, containerTagSet(nil, container))
+			containerTagSet(opentsdb.TagSet{"scope": "hierarchy", "type": "pgmajfault"}, container, config))
+		cadvisorAdd(md, "container.memory.working_set", stats.Memory.WorkingSet, containerTagSet(nil, container, config))
+		cadvisorAdd(md, "container.memory.usage", stats.Memory.Usage, containerTagSet(nil, container, config))
+		cadvisorAdd(md, "container.memory.cache", stats.Memory.Cache, containerTagSet(nil, container, config))
+		cadvisorAdd(md, "container.memory.rss", stats.Memory.RSS, containerTagSet(nil, container, config))
+		cadvisorAdd(md, "container.memory.swap", stats.Memory.Swap, containerTagSet(nil, container, config))
+		cadvisorAdd(md, "container.memory.failcnt", stats.Memory.Failcnt, containerTagSet(nil, container, config))
+		cadvisorAdd(md, "container.memory.limit", container.Spec.Memory.Limit, containerTagSet(nil, container, config))
+		cadvisorAdd(md, "container.memory.reservation", container.Spec.Memory.Reservation, containerTagSet(nil, container, config))
+		cadvisorAdd(md, "container.memory.swap_limit", container.Spec.Memory.SwapLimit, containerTagSet(nil, container, config))
 	}
 
 	if container.Spec.HasNetwork {
 		for _, iface := range stats.Network.Interfaces {
-			ts = containerTagSet(opentsdb.TagSet{"ifName": iface.Name, "direction": "in"}, container)
+			ts = containerTagSet(opentsdb.TagSet{"ifName": iface.Name, "direction": "in"}, container, config)
 			cadvisorAdd(md, "container.net.bytes", iface.RxBytes, ts)
 			cadvisorAdd(md, "container.net.errors", iface.RxErrors, ts)
 			cadvisorAdd(md, "container.net.dropped", iface.RxDropped, ts)
 			cadvisorAdd(md, "container.net.packets", iface.RxPackets, ts)
-			ts = containerTagSet(opentsdb.TagSet{"ifName": iface.Name, "direction": "out"}, container)
+			ts = containerTagSet(opentsdb.TagSet{"ifName": iface.Name, "direction": "out"}, container, config)
 			cadvisorAdd(md, "container.net.bytes", iface.TxBytes, ts)
 			cadvisorAdd(md, "container.net.errors", iface.TxErrors, ts)
 			cadvisorAdd(md, "container.net.dropped", iface.TxDropped, ts)
 			cadvisorAdd(md, "container.net.packets", iface.TxPackets, ts)
 		}
-		cadvisorAdd(md, "container.net.tcp", stats.Network.Tcp.Close, containerTagSet(opentsdb.TagSet{"state": "close"}, container))
-		cadvisorAdd(md, "container.net.tcp", stats.Network.Tcp.CloseWait, containerTagSet(opentsdb.TagSet{"state": "closewait"}, container))
-		cadvisorAdd(md, "container.net.tcp", stats.Network.Tcp.Closing, containerTagSet(opentsdb.TagSet{"state": "closing"}, container))
-		cadvisorAdd(md, "container.net.tcp", stats.Network.Tcp.Established, containerTagSet(opentsdb.TagSet{"state": "established"}, container))
-		cadvisorAdd(md, "container.net.tcp", stats.Network.Tcp.FinWait1, containerTagSet(opentsdb.TagSet{"state": "finwait1"}, container))
-		cadvisorAdd(md, "container.net.tcp", stats.Network.Tcp.FinWait2, containerTagSet(opentsdb.TagSet{"state": "finwait2"}, container))
-		cadvisorAdd(md, "container.net.tcp", stats.Network.Tcp.LastAck, containerTagSet(opentsdb.TagSet{"state": "lastack"}, container))
-		cadvisorAdd(md, "container.net.tcp", stats.Network.Tcp.Listen, containerTagSet(opentsdb.TagSet{"state": "listen"}, container))
-		cadvisorAdd(md, "container.net.tcp", stats.Network.Tcp.SynRecv, containerTagSet(opentsdb.TagSet{"state": "synrecv"}, container))
-		cadvisorAdd(md, "container.net.tcp", stats.Network.Tcp.SynSent, containerTagSet(opentsdb.TagSet{"state": "synsent"}, container))
-		cadvisorAdd(md, "container.net.tcp", stats.Network.Tcp.TimeWait, containerTagSet(opentsdb.TagSet{"state": "timewait"}, container))
+		cadvisorAdd(md, "container.net.tcp", stats.Network.Tcp.Close, containerTagSet(opentsdb.TagSet{"state": "close"}, container, config))
+		cadvisorAdd(md, "container.net.tcp", stats.Network.Tcp.CloseWait, containerTagSet(opentsdb.TagSet{"state": "closewait"}, container, config))
+		cadvisorAdd(md, "container.net.tcp", stats.Network.Tcp.Closing, containerTagSet(opentsdb.TagSet{"state": "closing"}, container, config))
+		cadvisorAdd(md, "container.net.tcp", stats.Network.Tcp.Established, containerTagSet(opentsdb.TagSet{"state": "established"}, container, config))
+		cadvisorAdd(md, "container.net.tcp", stats.Network.Tcp.FinWait1, containerTagSet(opentsdb.TagSet{"state": "finwait1"}, container, config))
+		cadvisorAdd(md, "container.net.tcp", stats.Network.Tcp.FinWait2, containerTagSet(opentsdb.TagSet{"state": "finwait2"}, container, config))
+		cadvisorAdd(md, "container.net.tcp", stats.Network.Tcp.LastAck, containerTagSet(opentsdb.TagSet{"state": "lastack"}, container, config))
+		cadvisorAdd(md, "container.net.tcp", stats.Network.Tcp.Listen, containerTagSet(opentsdb.TagSet{"state": "listen"}, container, config))
+		cadvisorAdd(md, "container.net.tcp", stats.Network.Tcp.SynRecv, containerTagSet(opentsdb.TagSet{"state": "synrecv"}, container, config))
+		cadvisorAdd(md, "container.net.tcp", stats.Network.Tcp.SynSent, containerTagSet(opentsdb.TagSet{"state": "synsent"}, container, config))
+		cadvisorAdd(md, "container.net.tcp", stats.Network.Tcp.TimeWait, containerTagSet(opentsdb.TagSet{"state": "timewait"}, container, config))
 
-		cadvisorAdd(md, "container.net.tcp6", stats.Network.Tcp6.Close, containerTagSet(opentsdb.TagSet{"state": "close"}, container))
-		cadvisorAdd(md, "container.net.tcp6", stats.Network.Tcp6.CloseWait, containerTagSet(opentsdb.TagSet{"state": "closewait"}, container))
-		cadvisorAdd(md, "container.net.tcp6", stats.Network.Tcp6.Closing, containerTagSet(opentsdb.TagSet{"state": "closing"}, container))
-		cadvisorAdd(md, "container.net.tcp6", stats.Network.Tcp6.Established, containerTagSet(opentsdb.TagSet{"state": "established"}, container))
-		cadvisorAdd(md, "container.net.tcp6", stats.Network.Tcp6.FinWait1, containerTagSet(opentsdb.TagSet{"state": "finwait1"}, container))
-		cadvisorAdd(md, "container.net.tcp6", stats.Network.Tcp6.FinWait2, containerTagSet(opentsdb.TagSet{"state": "finwait2"}, container))
-		cadvisorAdd(md, "container.net.tcp6", stats.Network.Tcp6.LastAck, containerTagSet(opentsdb.TagSet{"state": "lastack"}, container))
-		cadvisorAdd(md, "container.net.tcp6", stats.Network.Tcp6.Listen, containerTagSet(opentsdb.TagSet{"state": "listen"}, container))
-		cadvisorAdd(md, "container.net.tcp6", stats.Network.Tcp6.SynRecv, containerTagSet(opentsdb.TagSet{"state": "synrecv"}, container))
-		cadvisorAdd(md, "container.net.tcp6", stats.Network.Tcp6.SynSent, containerTagSet(opentsdb.TagSet{"state": "synsent"}, container))
-		cadvisorAdd(md, "container.net.tcp6", stats.Network.Tcp6.TimeWait, containerTagSet(opentsdb.TagSet{"state": "timewait"}, container))
+		cadvisorAdd(md, "container.net.tcp6", stats.Network.Tcp6.Close, containerTagSet(opentsdb.TagSet{"state": "close"}, container, config))
+		cadvisorAdd(md, "container.net.tcp6", stats.Network.Tcp6.CloseWait, containerTagSet(opentsdb.TagSet{"state": "closewait"}, container, config))
+		cadvisorAdd(md, "container.net.tcp6", stats.Network.Tcp6.Closing, containerTagSet(opentsdb.TagSet{"state": "closing"}, container, config))
+		cadvisorAdd(md, "container.net.tcp6", stats.Network.Tcp6.Established, containerTagSet(opentsdb.TagSet{"state": "established"}, container, config))
+		cadvisorAdd(md, "container.net.tcp6", stats.Network.Tcp6.FinWait1, containerTagSet(opentsdb.TagSet{"state": "finwait1"}, container, config))
+		cadvisorAdd(md, "container.net.tcp6", stats.Network.Tcp6.FinWait2, containerTagSet(opentsdb.TagSet{"state": "finwait2"}, container, config))
+		cadvisorAdd(md, "container.net.tcp6", stats.Network.Tcp6.LastAck, containerTagSet(opentsdb.TagSet{"state": "lastack"}, container, config))
+		cadvisorAdd(md, "container.net.tcp6", stats.Network.Tcp6.Listen, containerTagSet(opentsdb.TagSet{"state": "listen"}, container, config))
+		cadvisorAdd(md, "container.net.tcp6", stats.Network.Tcp6.SynRecv, containerTagSet(opentsdb.TagSet{"state": "synrecv"}, container, config))
+		cadvisorAdd(md, "container.net.tcp6", stats.Network.Tcp6.SynSent, containerTagSet(opentsdb.TagSet{"state": "synsent"}, container, config))
+		cadvisorAdd(md, "container.net.tcp6", stats.Network.Tcp6.TimeWait, containerTagSet(opentsdb.TagSet{"state": "timewait"}, container, config))
 	}
 
 	if container.Spec.HasDiskIo {

--- a/cmd/scollector/conf/conf.go
+++ b/cmd/scollector/conf/conf.go
@@ -227,9 +227,11 @@ type Github struct {
 }
 
 type Cadvisor struct {
-	URL         string
-	PerCpuUsage bool
-	IsRemote    bool
+	URL            string
+	PerCpuUsage    bool
+	IsRemote       bool
+	TagsFromLabels map[string]string
+	IgnoreTags     []string
 }
 
 type RedisCounters struct {

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -93,7 +93,9 @@ const (
 	Merge                = "merges"
 	Message              = "messages"
 	MilliSecond          = "milliseconds"
+	Microsecond          = "microseconds"
 	Nanosecond           = "nanoseconds"
+	CPUshare             = "cpushares" // Docker CPU shares
 	Node                 = "nodes"
 	Ok                   = "ok" // "OK" or not status, 0 = ok, 1 = not ok
 	Operation            = "Operations"

--- a/vendor/github.com/google/cadvisor/info/v1/container.go
+++ b/vendor/github.com/google/cadvisor/info/v1/container.go
@@ -266,7 +266,7 @@ type LoadStats struct {
 // CPU usage time statistics.
 type CpuUsage struct {
 	// Total CPU usage.
-	// Units: nanoseconds
+	// Unit: nanoseconds.
 	Total uint64 `json:"total"`
 
 	// Per CPU/core usage of the container.
@@ -274,17 +274,31 @@ type CpuUsage struct {
 	PerCpu []uint64 `json:"per_cpu_usage,omitempty"`
 
 	// Time spent in user space.
-	// Unit: nanoseconds
+	// Unit: nanoseconds.
 	User uint64 `json:"user"`
 
 	// Time spent in kernel space.
-	// Unit: nanoseconds
+	// Unit: nanoseconds.
 	System uint64 `json:"system"`
+}
+
+// Cpu Completely Fair Scheduler statistics.
+type CpuCFS struct {
+	// Total number of elapsed enforcement intervals.
+	Periods uint64 `json:"periods"`
+
+	// Total number of times tasks in the cgroup have been throttled.
+	ThrottledPeriods uint64 `json:"throttled_periods"`
+
+	// Total time duration for which tasks in the cgroup have been throttled.
+	// Unit: nanoseconds.
+	ThrottledTime uint64 `json:"throttled_time"`
 }
 
 // All CPU usage metrics are cumulative from the creation of the container
 type CpuStats struct {
 	Usage CpuUsage `json:"usage"`
+	CFS   CpuCFS   `json:"cfs"`
 	// Smoothed average of number of runnable threads x 1000.
 	// We multiply by thousand to avoid using floats, but preserving precision.
 	// Load is smoothed over the last 10 seconds. Instantaneous value can be read
@@ -293,9 +307,10 @@ type CpuStats struct {
 }
 
 type PerDiskStats struct {
-	Major uint64            `json:"major"`
-	Minor uint64            `json:"minor"`
-	Stats map[string]uint64 `json:"stats"`
+	Device string            `json:"-"`
+	Major  uint64            `json:"major"`
+	Minor  uint64            `json:"minor"`
+	Stats  map[string]uint64 `json:"stats"`
 }
 
 type DiskIoStats struct {
@@ -323,6 +338,10 @@ type MemoryStats struct {
 	// hugepages).
 	// Units: Bytes.
 	RSS uint64 `json:"rss"`
+
+	// The amount of swap currently used by the processes in this cgroup
+	// Units: Bytes.
+	Swap uint64 `json:"swap"`
 
 	// The amount of working set memory, this includes recently accessed memory,
 	// dirty memory, and kernel memory. Working set is <= "usage".
@@ -368,36 +387,57 @@ type NetworkStats struct {
 	Tcp TcpStat `json:"tcp"`
 	// TCP6 connection stats (Established, Listen...)
 	Tcp6 TcpStat `json:"tcp6"`
+	// UDP connection stats
+	Udp UdpStat `json:"udp"`
+	// UDP6 connection stats
+	Udp6 UdpStat `json:"udp6"`
 }
 
 type TcpStat struct {
-	//Count of TCP connections in state "Established"
+	// Count of TCP connections in state "Established"
 	Established uint64
-	//Count of TCP connections in state "Syn_Sent"
+	// Count of TCP connections in state "Syn_Sent"
 	SynSent uint64
-	//Count of TCP connections in state "Syn_Recv"
+	// Count of TCP connections in state "Syn_Recv"
 	SynRecv uint64
-	//Count of TCP connections in state "Fin_Wait1"
+	// Count of TCP connections in state "Fin_Wait1"
 	FinWait1 uint64
-	//Count of TCP connections in state "Fin_Wait2"
+	// Count of TCP connections in state "Fin_Wait2"
 	FinWait2 uint64
-	//Count of TCP connections in state "Time_Wait
+	// Count of TCP connections in state "Time_Wait
 	TimeWait uint64
-	//Count of TCP connections in state "Close"
+	// Count of TCP connections in state "Close"
 	Close uint64
-	//Count of TCP connections in state "Close_Wait"
+	// Count of TCP connections in state "Close_Wait"
 	CloseWait uint64
-	//Count of TCP connections in state "Listen_Ack"
+	// Count of TCP connections in state "Listen_Ack"
 	LastAck uint64
-	//Count of TCP connections in state "Listen"
+	// Count of TCP connections in state "Listen"
 	Listen uint64
-	//Count of TCP connections in state "Closing"
+	// Count of TCP connections in state "Closing"
 	Closing uint64
+}
+
+type UdpStat struct {
+	// Count of UDP sockets in state "Listen"
+	Listen uint64
+
+	// Count of UDP packets dropped by the IP stack
+	Dropped uint64
+
+	// Count of packets Queued for Receieve
+	RxQueued uint64
+
+	// Count of packets Queued for Transmit
+	TxQueued uint64
 }
 
 type FsStats struct {
 	// The block device name associated with the filesystem.
 	Device string `json:"device,omitempty"`
+
+	// Type of the filesytem.
+	Type string `json:"type"`
 
 	// Number of bytes that can be consumed by the container on this filesystem.
 	Limit uint64 `json:"capacity"`
@@ -411,6 +451,15 @@ type FsStats struct {
 
 	// Number of bytes available for non-root user.
 	Available uint64 `json:"available"`
+
+	// HasInodes when true, indicates that Inodes info will be available.
+	HasInodes bool `json:"has_inodes"`
+
+	// Number of Inodes
+	Inodes uint64 `json:"inodes"`
+
+	// Number of available Inodes
+	InodesFree uint64 `json:"inodes_free"`
 
 	// Number of reads completed
 	// This is the total number of reads completed successfully.
@@ -481,7 +530,7 @@ type ContainerStats struct {
 	// Task load stats
 	TaskStats LoadStats `json:"task_stats,omitempty"`
 
-	//Custom metrics from all collectors
+	// Custom metrics from all collectors
 	CustomMetrics map[string][]MetricVal `json:"custom_metrics,omitempty"`
 }
 

--- a/vendor/github.com/google/cadvisor/info/v1/docker.go
+++ b/vendor/github.com/google/cadvisor/info/v1/docker.go
@@ -1,0 +1,38 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Types used for docker containers.
+package v1
+
+type DockerStatus struct {
+	Version       string            `json:"version"`
+	APIVersion    string            `json:"api_version"`
+	KernelVersion string            `json:"kernel_version"`
+	OS            string            `json:"os"`
+	Hostname      string            `json:"hostname"`
+	RootDir       string            `json:"root_dir"`
+	Driver        string            `json:"driver"`
+	DriverStatus  map[string]string `json:"driver_status"`
+	ExecDriver    string            `json:"exec_driver"`
+	NumImages     int               `json:"num_images"`
+	NumContainers int               `json:"num_containers"`
+}
+
+type DockerImage struct {
+	ID          string   `json:"id"`
+	RepoTags    []string `json:"repo_tags"` // repository name and tags.
+	Created     int64    `json:"created"`   // unix time since creation.
+	VirtualSize int64    `json:"virtual_size"`
+	Size        int64    `json:"size"`
+}

--- a/vendor/github.com/google/cadvisor/info/v1/machine.go
+++ b/vendor/github.com/google/cadvisor/info/v1/machine.go
@@ -17,9 +17,22 @@ package v1
 type FsInfo struct {
 	// Block device associated with the filesystem.
 	Device string `json:"device"`
+	// DeviceMajor is the major identifier of the device, used for correlation with blkio stats
+	DeviceMajor uint64 `json:"-"`
+	// DeviceMinor is the minor identifier of the device, used for correlation with blkio stats
+	DeviceMinor uint64 `json:"-"`
 
 	// Total number of bytes available on the filesystem.
 	Capacity uint64 `json:"capacity"`
+
+	// Type of device.
+	Type string `json:"type"`
+
+	// Total number of inodes available on the filesystem.
+	Inodes uint64 `json:"inodes"`
+
+	// HasInodes when true, indicates that Inodes info will be available.
+	HasInodes bool `json:"has_inodes"`
 }
 
 type Node struct {
@@ -115,10 +128,11 @@ type NetInfo struct {
 type CloudProvider string
 
 const (
-	GCE            CloudProvider = "GCE"
-	AWS                          = "AWS"
-	Baremetal                    = "Baremetal"
-	UnkownProvider               = "Unknown"
+	GCE             CloudProvider = "GCE"
+	AWS                           = "AWS"
+	Azure                         = "Azure"
+	Baremetal                     = "Baremetal"
+	UnknownProvider               = "Unknown"
 )
 
 type InstanceType string
@@ -126,6 +140,12 @@ type InstanceType string
 const (
 	NoInstance      InstanceType = "None"
 	UnknownInstance              = "Unknown"
+)
+
+type InstanceID string
+
+const (
+	UnNamedInstance InstanceID = "None"
 )
 
 type MachineInfo struct {
@@ -165,6 +185,9 @@ type MachineInfo struct {
 
 	// Type of cloud instance (e.g. GCE standard) the machine is.
 	InstanceType InstanceType `json:"instance_type"`
+
+	// ID of cloud instance (e.g. instance-1) given to it by the cloud provider.
+	InstanceID InstanceID `json:"instance_id"`
 }
 
 type VersionInfo struct {
@@ -176,6 +199,9 @@ type VersionInfo struct {
 
 	// Docker version.
 	DockerVersion string `json:"docker_version"`
+
+	// Docker API Version
+	DockerAPIVersion string `json:"docker_api_version"`
 
 	// cAdvisor version.
 	CadvisorVersion string `json:"cadvisor_version"`

--- a/vendor/github.com/google/cadvisor/info/v1/metric.go
+++ b/vendor/github.com/google/cadvisor/info/v1/metric.go
@@ -26,10 +26,10 @@ const (
 	MetricGauge MetricType = "gauge"
 
 	// A counter-like value that is only expected to increase.
-	MetricCumulative = "cumulative"
+	MetricCumulative MetricType = "cumulative"
 
 	// Rate over a time period.
-	MetricDelta = "delta"
+	MetricDelta MetricType = "delta"
 )
 
 // DataType for metric being exported.
@@ -37,7 +37,7 @@ type DataType string
 
 const (
 	IntType   DataType = "int"
-	FloatType          = "float"
+	FloatType DataType = "float"
 )
 
 // Spec for custom metric.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -421,13 +421,13 @@
 		},
 		{
 			"path": "github.com/google/cadvisor/client",
-			"revision": "e9739af18411bcd6fc45b1094867d01b1f8cb48e",
-			"revisionTime": "2016-02-12T14:43:45-08:00"
+			"revision": "f0cc82200ab84c0106063a0d0c2b89b674c0b818",
+			"revisionTime": "2017-05-31T23:00:16Z"
 		},
 		{
 			"path": "github.com/google/cadvisor/info/v1",
-			"revision": "e9739af18411bcd6fc45b1094867d01b1f8cb48e",
-			"revisionTime": "2016-02-12T14:43:45-08:00"
+			"revision": "f0cc82200ab84c0106063a0d0c2b89b674c0b818",
+			"revisionTime": "2017-05-31T23:00:16Z"
 		},
 		{
 			"path": "github.com/google/go-github/github",


### PR DESCRIPTION
Increase the capabilities of the cadvisor collector.
This includes:
* Extra cpu metrics: quota, shares and period
* Extra memory metrics: cache, rss, swap, failcnt, limit, reservation, swaplimit
* New option TagsFromLabels. Enabling adding custom tags based on labels.
* New option IgnoreTags. Enable removing tags.
* Update cadvisor vendor client
