### PR TITLE
ElasticIndexDetails IP field is not an array

### DIFF
--- a/cmd/scollector/collectors/elasticsearch.go
+++ b/cmd/scollector/collectors/elasticsearch.go
@@ -499,7 +499,7 @@ type ElasticClusterStats struct {
 			TotalOpened int `json:"total_opened"`
 		} `json:"http"`
 		Indices ElasticIndexDetails `json:"indices" exclude:"true"` // Stored under elastic.indices.local namespace.
-		IP      []string            `json:"ip" exclude:"true"`
+		IP      string            `json:"ip" exclude:"true"`
 		JVM     struct {
 			BufferPools struct {
 				Direct struct {


### PR DESCRIPTION
The elasticsearch collector was failing due to:
`scollector[13949]: error: interval.go:65: elasticsearch: json: cannot unmarshal string into Go struct field .ip of type []string`

On my elasticsearch 5.x node:

`elastic-1:~# curl localhost:9200/_nodes/_local/stats`
`... ,"ip":"172.16.0.19:9300",....`

So this PR fixes it, although I have a single node cluster, so I dont really know if this response would be different with more nodes