### PR TITLE
Stop sending mail if 'To' slice empty

### DIFF
--- a/cmd/bosun/conf/notify.go
+++ b/cmd/bosun/conf/notify.go
@@ -188,6 +188,11 @@ func (n *Notification) PrepEmail(subject, body string, ak string, attachments []
 }
 
 func (p *PreparedEmail) Send(c SystemConfProvider) error {
+	// make sure "To" was not null
+	if len(p.To) <= 0 {
+		return nil
+	}
+
 	e := email.NewEmail()
 	e.From = c.GetEmailFrom()
 	for _, a := range p.To {


### PR DESCRIPTION
We have noticed when a post action notification triggered bosun also trying to send mail with empty 'To' address

`2018/02/05 12:15:30 error: notify.go:49: sending email: Must specify at least one From address and one To address
`
`
2018/02/05 12:17:30 error: notify.go:205: failed to send alert  to [] Must specify at least one From address and one To address`

This patch will validate the 'To' address slice length and stop trying sending mail if it's empty

Thanks,