### PR TITLE
cmd/bosun, docs: Add execTmpl template function

### DIFF
--- a/cmd/bosun/conf/rule/loaders.go
+++ b/cmd/bosun/conf/rule/loaders.go
@@ -1,6 +1,7 @@
 package rule
 
 import (
+	"bytes"
 	"fmt"
 	"net/mail"
 	"net/url"
@@ -33,6 +34,17 @@ func (c *Conf) loadTemplate(s *parse.SectionNode) {
 	funcs := template.FuncMap{
 		"V": func(v string) string {
 			return c.Expand(v, t.Vars, false)
+		},
+		"execTmpl": func(text string, data interface{}) string {
+			tmpl, err := template.New("inline-tmpl").Funcs(defaultFuncs).Parse(text)
+			if err != nil {
+				return "execTmpl fails to parse template: " + err.Error()
+			}
+			buf := &bytes.Buffer{}
+			if err := tmpl.Execute(buf, data); err != nil {
+				return "execTmpl fails to execute template: " + err.Error()
+			}
+			return buf.String()
 		},
 	}
 	saw := make(map[string]bool)

--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -1280,6 +1280,37 @@ alert bytes {
 }
 ```
 
+##### execTmpl(string, data) (string)
+{: .func}
+
+`execTmpl` takes a template string, applies it to the given data, and returns a resulting string. The template format is the same as the one used to describe [alert templates](definitions#templates) themselves. This function is useful when you want to capture the result of executing a template into a variable instead of outputting it directly.
+
+Example:
+
+```
+alert execTmpl {
+    template = execTmpl
+    critNotification = execTmpl
+    crit = 1
+}
+
+notification execTmpl {
+    post = https://api.example.com/jabber?send_to=somebody@example.com
+    runOnActions  = Ack
+    actionBodyAck = execTmplAck
+}
+
+template execTmpl {
+    subject = `execTmpl example`
+    body = `execTmpl example body`
+    execTmplAck = `
+        {{- $incidentIds := execTmpl "{{range .}}{{.Id}} {{end}}" .States -}}
+        {{- $text := printf "%v %v %v incident(s): %v" .User .ActionType $incidentIds .Message -}}
+        {{- makeMap "message" $text | json -}}
+    `
+}
+```
+
 ##### html(string) (htemplate.HTML)
 {: .func}
 


### PR DESCRIPTION
In this commit I try to partly address an issue raised in the report #2197:
I want to generate a JSON on `actionBodyAck` and send it to an HTTP API.
One of the fields in the JSON payload should contain a message attached
to the performed action and also a list of ids of affected incidents,
e.g.: "User X acknowledged N incidents (ids: 1, 2, 4) with a note: M".
I need to use `makeMap` and `json` functions, which take a "pipeline"
in Go's terms, to build a properly encoded JSON; but I also need a
way to traverse `.States[]` and extract a list of ids in a form of a
"pipeline". I could traverse with a help of the `{{range}}` template
action, but there is no way I can capture the result of that execution.

This patch adds a template function `execTmpl` which executes given Go
text/template provided a data structure and returns a resulting string
which can be kept in a template variable or passed on through the
template pipeline. Another way of looking at it is in-line or
sub-templates.

    {{- $list := execTmpl "{{range .}}<li>{{.Id}}</li>\n{{end}}" .States -}}
    {{- $html := printf "%v<br/>Affected incidents:<ul>%v</ul>" .Message $list -}}
    {{- makeMap "message" $html | json -}}

At first I wanted to take advantage of Go's named sub-templates
(`{{define NAME}}...`) and pass that NAME to `execTmpl` instead of a
literal template. Unfortunately template functions do not get a context
of a template in which they are being invoked, therefore I did not have
an access to the parent template containing sub-templates. I could wrap
it in a closure, but there are too many text/template instances created
in different places in code, so I figured that I will give the current
approach a go first and see how is it accepted.