### PR TITLE
cmd/bosun: Add jsonStr template function

### DIFF
--- a/cmd/bosun/conf/rule/rule.go
+++ b/cmd/bosun/conf/rule/rule.go
@@ -449,6 +449,14 @@ var defaultFuncs = template.FuncMap{
 		}
 		return string(b)
 	},
+	// Just like "json", but cuts front and rear double quotes off
+	"jsonStr": func(s string) string {
+		b, err := json.Marshal(s)
+		if err != nil {
+			return err.Error()
+		}
+		return string(b[1 : len(b)-1])
+	},
 }
 
 var exRE = regexp.MustCompile(`\$(?:[\w.]+|\{[\w.]+\})`)


### PR DESCRIPTION
Follow-up on #2197 and #2243.

jsonStr template function is a new better version of its ancestor
.RemoveQuotes. The .RemoveQuotes helper is a temporary patch that helps
to sanitise data in order to use it inside JSON string literals.
Unfortunately it does not handle all characters (e.g. `\n`) but only
`"`, so at times resulting JSON documents still would be malformed. That
results in failure to deliver notifications.

The new version "jsonStr" works just like "json", but it cuts front and
rear double quotes off. So now one can include any template rubbish
*inside* JSON string literal and worry about breaking JSON not:

    alert A {
        $Rubbish= `say "hi '\xyz'!\n" &
            jump <sup>high</sup>`
        ...
    }

    template T {
        jabberAlertBody = `{
            "text": "hello {{ .Alert.Vars.Rubbish | jsonStr }}!"
        }`
        ...
    }