### PR TITLE
Fix notifications log

### DIFF
--- a/cmd/bosun/conf/actionNotify.go
+++ b/cmd/bosun/conf/actionNotify.go
@@ -103,6 +103,33 @@ func (n *Notification) PrepareAction(at models.ActionType, t *Template, c System
 		}
 		return buf.String(), nil
 	}
-	n.prepareFromTemplateKeys(pn, *tks, render, actionDefaults)
+
+	ak := map[string][]string{
+		"alert_key": {},
+	}
+
+	for i := range states {
+		contain := func(key string, array []string) bool {
+			for _, value := range array {
+				if value == key {
+					return true
+				}
+			}
+			return false
+		}
+
+		if contain(fmt.Sprint(states[i].AlertKey), ak["alert_key"]) != true {
+			ak["alert_key"] = append(ak["alert_key"], fmt.Sprint(states[i].AlertKey))
+		}
+	}
+
+	details := &NotificationDetails{
+		Ak:          ak["alert_key"],
+		At:          at.String(),
+		NotifyName:  n.Name,
+		TemplateKey: tks.BodyTemplate,
+	}
+
+	n.prepareFromTemplateKeys(pn, *tks, render, actionDefaults, details)
 	return pn
 }

--- a/cmd/bosun/conf/notify.go
+++ b/cmd/bosun/conf/notify.go
@@ -78,7 +78,13 @@ func (n *Notification) PrepareAlert(rt *models.RenderedTemplates, ak string, att
 			url = rt.Get(n.PostTemplate)
 		}
 		body := rt.GetDefault(n.BodyTemplate, "subject")
-		pn.HTTP = append(pn.HTTP, n.PrepHttp("POST", url, body, ak))
+		details := &NotificationDetails{
+			Ak:          []string{ak},
+			NotifyName:  n.Name,
+			TemplateKey: n.BodyTemplate,
+			NotifyType:  1,
+		}
+		pn.HTTP = append(pn.HTTP, n.PrepHttp("POST", url, body, details))
 	}
 	if n.Get != nil || n.GetTemplate != "" {
 		url := ""
@@ -87,7 +93,13 @@ func (n *Notification) PrepareAlert(rt *models.RenderedTemplates, ak string, att
 		} else {
 			url = rt.Get(n.GetTemplate)
 		}
-		pn.HTTP = append(pn.HTTP, n.PrepHttp("GET", url, "", ak))
+		details := &NotificationDetails{
+			Ak:          []string{ak},
+			NotifyName:  n.Name,
+			TemplateKey: n.BodyTemplate,
+			NotifyType:  1,
+		}
+		pn.HTTP = append(pn.HTTP, n.PrepHttp("GET", url, "", details))
 	}
 	if n.Print {
 		if n.BodyTemplate != "" {
@@ -105,12 +117,25 @@ func (n *Notification) NotifyAlert(rt *models.RenderedTemplates, c SystemConfPro
 }
 
 type PreparedHttp struct {
-	URL        string
-	Method     string
-	Headers    map[string]string `json:",omitempty"`
-	Body       string
-	AK         string
-	NotifyName string
+	URL     string
+	Method  string
+	Headers map[string]string `json:",omitempty"`
+	Body    string
+	Details *NotificationDetails
+}
+
+const (
+	alert = iota + 1
+	unknown
+	multiunknown
+)
+
+type NotificationDetails struct {
+	Ak          []string // alert key
+	At          string   // action type
+	NotifyName  string   // notification name
+	TemplateKey string   // template key
+	NotifyType  int      // notifications type e.g alert, unknown etc
 }
 
 func (p *PreparedHttp) Send() (int, error) {
@@ -136,19 +161,31 @@ func (p *PreparedHttp) Send() (int, error) {
 	}
 	if resp.StatusCode >= 300 {
 		collect.Add("post.sent_failed", nil, 1)
-		return resp.StatusCode, fmt.Errorf("bad response on notification with name %s for alert %s method %s: %d", p.NotifyName, p.AK, p.Method, resp.StatusCode)
+		switch p.Details.NotifyType {
+		case alert:
+			return resp.StatusCode, fmt.Errorf("bad response for '%s' alert notification using template key '%s' for alert keys %v method %s: %d",
+				p.Details.NotifyName, p.Details.TemplateKey, strings.Join(p.Details.Ak, ","), p.Method, resp.StatusCode)
+		case unknown:
+			return resp.StatusCode, fmt.Errorf("bad response for '%s' unknown notification using template key '%s' for alert keys %v method %s: %d",
+				p.Details.NotifyName, p.Details.TemplateKey, strings.Join(p.Details.Ak, ","), p.Method, resp.StatusCode)
+		case multiunknown:
+			return resp.StatusCode, fmt.Errorf("bad response for '%s' multi-unknown notification using template key '%s' for alert keys %v method %s: %d",
+				p.Details.NotifyName, p.Details.TemplateKey, strings.Join(p.Details.Ak, ","), p.Method, resp.StatusCode)
+		default:
+			return resp.StatusCode, fmt.Errorf("bad response for '%s' action '%s' notification using template key '%s' for alert keys %v method %s: %d",
+				p.Details.NotifyName, p.Details.At, p.Details.TemplateKey, strings.Join(p.Details.Ak, ","), p.Method, resp.StatusCode)
+		}
 	}
 	collect.Add("post.sent", nil, 1)
 	return resp.StatusCode, nil
 }
 
-func (n *Notification) PrepHttp(method string, url string, body string, ak string) *PreparedHttp {
+func (n *Notification) PrepHttp(method string, url string, body string, alertDetails *NotificationDetails) *PreparedHttp {
 	prep := &PreparedHttp{
-		Method:     method,
-		URL:        url,
-		Headers:    map[string]string{},
-		AK:         ak,
-		NotifyName: n.Name,
+		Method:  method,
+		URL:     url,
+		Headers: map[string]string{},
+		Details: alertDetails,
 	}
 	if method == http.MethodPost {
 		prep.Body = body
@@ -157,13 +194,14 @@ func (n *Notification) PrepHttp(method string, url string, body string, ak strin
 	return prep
 }
 
-func (n *Notification) SendHttp(method string, url string, body string, ak string) {
-	p := n.PrepHttp(method, url, body, ak)
+func (n *Notification) SendHttp(method string, url string, body string) {
+	details := &NotificationDetails{}
+	p := n.PrepHttp(method, url, body, details)
 	stat, err := p.Send()
 	if err != nil {
 		slog.Errorf("Sending http notification: %s", err)
 	}
-	slog.Infof("%s notification successful for alert %s. Status: %d", method, ak, stat)
+	slog.Infof("%s notification successful for alert %s. Status: %d", method, details.Ak, stat)
 }
 
 type PreparedEmail struct {


### PR DESCRIPTION
This is follow up to our last PR #2196, we still having difficulties to trace notifications failures due to missing alert key's for action and unknown notifications e.g. mentioned below is an error sample we are getting more often  

`2018/02/08 16:31:44 error: notify.go:55: sending http: bad response on notification with name memcached_pagerduty for alert  method POST: 400`

As you can see it's very difficult to find out details like for which alert it's failing and either it's an action notification or an unknown etc, with this change we will be able to get more details e.g 

`2018/02/09 15:28:06 error: notify.go:56: sending http: bad response for 'memcached_pagerduty' unknown notification using template key '' for alert keys memcached_memory_usage{host=XXXXXXX} method POST: 400`

With above we can see the `unknown` notification is failing due to missing template key and bosun trying to render the default HTML template which in this case will fail because PagerDuty event requires JSON.

Thanks,