### PR TITLE
iterable: use status.io api

### DIFF
--- a/cmd/scollector/collectors/fastly.go
+++ b/cmd/scollector/collectors/fastly.go
@@ -1,6 +1,7 @@
 package collectors
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -67,6 +68,7 @@ const (
 	fastlyScheduledMaintDesc       = "The number of currently scheduled maintenances. Does not include maintenance that is current active"
 	fastlyActiveScheduledMaintDesc = "The number of currently scheduled maintenances currently in progress. Includes the 'in_progress' and 'verifying'"
 	fastlyActiveIncidentDesc       = "The number of currently active incidents. Includes the 'investingating', 'identified', and 'monitoring' states."
+	fastlyMaxDuration              = 3 * time.Minute
 )
 
 var (
@@ -76,7 +78,9 @@ var (
 func c_fastly_status(baseAddr string) (opentsdb.MultiDataPoint, error) {
 	var md opentsdb.MultiDataPoint
 	c := statusio.NewClient(baseAddr)
-	summary, err := c.GetSummary()
+	ctx, cancel := context.WithTimeout(context.Background(), fastlyMaxDuration)
+	defer cancel()
+	summary, err := c.GetSummary(ctx)
 	if err != nil {
 		return md, err
 	}

--- a/cmd/scollector/collectors/fastly.go
+++ b/cmd/scollector/collectors/fastly.go
@@ -68,7 +68,7 @@ const (
 	fastlyScheduledMaintDesc       = "The number of currently scheduled maintenances. Does not include maintenance that is current active"
 	fastlyActiveScheduledMaintDesc = "The number of currently scheduled maintenances currently in progress. Includes the 'in_progress' and 'verifying'"
 	fastlyActiveIncidentDesc       = "The number of currently active incidents. Includes the 'investingating', 'identified', and 'monitoring' states."
-	fastlyMaxDuration              = 3 * time.Minute
+	fastlyMaxDuration              = 1 * time.Minute
 )
 
 var (

--- a/cmd/scollector/collectors/iterable.go
+++ b/cmd/scollector/collectors/iterable.go
@@ -1,0 +1,95 @@
+package collectors
+
+import (
+	"context"
+	"time"
+
+	"bosun.org/cmd/scollector/conf"
+	"bosun.org/metadata"
+	"bosun.org/opentsdb"
+	"bosun.org/slog"
+	"github.com/bosun-monitor/statusio"
+)
+
+// iterable.io collector
+// to use add this in your scollector.toml:
+// [Iterable]
+//   StatusBaseAddr = "https://iterable.statuspage.io"
+//   # TsdbPrefix = "iterable.status."
+//   # MaxDuration = 3 # seconds
+
+type IterComp map[string]string
+
+func init() {
+	const (
+		defaultStatusBaseAddr = "https://iterable.statuspage.io"
+		defaultTsdbPrefix     = "iterable.status."
+		defaultMaxDuration    = 3 // Seconds
+	)
+
+	// components that we care about
+	// mapped to their tsdb key
+	// name => key
+	var componentKey = IterComp{
+		"Web Application": "webapp",
+		"API":             "api",
+		"Email Sending":   "email.sending",
+		"Email Links":     "email.links",
+		"Workflows":       "workflows",
+		//"Push Sending":    "pushSending",
+		// "SMS Sending": nil,
+		//"System Webhooks":      "systemWebhooks",
+		//"Analytics Processing": "analyticsProcessing",
+		//"List Upload":          "listUpload",
+		"User Updates": "userUpdate",
+	}
+
+	registerInit(func(c *conf.Conf) {
+		// use default values when unspecified
+		iter := c.Iterable
+		if iter.StatusBaseAddr == "" {
+			slog.Warningf("No StatusBaseAddr given, using: '%s'", defaultStatusBaseAddr)
+			iter.StatusBaseAddr = defaultStatusBaseAddr
+		}
+		if iter.TsdbPrefix == "" {
+			iter.TsdbPrefix = defaultTsdbPrefix
+		}
+		if iter.MaxDuration == 0 {
+			iter.MaxDuration = defaultMaxDuration
+		}
+		if iter.MaxDuration <= 0 || iter.MaxDuration > 10000000 {
+			slog.Fatalf("Iterable: invalid MaxDuration: %d", iter.MaxDuration)
+		}
+
+		collectors = append(collectors, &IntervalCollector{
+			F: func() (opentsdb.MultiDataPoint, error) {
+				ctx, cancel := context.WithTimeout(context.Background(), time.Duration(iter.MaxDuration)*time.Second)
+				defer cancel()
+				return iterable(ctx, iter, componentKey)
+			},
+			name:     "c_iterable_status",
+			Interval: time.Minute * 5,
+		})
+	})
+}
+
+// iterable() returns the MultiDataPoint with all the interesting
+// components for iterable service.
+// It uses status.io format (and library)
+func iterable(ctx context.Context, iter conf.Iterable, compKey IterComp) (opentsdb.MultiDataPoint, error) {
+	var md opentsdb.MultiDataPoint
+	c := statusio.NewClient(iter.StatusBaseAddr)
+	summary, err := c.GetSummary(ctx)
+	if err != nil {
+		return md, err
+	}
+	for _, comp := range summary.Components {
+		if key, ok := compKey[comp.Name]; ok {
+			// TODO: should Add() support a timeout?
+			Add(&md, iter.TsdbPrefix+key, int(comp.Status), opentsdb.TagSet{},
+				metadata.Gauge, metadata.StatusCode,
+				"Iterable status: 0: Operational, 1: Degraded Performance, 2: Partial Outage, 3: Major Outage.")
+		}
+	}
+	return md, nil
+}

--- a/cmd/scollector/collectors/iterable.go
+++ b/cmd/scollector/collectors/iterable.go
@@ -16,7 +16,7 @@ import (
 // [Iterable]
 //   StatusBaseAddr = "https://iterable.statuspage.io"
 //   # TsdbPrefix = "iterable.status."
-//   # MaxDuration = 3 # seconds
+//   # MaxDuration = "10s"
 
 type IterComp map[string]string
 
@@ -24,7 +24,7 @@ func init() {
 	const (
 		defaultStatusBaseAddr = "https://iterable.statuspage.io"
 		defaultTsdbPrefix     = "iterable.status."
-		defaultMaxDuration    = 3 // Seconds
+		defaultMaxDuration    = conf.Duration(10 * time.Second)
 	)
 
 	// components that we care about
@@ -54,10 +54,10 @@ func init() {
 		if iter.TsdbPrefix == "" {
 			iter.TsdbPrefix = defaultTsdbPrefix
 		}
-		if iter.MaxDuration == 0 {
+		if iter.MaxDuration == conf.Duration(0) {
 			iter.MaxDuration = defaultMaxDuration
 		}
-		if iter.MaxDuration <= 0 || iter.MaxDuration > 10000000 {
+		if iter.MaxDuration <= conf.Duration(0) || iter.MaxDuration > conf.Duration(10000000*time.Second) {
 			slog.Fatalf("Iterable: invalid MaxDuration: %d", iter.MaxDuration)
 		}
 
@@ -85,7 +85,6 @@ func iterable(ctx context.Context, iter conf.Iterable, compKey IterComp) (opents
 	}
 	for _, comp := range summary.Components {
 		if key, ok := compKey[comp.Name]; ok {
-			// TODO: should Add() support a timeout?
 			Add(&md, iter.TsdbPrefix+key, int(comp.Status), opentsdb.TagSet{},
 				metadata.Gauge, metadata.StatusCode,
 				"Iterable status: 0: Operational, 1: Degraded Performance, 2: Partial Outage, 3: Major Outage.")

--- a/cmd/scollector/collectors/iterable_test.go
+++ b/cmd/scollector/collectors/iterable_test.go
@@ -1,0 +1,66 @@
+package collectors
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"bosun.org/cmd/scollector/conf"
+)
+
+func mockServerTooSlow(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	time.Sleep(2 * time.Second)
+	fmt.Fprintln(w, `too late`)
+}
+
+func TestIterableStatSlow(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(mockServerTooSlow))
+	defer ts.Close()
+	iter := conf.Iterable{StatusBaseAddr: ts.URL}
+	compKey := IterComp{"API": "api"}
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	_, err := iterable(ctx, iter, compKey)
+	if err == nil || ctx.Err() != context.DeadlineExceeded {
+		t.Errorf("should have timed out")
+	}
+}
+
+func mockServerAllOk(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprintln(w, allOKAnswer)
+}
+
+func TestIterableStatAllOk(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(mockServerAllOk))
+	defer ts.Close()
+	iter := conf.Iterable{StatusBaseAddr: ts.URL}
+
+	compKey := IterComp{
+		"Web Application": "webapp",
+		"API":             "api",
+		"Email Sending":   "email.sending",
+		"Email Links":     "email.links",
+		"Workflows":       "workflows",
+		"User Updates":    "userUpdate",
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	md, err := iterable(ctx, iter, compKey)
+	if err != nil {
+		t.Errorf("should have no errors: having: %v", err)
+	}
+	for _, dp := range md {
+		if dp.Value != 0 {
+			t.Errorf("%v: value should be 0, having: %v", dp.Metric, dp.Value)
+		}
+	}
+}
+
+// This is something the real server could return
+var allOKAnswer = `{"page":{"id":"hm1wdv9pcjp9","name":"Iterable","url":"http://status.iterable.com","updated_at":"2017-08-22T00:52:57.454Z"},"components":[{"status":"operational","name":"Web Application","created_at":"2013-08-17T00:37:59.490Z","updated_at":"2017-08-22T00:52:55.578Z","position":1,"description":"The Iterable Web Application","showcase":false,"id":"s38dq3d6bvxh","group_id":null,"page_id":"hm1wdv9pcjp9","group":false,"only_show_if_degraded":false},{"status":"operational","name":"API","created_at":"2013-08-16T21:11:07.992Z","updated_at":"2017-08-16T21:52:34.245Z","position":2,"description":"API Endpoints for Email Campaigns","showcase":false,"id":"st4wbr6s52v6","group_id":null,"page_id":"hm1wdv9pcjp9","group":false,"only_show_if_degraded":false},{"status":"operational","name":"Email Sending","created_at":"2013-08-20T21:00:09.890Z","updated_at":"2017-08-14T16:36:39.660Z","position":4,"description":"Email sending service","showcase":false,"id":"ltndy3zzlys0","group_id":null,"page_id":"hm1wdv9pcjp9","group":false,"only_show_if_degraded":false},{"status":"operational","name":"Email Links","created_at":"2013-08-20T21:00:48.129Z","updated_at":"2016-11-16T02:11:53.077Z","position":5,"description":"Tracking events such as converts, clicks, opens","showcase":false,"id":"wk3bhq37zyxz","group_id":null,"page_id":"hm1wdv9pcjp9","group":false,"only_show_if_degraded":false},{"status":"operational","name":"Workflows","created_at":"2013-08-20T21:05:47.820Z","updated_at":"2017-08-22T00:52:57.354Z","position":6,"description":"Tracking links from emails","showcase":false,"id":"69n5wf13fn2j","group_id":null,"page_id":"hm1wdv9pcjp9","group":false,"only_show_if_degraded":false},{"status":"operational","name":"Push Sending","created_at":"2015-04-15T22:35:36.924Z","updated_at":"2017-07-26T18:53:48.983Z","position":7,"description":null,"showcase":false,"id":"2zpszq733pcd","group_id":null,"page_id":"hm1wdv9pcjp9","group":false,"only_show_if_degraded":false},{"status":"operational","name":"SMS Sending","created_at":"2016-11-16T02:10:36.482Z","updated_at":"2017-07-26T18:53:50.249Z","position":8,"description":null,"showcase":false,"id":"q53wf53znzb6","group_id":null,"page_id":"hm1wdv9pcjp9","group":false,"only_show_if_degraded":false},{"status":"operational","name":"System Webhooks","created_at":"2016-11-16T02:10:51.278Z","updated_at":"2017-07-26T18:53:51.171Z","position":9,"description":null,"showcase":false,"id":"tt0nqf58tx3k","group_id":null,"page_id":"hm1wdv9pcjp9","group":false,"only_show_if_degraded":false},{"status":"operational","name":"Analytics Processing","created_at":"2016-11-16T02:14:03.650Z","updated_at":"2017-07-26T18:53:52.430Z","position":10,"description":null,"showcase":false,"id":"gyxps64956z1","group_id":null,"page_id":"hm1wdv9pcjp9","group":false,"only_show_if_degraded":false},{"status":"operational","name":"List Upload","created_at":"2017-03-30T21:48:11.014Z","updated_at":"2017-06-03T01:54:42.602Z","position":11,"description":null,"showcase":false,"id":"xrwfglh220wc","group_id":null,"page_id":"hm1wdv9pcjp9","group":false,"only_show_if_degraded":false}],"incidents":[],"scheduled_maintenances":[],"status":{"indicator":"none","description":"All Systems Operational"}}`

--- a/cmd/scollector/conf/conf.go
+++ b/cmd/scollector/conf/conf.go
@@ -3,6 +3,7 @@ package conf // import "bosun.org/cmd/scollector/conf"
 
 import (
 	"bosun.org/opentsdb"
+	"time"
 )
 
 type Conf struct {
@@ -137,10 +138,22 @@ type Fastly struct {
 	StatusBaseAddr string
 }
 
+// Duration is a time.Duration with a UnmarshalText method so
+// durations can be decoded from TOML.
+type Duration time.Duration
+
+// UnmarshalText is the method called by TOML when decoding a value
+func (d *Duration) UnmarshalText(text []byte) error {
+	var err error
+	t, err := time.ParseDuration(string(text))
+	*d = Duration(t)
+	return err
+}
+
 type Iterable struct {
 	StatusBaseAddr string // URL where we get json data
 	TsdbPrefix     string
-	MaxDuration    int // max duration of the http request in seconds
+	MaxDuration    Duration // max duration of the http request in seconds
 }
 
 type GoogleAnalyticsSite struct {

--- a/cmd/scollector/conf/conf.go
+++ b/cmd/scollector/conf/conf.go
@@ -96,6 +96,7 @@ type Conf struct {
 	HbaseRegions        bool
 	Oracles             []Oracle
 	Fastly              []Fastly
+	Iterable            Iterable
 }
 
 type HAProxy struct {
@@ -134,6 +135,12 @@ type GoogleWebmaster struct {
 type Fastly struct {
 	Key            string
 	StatusBaseAddr string
+}
+
+type Iterable struct {
+	StatusBaseAddr string // URL where we get json data
+	TsdbPrefix     string
+	MaxDuration    int // max duration of the http request in seconds
 }
 
 type GoogleAnalyticsSite struct {

--- a/vendor/github.com/bosun-monitor/statusio/statusio.go
+++ b/vendor/github.com/bosun-monitor/statusio/statusio.go
@@ -2,6 +2,7 @@
 package statusio
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -15,14 +16,26 @@ import (
 type Client struct {
 	baseAddr string
 	client   *http.Client
+	scheme   string
+}
+
+// extractScheme detects if the url is http instead of https
+func extractScheme(rawurl string) (scheme, baseAddr string) {
+	u, err := url.Parse(rawurl)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "https", rawurl
+	}
+	return u.Scheme, u.Host
 }
 
 // NewClient creates a new statusio client for the *public api*.
 // baseAddr is i.e. status.example.copm/api/v2/
 func NewClient(baseAddr string) *Client {
+	scheme, baseAddr := extractScheme(baseAddr)
 	return &Client{
 		baseAddr: baseAddr,
 		client:   &http.Client{},
+		scheme:   scheme,
 	}
 }
 
@@ -38,9 +51,9 @@ type SummaryResponse struct {
 }
 
 // GetSummary returns a summary of the status page, including a status indicator, component statuses, unresolved incidents, and any upcoming or in-progress scheduled maintenances.
-func (c *Client) GetSummary() (SummaryResponse, error) {
+func (c *Client) GetSummary(ctx context.Context) (SummaryResponse, error) {
 	s := SummaryResponse{}
-	err := c.request("api/v2/summary.json", &s)
+	err := c.request(ctx, "api/v2/summary.json", &s)
 	return s, err
 }
 
@@ -54,9 +67,9 @@ type StatusResponse struct {
 
 // GetStatus returns rollup for the whole page. This endpoint includes an indicator - one of none, minor, major, or critical, as well as a human description of the blended component status.
 // Examples of the blended status include "All Systems Operational", "Partial System Outage", and "Major Service Outage".
-func (c *Client) GetStatus() (StatusResponse, error) {
+func (c *Client) GetStatus(ctx context.Context) (StatusResponse, error) {
 	s := StatusResponse{}
-	err := c.request("api/v2/status.json", &s)
+	err := c.request(ctx, "api/v2/status.json", &s)
 	return s, err
 }
 
@@ -66,9 +79,9 @@ type ComponentsResponse struct {
 }
 
 // GetComponents gets the components for the page. Each component is listed along with its status - one of operational, degraded_performance, partial_outage, or major_outage.
-func (c *Client) GetComponents() (ComponentsResponse, error) {
+func (c *Client) GetComponents(ctx context.Context) (ComponentsResponse, error) {
 	comp := ComponentsResponse{}
-	err := c.request("api/v2/components.json", &comp)
+	err := c.request(ctx, "api/v2/components.json", &comp)
 	return comp, err
 }
 
@@ -79,17 +92,17 @@ type IncidentsResponse struct {
 
 // GetUnresolvedIncidents gets a list of any unresolved incidents.
 // This endpoint will only return incidents in the Investigating, Identified, or Monitoring state.
-func (c *Client) GetUnresolvedIncidents() (IncidentsResponse, error) {
+func (c *Client) GetUnresolvedIncidents(ctx context.Context) (IncidentsResponse, error) {
 	i := IncidentsResponse{}
-	err := c.request("api/v2/incidents/unresolved.json", &i)
+	err := c.request(ctx, "api/v2/incidents/unresolved.json", &i)
 	return i, err
 }
 
 // GetIncidents returns a list of the 50 most recent incidents.
 // This includes all unresolved incidents returned in GetUnresolvedIncidents, as well as those in the Resolved and Postmortem state.
-func (c *Client) GetIncidents() (IncidentsResponse, error) {
+func (c *Client) GetIncidents(ctx context.Context) (IncidentsResponse, error) {
 	i := IncidentsResponse{}
-	err := c.request("api/v2/incidents.json", &i)
+	err := c.request(ctx, "api/v2/incidents.json", &i)
 	return i, err
 }
 
@@ -100,24 +113,24 @@ type ScheduledMaintenancesResponse struct {
 
 // GetUpcomingScheduledMaintenances gets a list of any upcoming maintenances.
 // This endpoint will only return scheduled maintenances still in the Scheduled state.
-func (c *Client) GetUpcomingScheduledMaintenances() (ScheduledMaintenancesResponse, error) {
+func (c *Client) GetUpcomingScheduledMaintenances(ctx context.Context) (ScheduledMaintenancesResponse, error) {
 	s := ScheduledMaintenancesResponse{}
-	err := c.request("api/v2/scheduled-maintenances/upcoming.json", &s)
+	err := c.request(ctx, "api/v2/scheduled-maintenances/upcoming.json", &s)
 	return s, err
 }
 
 // GetActiveScheduledMaintenances gets a list of any upcoming maintenances. // This endpoint will only return scheduled maintenances in the In Progress or Verifying state.
-func (c *Client) GetActiveScheduledMaintenances() (ScheduledMaintenancesResponse, error) {
+func (c *Client) GetActiveScheduledMaintenances(ctx context.Context) (ScheduledMaintenancesResponse, error) {
 	s := ScheduledMaintenancesResponse{}
-	err := c.request("api/v2/scheduled-maintenances/active.json", &s)
+	err := c.request(ctx, "api/v2/scheduled-maintenances/active.json", &s)
 	return s, err
 }
 
 // GetAllScheduledMaintenances gets a list of the 50 most recent scheduled maintenances.
 // This includes scheduled maintenances as described in the above two endpoints, as well as those in the Completed state.
-func (c *Client) GetAllScheduledMaintenances() (ScheduledMaintenancesResponse, error) {
+func (c *Client) GetAllScheduledMaintenances(ctx context.Context) (ScheduledMaintenancesResponse, error) {
 	s := ScheduledMaintenancesResponse{}
-	err := c.request("api/v2/scheduled-maintenances.json", &s)
+	err := c.request(ctx, "api/v2/scheduled-maintenances.json", &s)
 	return s, err
 }
 
@@ -138,9 +151,9 @@ func (c *Client) RemoveSubscription() NotImplemented {
 	return true
 }
 
-func (c *Client) request(path string, s interface{}) error {
+func (c *Client) request(ctx context.Context, path string, s interface{}) error {
 	u := &url.URL{
-		Scheme: "https",
+		Scheme: c.scheme,
 		Host:   c.baseAddr,
 		Path:   path,
 	}
@@ -149,6 +162,7 @@ func (c *Client) request(path string, s interface{}) error {
 		slog.Error(err)
 		return err
 	}
+	req = req.WithContext(ctx)
 	req.Header.Set("Accept", "application/json")
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/vendor/github.com/bosun-monitor/statusio/statusio_test.go
+++ b/vendor/github.com/bosun-monitor/statusio/statusio_test.go
@@ -1,0 +1,29 @@
+package statusio
+
+import "testing"
+
+func TestExtractScheme(t *testing.T) {
+	samples := []struct {
+		url      string
+		scheme   string
+		baseAddr string
+	}{
+		// url      =>             scheme, base address
+		{"foo.com", "https", "foo.com"},
+		{"http://foo.com", "http", "foo.com"},
+		{"https://foo.com", "https", "foo.com"},
+		{"http://https://foo.com", "http", "https:"},
+		{"", "https", ""},
+	}
+	for _, s := range samples {
+		scheme, baseAddr := extractScheme(s.url)
+		if scheme != s.scheme {
+			t.Errorf("scheme: got %s, wants: %s (%s)",
+				scheme, s.scheme, s.url)
+		}
+		if baseAddr != s.baseAddr {
+			t.Errorf("baseAddr: got %s, wants: %s (%s)",
+				baseAddr, s.baseAddr, s.url)
+		}
+	}
+}


### PR DESCRIPTION
* add context.Context: timeout for fastly and iterable.

* https support,
* tunings through configuration,
* variables and consts are not global,
* less reliance on states outside of functions.

* has tests

* only monitors according to the plan

https://docs.google.com/document/d/1ZO4fKLGU0WCC9eldOLIvLU80iNEFupcUS9kswclm2Q8/edit?ts=59b9b782#
(section Iterable System Health)