### PR TITLE
Trim "* " prefix from check_status value in HAProxy stats

### DIFF
--- a/cmd/scollector/collectors/haproxy_unix.go
+++ b/cmd/scollector/collectors/haproxy_unix.go
@@ -109,7 +109,7 @@ func haproxyFetch(user, pwd, tier, url string) (opentsdb.MultiDataPoint, error) 
 				if value == "" {
 					continue
 				}
-				v, ok := haproxyCheckStatus[value]
+				v, ok := haproxyCheckStatus[strings.TrimPrefix(value, "* ")]
 				if !ok {
 					return nil, fmt.Errorf("unknown check status %v", value)
 				}


### PR DESCRIPTION
A "* " prefix in the check_status fields means the check is in progress.
This patch fixes the following error message:

    error: interval.go:65: haproxy-1-http://localhost:9001/haproxy;csv: unknown check status * L7OK

On a load balancer with high load and many health check status changes,
data collected during a polling interval were entirely dropped by
scollector each time this error was encountered and the resulting
haproxy.* time series were very scarce.

I haven't found this prefix mentioned in the documentation, but here is
where it happens in HAProxy source code:

http://git.haproxy.org/?p=haproxy-1.7.git;a=blob;f=src/stats.c;h=60b375616d44d8b1b96ed304b0e53316706beee0;hb=640d526f8cdad00f7f5043b51f6a34f3f6ebb49f#l1376
(file src/stats.c, lines 1376 to 1397 on commit tagged v1.7.9)