### PR TITLE
Added info about the built-in MIBs, corrected defaults.

### DIFF
--- a/cmd/scollector/collectors/snmp.go
+++ b/cmd/scollector/collectors/snmp.go
@@ -36,7 +36,7 @@ func SNMP(cfg conf.SNMP, mibs map[string]conf.MIB) error {
 		return fmt.Errorf("empty SNMP community")
 	}
 	if len(cfg.MIBs) == 0 {
-		cfg.MIBs = []string{"ifaces", "cisco", "bridge"}
+		cfg.MIBs = []string{"ifaces", "bridge"}
 	}
 	for _, m := range cfg.MIBs {
 		mib, ok := mibs[m]

--- a/cmd/scollector/doc.go
+++ b/cmd/scollector/doc.go
@@ -151,14 +151,18 @@ to poll. The Instances key is an array of table with keys Tier and URL.
 SNMP (array of table, keys are Community and Host): SNMP hosts to connect
 to at a 5 minute poll interval.
 
+There are several built-in MIBs that are pre-configured, an up-to-date list can be found by looking
+at the code in https://github.com/bosun-monitor/bosun/blob/master/cmd/scollector/collectors/snmp.go
+
 	[[SNMP]]
 	  Community = "com"
 	  Host = "host"
-	  MIBs = ["cisco"]
+	  # Use the built-in "sys" MIB
+	  MIBs = ["sys"]
 	[[SNMP]]
 	  Community = "com2"
 	  Host = "host2"
-	  # List of mibs to run for this host. Default is built-in set of ["ifaces","cisco"]
+	  # List of MIBs to run for this host. Default is built-in set of ["ifaces","bridge"]
 	  MIBs = ["custom", "ifaces"]
 
 MIBs (map of string to table): Allows user-specified, custom SNMP configurations.


### PR DESCRIPTION
Fixes issue https://github.com/bosun-monitor/bosun/issues/2169

 - Added information about the built-in MIBs to the scollector documentation.
 - Removed the incorrect `"cisco"` entry from the list of default MIBs for an SNMP entry.