### PR TITLE
This will fix `go vet` composite literals

### DIFF
--- a/cmd/bosun/web/web.go
+++ b/cmd/bosun/web/web.go
@@ -494,7 +494,7 @@ func OpenTSDBVersion(t miniprofiler.Timer, w http.ResponseWriter, r *http.Reques
 	if schedule.SystemConf.GetTSDBContext() != nil {
 		return schedule.SystemConf.GetTSDBContext().Version(), nil
 	}
-	return opentsdb.Version{0, 0}, nil
+	return opentsdb.Version{Major: 0, Minor: 0}, nil
 }
 
 func AnnotateEnabled(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (interface{}, error) {


### PR DESCRIPTION
We are unable to build bosun RPM package due to `go vet` complaining about composite literal uses unkeyed fields.