### PR TITLE
Fix macros for Notifications

### DIFF
--- a/cmd/bosun/conf/rule/rule.go
+++ b/cmd/bosun/conf/rule/rule.go
@@ -179,8 +179,8 @@ func NewConf(name string, backends conf.EnabledBackends, sysVars map[string]stri
 	}
 
 	loadSections("template")
-	loadSections("notification")
 	loadSections("macro")
+	loadSections("notification")
 	loadSections("lookup")
 	loadSections("alert")
 


### PR DESCRIPTION
Load `macros` before notifications, so that we can able use it in notifications which will reduce the duplications.

https://github.com/bosun-monitor/bosun/issues/2194  