### PR TITLE
Bosun complaining about `actionBodyForceClose`, `actionBodyDelayedClo` and `actionBodyCancelClose`

### DIFF
--- a/cmd/bosun/conf/rule/loaders.go
+++ b/cmd/bosun/conf/rule/loaders.go
@@ -439,11 +439,14 @@ func (c *Conf) loadNotification(s *parse.SectionNode) {
 				keyType = strings.TrimPrefix(k, "action")
 				at := models.ActionNone
 				// look for and trim suffix if there
+				// trim the templateKey and explicitly match actiontype
 				for s, t := range models.ActionShortNames {
-					if strings.HasSuffix(keyType, s) {
-						at = t
-						keyType = keyType[:len(keyType)-len(s)]
-						break
+					for _, e := range []string{"Body", "Get", "EmailSubject"} {
+						if strings.Compare(strings.TrimPrefix(keyType, e), s) == 0 {
+							at = t
+							keyType = keyType[:len(keyType)-len(s)]
+							break
+						}
 					}
 				}
 				if n.ActionTemplateKeys[at] == nil {


### PR DESCRIPTION
Bosun complaining about `actionBodyForceClose`, `actionBodyDelayedClose`, and `actionBodyCancelClose` intermediately and causing crash with error `couldn't read rules: unknown key actionBodyDelayedClose` after looking at the code cmd/bosun/conf/rule/loaders.go#L442 we found strings.HasSuffix sometime getting matched with 'Close' rather then 'DelayedClose, ForceClose or CancelClose' and later it breaks in the switch statement cmd/bosun/conf/rule/loaders.go#L462 due to invalid template type

Debug log:
```
2017/11/29 11:27:26 enabling syslog
2017/11/29 11:27:26 info: loaders.go:439: Key was: actionBodyDelayedClose
2017/11/29 11:27:26 info: loaders.go:442: Key after trim action: BodyDelayedClose
2017/11/29 11:27:26 info: loaders.go:448: ActionType: Closed
2017/11/29 11:27:26 info: loaders.go:450: Template keyType: BodyDelayed
2017/11/29 11:27:26 fatal: main.go:119: couldn't read rules: conf: test01.conf:34:3: at <actionBodyDelayedClo...>: unknown key actionBodyDelayedClose
```

In this patch, we try to match the actionType explicitly with strings.Compare