### PR TITLE
fixes 2211

### DIFF
--- a/opentsdb/tsdb.go
+++ b/opentsdb/tsdb.go
@@ -582,7 +582,9 @@ func ParseFilters(rawFilters string, grouping bool, q *Query) ([]Filter, error) 
 		}
 		filter := Filter{}
 		filter.TagK = splitRawFilter[0]
-		q.GroupByTags[filter.TagK] = ""
+		if grouping {
+			q.GroupByTags[filter.TagK] = ""
+		}
 		// See if we have a filter function, if not we have to use legacy parsing defined in
 		// filter conversions of http://opentsdb.net/docs/build/html/api_http/query/index.html
 		m := filterValueRe.FindStringSubmatch(splitRawFilter[1])

--- a/opentsdb/tsdb_test.go
+++ b/opentsdb/tsdb_test.go
@@ -138,6 +138,24 @@ func TestParseRequestV2_2(t *testing.T) {
 		}
 	}
 }
+func TestTagGroupParsing(t *testing.T) {
+	tests := []struct {
+		query  string
+		groups string
+	}{
+		{"sum:10m-avg:proc.stat.cpu{}{t=v,o=k}", "{}"},
+		{"sum:10m-avg:proc.stat.cpu{dc=uk}{t=v,o=k}", "{dc=}"},
+	}
+	for _, q := range tests {
+		r, err := ParseQuery(q.query, Version2_2)
+		if err == nil {
+			if r.GroupByTags.String() != q.groups {
+				t.Errorf("expected group tags %s got %s", q.groups, r.GroupByTags)
+			}
+
+		}
+	}
+}
 
 func TestParseFilters(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
opentsdb/tsdb:      Fix parsing of 2.2+ filters so that only group terms get added to the result tag set
opentsdb/test_test: Add test cases to validate that the result tag set is being correctly populated