### PR TITLE
cmd/scollector: Fixed bug in ElasticSearch collector for Elastic 5.x

### DIFF
--- a/cmd/scollector/collectors/elasticsearch.go
+++ b/cmd/scollector/collectors/elasticsearch.go
@@ -499,8 +499,8 @@ type ElasticClusterStats struct {
 			TotalOpened int `json:"total_opened"`
 		} `json:"http"`
 		Indices ElasticIndexDetails `json:"indices" exclude:"true"` // Stored under elastic.indices.local namespace.
-		IP      []string            `json:"ip" exclude:"true"`
-		JVM     struct {
+		//IP      []string            `json:"ip" exclude:"true"`	// Incompatible format between 5.x and previous, and not used in collector
+		JVM struct {
 			BufferPools struct {
 				Direct struct {
 					Count                int `json:"count"`


### PR DESCRIPTION
Elastic 5.x route of `/_nodes/_local/stats` emits a single IP address,
such as

```
"ip": "10.7.1.74:9300"
````

However prior to v5 this is an array:

```
"ip": [
	"10.7.1.74:9300"
],
```

We do not use the IP address attribute from this route anywhere in the
collector, so removing it from the JSON decoding stops the error, and has no
impact on the collectors functionality (apart from making it work again).