### PR TITLE
Added new api endpoint /api/debug/{key}

### DIFF
--- a/cmd/bosun/conf/notify.go
+++ b/cmd/bosun/conf/notify.go
@@ -27,6 +27,12 @@ func init() {
 	metadata.AddMetricMeta(
 		"bosun.email.sent_failed", metadata.Counter, metadata.PerSecond,
 		"The number of email notifications that Bosun failed to send.")
+	metadata.AddMetricMeta(
+		"bosun.post.sent", metadata.Counter, metadata.PerSecond,
+		"The number of post notifications sent by Bosun.")
+	metadata.AddMetricMeta(
+		"bosun.post.sent_failed", metadata.Counter, metadata.PerSecond,
+		"The number of post notifications that Bosun failed to send.")
 }
 
 type PreparedNotifications struct {
@@ -129,8 +135,10 @@ func (p *PreparedHttp) Send() (int, error) {
 		return 0, err
 	}
 	if resp.StatusCode >= 300 {
+		collect.Add("post.sent_failed", nil, 1)
 		return resp.StatusCode, fmt.Errorf("bad response on notification with name %s for alert %s method %s: %d", p.NotifyName, p.AK, p.Method, resp.StatusCode)
 	}
+	collect.Add("post.sent", nil, 1)
 	return resp.StatusCode, nil
 }
 

--- a/cmd/bosun/web/web.go
+++ b/cmd/bosun/web/web.go
@@ -154,7 +154,6 @@ func Listen(httpAddr, httpsAddr, certFile, keyFile string, devMode bool, tsdbHos
 	handle("/api/graph", JSON(Graph), canViewDash).Name("graph").Methods(GET)
 
 	handle("/api/health", JSON(HealthCheck), fullyOpen).Name("health_check").Methods(GET)
-	handle("/api/debug/{key}", JSON(DebugStats), fullyOpen).Name("debug_stats").Methods(GET)
 	handle("/api/host", JSON(Host), canViewDash).Name("host").Methods(GET)
 	handle("/api/last", JSON(Last), canViewDash).Name("last").Methods(GET)
 	handle("/api/quiet", JSON(Quiet), canViewDash).Name("quiet").Methods(GET)
@@ -439,6 +438,15 @@ type Health struct {
 	Quiet         bool
 	UptimeSeconds int64
 	StartEpoch    int64
+	Notifications NotificationStats
+}
+
+type NotificationStats struct {
+	// Post and email notifiaction stats
+	PostNotificationsSuccess  int64
+	PostNotificationsFailed   int64
+	EmailNotificationsSuccess int64
+	EmailNotificationsFailed  int64
 }
 
 func Reload(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (interface{}, error) {
@@ -466,39 +474,20 @@ func Quiet(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (interf
 
 func HealthCheck(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	var h Health
+	var n NotificationStats
 	h.RuleCheck = schedule.LastCheck.After(time.Now().Add(-schedule.SystemConf.GetCheckFrequency()))
 	h.Quiet = schedule.GetQuiet()
 	h.UptimeSeconds = int64(time.Since(startTime).Seconds())
 	h.StartEpoch = startTime.Unix()
+
+	//notifications stats
+	n.PostNotificationsSuccess = collect.Get("post.sent", nil)
+	n.PostNotificationsFailed = collect.Get("post.sent_failed", nil)
+	n.EmailNotificationsSuccess = collect.Get("email.sent", nil)
+	n.EmailNotificationsFailed = collect.Get("email.sent_failed", nil)
+
+	h.Notifications = n
 	return h, nil
-}
-
-type NotificationStats struct {
-	// Post and email notifiaction stats
-	PostNotificationsSuccess  int64
-	PostNotificationsFailed   int64
-	EmailNotificationsSuccess int64
-	EmailNotificationsFailed  int64
-}
-
-func DebugStats(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (interface{}, error) {
-	vars := mux.Vars(r)
-	key := vars["key"]
-
-	switch key {
-	case "notification":
-		var n NotificationStats
-		n.PostNotificationsSuccess = collect.Get("post.sent", nil)
-		n.PostNotificationsFailed = collect.Get("post.sent_failed", nil)
-		n.EmailNotificationsSuccess = collect.Get("email.sent", nil)
-		n.EmailNotificationsFailed = collect.Get("email.sent_failed", nil)
-		return n, nil
-	default:
-		h_out := map[string]string{
-			"msg": fmt.Sprintf("Missing stats for key: %s", key),
-		}
-		return h_out, nil
-	}
 }
 
 func OpenTSDBVersion(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (interface{}, error) {

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -369,6 +369,22 @@ func Add(metric string, ts opentsdb.TagSet, inc int64) error {
 	return nil
 }
 
+func Get(metric string, ts opentsdb.TagSet) int64 {
+	var counter_value int64
+	if err := check(metric, &ts); err != nil {
+		return 0
+	}
+	tss := metric + ts.String()
+	mlock.Lock()
+	if counters[tss] != nil {
+		counter_value = counters[tss].value
+	} else {
+		counter_value = 0
+	}
+	mlock.Unlock()
+	return counter_value
+}
+
 type putMetric struct {
 	metric string
 	ts     opentsdb.TagSet

--- a/docs/api.md
+++ b/docs/api.md
@@ -216,5 +216,15 @@ errors. Returns an error if invalid.
 
 Reloads the rule configuration when `{ "Reload": true }` is POST'd to the endpoint.
 
+## Debug Endpoints
+
+### /api/debug/{key}
+
+Return debug statistics of given key, supported keys are
+
+* notification: Return POST and Email notification failure and success counts
+
+`Note: all debugging stats are kept in memory and reset upon bosun restart`
+
 </div>
 </div>

--- a/docs/api.md
+++ b/docs/api.md
@@ -168,6 +168,8 @@ Returns a list of alert summaries matching the given filter (defaults to all).
 Returns an object of internal health checks. True values are good, falses are
 bad.
 
+`Note: all health checks stats are kept in memory and reset upon bosun restart`
+
 ### /api/run
 
 Runs a rule check. Returns an error if one is already running (either from the
@@ -215,16 +217,6 @@ errors. Returns an error if invalid.
 ### /api/reload
 
 Reloads the rule configuration when `{ "Reload": true }` is POST'd to the endpoint.
-
-## Debug Endpoints
-
-### /api/debug/{key}
-
-Return debug statistics of given key, supported keys are
-
-* notification: Return POST and Email notification failure and success counts
-
-`Note: all debugging stats are kept in memory and reset upon bosun restart`
 
 </div>
 </div>


### PR DESCRIPTION
Currently, bosun collects a bunch of runtime debug and performance stats and write it back to OpenTSDB. This endpoint will expose these stats,  useful when you are not using Bosun with OpenTSDB.

At present, the endpoint only exposes `notification` success and failure stats but we can add any other stats in future if required.

Thanks,