### PR TITLE
fix user filter

### DIFF
--- a/cmd/bosun/sched/views.go
+++ b/cmd/bosun/sched/views.go
@@ -190,7 +190,7 @@ func (is IncidentSummaryView) Ask(filter string) (bool, error) {
 		return glob.Glob(value, is.AlertName), nil
 	case "user":
 		for _, action := range is.Actions {
-			if action.User == value {
+			if glob.Glob(value, action.User) {
 				return true, nil
 			}
 		}


### PR DESCRIPTION
If we use **... AND (user:*)** filter in incident-filter - nothing return...
So, this this small patch fixes it and filter begin work like it written in  [help](https://bosun.org/usage#incident-filters)