### PR TITLE
Added a incident filter called "since"

### DIFF
--- a/cmd/bosun/sched/views.go
+++ b/cmd/bosun/sched/views.go
@@ -60,6 +60,7 @@ type IncidentSummaryView struct {
 	Events                 []EventSummary
 	WarnNotificationChains [][]string
 	CritNotificationChains [][]string
+	LastStatusTime         int64
 }
 
 func MakeIncidentSummary(c conf.RuleConfProvider, s SilenceTester, is *models.IncidentState) (*IncidentSummaryView, error) {
@@ -107,6 +108,7 @@ func MakeIncidentSummary(c conf.RuleConfProvider, s SilenceTester, is *models.In
 		Events:                 eventSummaries,
 		WarnNotificationChains: conf.GetNotificationChains(warnNotifications),
 		CritNotificationChains: conf.GetNotificationChains(critNotifications),
+		LastStatusTime:         is.Last().Time.Unix(),
 	}, nil
 }
 
@@ -237,6 +239,8 @@ func (is IncidentSummaryView) Ask(filter string) (bool, error) {
 		return is.LastAbnormalStatus.String() == value, nil
 	case "subject":
 		return glob.Glob(value, is.Subject), nil
+	case "since":
+		return checkTimeArg(is.LastStatusTime, value)
 	}
 	return false, nil
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -161,6 +161,16 @@ The open incident filter supports joining terms in `()` as well as the `AND`, `O
         <td><code>subject:(something*)</code></td>
         <td>Returns incidents where the subject string matches the value. Globs can be used in the value</td>
     </tr>
+    <tr>
+        <td><code>since:[<|>](1d)</code> </td>
+        <td>Returns incidents that in `status` more than <code><</code> or incidents that in `status` less than <code>></code> the
+            relative time to now based on the duration. Duration can be in units of s (seconds), m (minutes),
+            h (hours), d (days), w (weeks), n (months), y (years). If less than or greater than are not part
+            of the value, it defaults to greater than (after). Now is clock time and is not related to the time
+            range specified in Grafana.<br>
+            e.g. `status:normal AND since:<15d` return alerts that are in `normal` more than 15 day's
+        </td>
+    </tr>
 </table>
 
 # Rule Editor


### PR DESCRIPTION
Hi,

We often have difficulties to filter out alerts which are in given status (e.g. normal) older than given time (e.g. 1d or 1h).  This new filter will allow us to filter alert with last update time, same as `Current Status since` displayed in the incident page.

e.g. `status:normal AND since:<15d` will display alerts that are in `normal` since 15day's or more.

Thanks,