### PR TITLE
Distributed alert checks to prevent high load spikes

### DIFF
--- a/cmd/bosun/conf/conf.go
+++ b/cmd/bosun/conf/conf.go
@@ -50,7 +50,7 @@ type SystemConfProvider interface {
 
 	GetCheckFrequency() time.Duration
 	GetDefaultRunEvery() int
-	GetAlertCheckDistribution() bool
+	GetAlertCheckDistribution() string
 	GetUnknownThreshold() int
 	GetMinGroupSize() int
 

--- a/cmd/bosun/conf/conf.go
+++ b/cmd/bosun/conf/conf.go
@@ -50,6 +50,7 @@ type SystemConfProvider interface {
 
 	GetCheckFrequency() time.Duration
 	GetDefaultRunEvery() int
+	GetAlertCheckDistribution() bool
 	GetUnknownThreshold() int
 	GetMinGroupSize() int
 

--- a/cmd/bosun/conf/system.go
+++ b/cmd/bosun/conf/system.go
@@ -35,7 +35,7 @@ type SystemConf struct {
 	UnknownThreshold       int
 	CheckFrequency         Duration // Time between alert checks: 5m
 	DefaultRunEvery        int      // Default number of check intervals to run each alert: 1
-	AlertCheckDistribution bool     // Should the alert rule checks be scattered across their running period?
+	AlertCheckDistribution string   // Method to distribute alet checks. No distribution if equals ""
 
 	DBConf DBConf
 
@@ -228,7 +228,7 @@ func newSystemConf() *SystemConf {
 		CheckFrequency:         Duration{Duration: time.Minute * 5},
 		DefaultRunEvery:        1,
 		HTTPListen:             defaultHTTPListen,
-		AlertCheckDistribution: false,
+		AlertCheckDistribution: "",
 		DBConf: DBConf{
 			LedisDir:      "ledis_data",
 			LedisBindAddr: "127.0.0.1:9565",
@@ -269,6 +269,10 @@ func loadSystemConfig(conf string, isFileName bool) (*SystemConf, error) {
 	}
 	if len(decodeMeta.Undecoded()) > 0 {
 		return sc, fmt.Errorf("undecoded fields in system configuration: %v", decodeMeta.Undecoded())
+	}
+
+	if sc.GetAlertCheckDistribution() != "" && sc.GetAlertCheckDistribution() != "simple" {
+		return sc, fmt.Errorf("invalid value %v for AlertCheckDistribution", sc.GetAlertCheckDistribution())
 	}
 
 	// iterate over each hosts
@@ -404,7 +408,7 @@ func (sc *SystemConf) GetDefaultRunEvery() int {
 }
 
 // GetAlertCheckDistribution returns if the alert rule checks are scattered over check period
-func (sc *SystemConf) GetAlertCheckDistribution() bool {
+func (sc *SystemConf) GetAlertCheckDistribution() string {
 	return sc.AlertCheckDistribution
 }
 

--- a/cmd/bosun/conf/system.go
+++ b/cmd/bosun/conf/system.go
@@ -32,9 +32,10 @@ type SystemConf struct {
 	InternetProxy string
 	MinGroupSize  int
 
-	UnknownThreshold int
-	CheckFrequency   Duration // Time between alert checks: 5m
-	DefaultRunEvery  int      // Default number of check intervals to run each alert: 1
+	UnknownThreshold       int
+	CheckFrequency         Duration // Time between alert checks: 5m
+	DefaultRunEvery        int      // Default number of check intervals to run each alert: 1
+	AlertCheckDistribution bool     // Should the alert rule checks be scattered across their running period?
 
 	DBConf DBConf
 
@@ -223,10 +224,11 @@ const (
 // NewSystemConf retruns a system conf with default values set
 func newSystemConf() *SystemConf {
 	return &SystemConf{
-		Scheme:          "http",
-		CheckFrequency:  Duration{Duration: time.Minute * 5},
-		DefaultRunEvery: 1,
-		HTTPListen:      defaultHTTPListen,
+		Scheme:                 "http",
+		CheckFrequency:         Duration{Duration: time.Minute * 5},
+		DefaultRunEvery:        1,
+		HTTPListen:             defaultHTTPListen,
+		AlertCheckDistribution: false,
 		DBConf: DBConf{
 			LedisDir:      "ledis_data",
 			LedisBindAddr: "127.0.0.1:9565",
@@ -399,6 +401,11 @@ func (sc *SystemConf) GetCheckFrequency() time.Duration {
 // the CheckFrequency. Checks by default will run at CheckFrequency * RunEvery
 func (sc *SystemConf) GetDefaultRunEvery() int {
 	return sc.DefaultRunEvery
+}
+
+// GetAlertCheckDistribution returns if the alert rule checks are scattered over check period
+func (sc *SystemConf) GetAlertCheckDistribution() bool {
+	return sc.AlertCheckDistribution
 }
 
 // GetUnknownThreshold returns the threshold in which multiple unknown alerts in a check iteration

--- a/cmd/bosun/sched/alertRunner.go
+++ b/cmd/bosun/sched/alertRunner.go
@@ -35,7 +35,7 @@ func (s *Schedule) Run() error {
 		}
 		go s.runAlert(a, ch)
 
-		if s.SystemConf.GetAlertCheckDistribution() { // only apply shifts if the respective option is enabled
+		if s.SystemConf.GetAlertCheckDistribution() == "simple" { // only apply shifts if the respective option is set
 			chs = append(chs, alertCh{ch: ch, modulo: re, shift: circular_shifts[re]})
 		} else {
 			// there are no shifts if option is off

--- a/cmd/bosun/sched/alertRunner.go
+++ b/cmd/bosun/sched/alertRunner.go
@@ -26,7 +26,7 @@ func (s *Schedule) Run() error {
 	// Every alert gets a small shift in time.
 	// This way the alerts with the same period are not fired
 	// simultaneously, but are distributed.
-	circular_shifts := make(map[int]int)
+	circular_shifts := make(map[int]int) // the map is *run period* -> *time shift to add*
 	for _, a := range s.RuleConf.GetAlerts() {
 		ch := make(chan *checkContext, 1)
 		re := a.RunEvery

--- a/cmd/bosun/sched/alertRunner.go
+++ b/cmd/bosun/sched/alertRunner.go
@@ -34,7 +34,13 @@ func (s *Schedule) Run() error {
 			re = s.SystemConf.GetDefaultRunEvery()
 		}
 		go s.runAlert(a, ch)
-		chs = append(chs, alertCh{ch: ch, modulo: re, shift: circular_shifts[re]})
+
+		if s.SystemConf.GetAlertCheckDistribution() { // only apply shifts if the respective option is enabled
+			chs = append(chs, alertCh{ch: ch, modulo: re, shift: circular_shifts[re]})
+		} else {
+			// there are no shifts if option is off
+			chs = append(chs, alertCh{ch: ch, modulo: re, shift: 0})
+		}
 
 		// the shifts for a given period range 0..(period - 1)
 		circular_shifts[re] = (circular_shifts[re] + 1) % re

--- a/docs/system_configuration.md
+++ b/docs/system_configuration.md
@@ -103,6 +103,13 @@ frequent as every "1m", and others that run less often (any multiple of
 Example:
 `DefaultRunEvery = 5`
 
+### AlertCheckDistribution
+Selects algorithm to distribute alert checks to decrease system load spikes.  There is no distribution by default. This means, if there are several checks with same period, they all will happen at the same points in time. This method is used if the option is not specified or equals to empty string.
+
+The single alternative option is `simple`. If specified, the alert checks with the same period will be uniformly distributed on second marks.
+
+Example: `AlertCheckDistribution = "simple"`
+
 ### RuleFilePath
 Path to the file containing definitions of alerts, macros, lookups,
 templates, notifications, and global variables which are [documented


### PR DESCRIPTION
This is a solution for #2065 

The idea behind this is simple. Every check run is slightly shifted so that the checks are distributed uniformly. 

For the subset of checks that run with the period `T`, a shift is added to every check. The shift ranges from `0` to `T-1`. The shifts are incremental. For example, if we have 6 checks every 5 mins (`T=5`). The shifts will be ` 0`, `1`, `2`, `3`, `4`, `0`. This way, without the patch 6 checks will happen at times `0`, and `5`; with the patch, two checks will happen at the time `0`, one at `1`, one at `2`, and so on. The total number of checks and check period stay the same.

Here is the test that shows the effect of the patch on system load. Note, that the majority of checks in this system have 5 mins period.
![patch_test](https://user-images.githubusercontent.com/3339062/39817002-3e91f8ac-539d-11e8-96c5-dd31154d39d4.png)