### PR TITLE
We have noticed sometimes ES config maps are getting conflicts when using multiple ES cluster with client options enable.

### DIFF
--- a/cmd/bosun/conf/system_elastic2.go
+++ b/cmd/bosun/conf/system_elastic2.go
@@ -12,15 +12,18 @@ import (
 // ParseESConfig return expr.ElasticHost
 func parseESConfig(sc *SystemConf) expr.ElasticHosts {
 	var options ESClientOptions
-	esConf := expr.ElasticConfig{}
 	store := make(map[string]expr.ElasticConfig)
 	esHost := expr.ElasticHosts{}
 
-	addClientOptions := func(item elastic.ClientOptionFunc) {
-		esConf.ClientOptionFuncs = append(esConf.ClientOptionFuncs, item)
-	}
-
 	for hostPrefix, value := range sc.ElasticConf {
+		// build es config per cluster
+		esConf := expr.ElasticConfig{}
+
+		// method to append clinet options
+		addClientOptions := func(item elastic.ClientOptionFunc) {
+			esConf.ClientOptionFuncs = append(esConf.ClientOptionFuncs, item)
+		}
+
 		options = value.ClientOptions
 
 		if !options.Enabled {

--- a/cmd/bosun/conf/system_elastic5.go
+++ b/cmd/bosun/conf/system_elastic5.go
@@ -12,15 +12,18 @@ import (
 // ParseESConfig return expr.ElasticHost
 func parseESConfig(sc *SystemConf) expr.ElasticHosts {
 	var options ESClientOptions
-	esConf := expr.ElasticConfig{}
 	store := make(map[string]expr.ElasticConfig)
 	esHost := expr.ElasticHosts{}
 
-	addClientOptions := func(item elastic.ClientOptionFunc) {
-		esConf.ClientOptionFuncs = append(esConf.ClientOptionFuncs, item)
-	}
-
 	for hostPrefix, value := range sc.ElasticConf {
+		// build es config per cluster
+		esConf := expr.ElasticConfig{}
+
+		// method to append clinet options
+		addClientOptions := func(item elastic.ClientOptionFunc) {
+			esConf.ClientOptionFuncs = append(esConf.ClientOptionFuncs, item)
+		}
+
 		options = value.ClientOptions
 
 		if !options.Enabled {


### PR DESCRIPTION
This patch will fix the ES cluster config maps by moving the `addClientOptions` and `esConf` inside the for loop

    - conf/system_elastic2.go :-  moved `addClientOptions` and `esConf` inside the for loop
    - conf/system_elastic5.go :-  moved `addClientOptions` and `esConf` inside the for loop

Thanks,