### PR TITLE
Print `db` as well, when profiling InfluxDB queries

### DIFF
--- a/cmd/bosun/expr/influx.go
+++ b/cmd/bosun/expr/influx.go
@@ -196,7 +196,8 @@ func timeInfluxRequest(e *State, T miniprofiler.Timer, db, query, startDuration,
 	if err != nil {
 		return nil, err
 	}
-	T.StepCustomTiming("influx", "query", q, func() {
+	q_key := fmt.Sprintf("%s: %s", db, q)
+	T.StepCustomTiming("influx", "query", q_key, func() {
 		getFn := func() (interface{}, error) {
 			res, err := conn.Query(client.Query{
 				Command:  q,
@@ -221,7 +222,7 @@ func timeInfluxRequest(e *State, T miniprofiler.Timer, db, query, startDuration,
 		}
 		var val interface{}
 		var ok bool
-		val, err = e.Cache.Get(fmt.Sprintf("%s : %s", db, q), getFn)
+		val, err = e.Cache.Get(q_key, getFn)
 		if s, ok = val.([]influxModels.Row); !ok {
 			err = fmt.Errorf("influx: did not get a valid result from InfluxDB")
 		}


### PR DESCRIPTION
Follow up to #2234
Sorry, you've merged it so fast : )