### PR TITLE
Added extra info to unknown templates

### DIFF
--- a/cmd/bosun/conf/unknownNotify.go
+++ b/cmd/bosun/conf/unknownNotify.go
@@ -3,6 +3,7 @@ package conf
 import (
 	"bytes"
 	"fmt"
+	"net/url"
 	"time"
 
 	"bosun.org/cmd/bosun/conf/template"
@@ -11,9 +12,17 @@ import (
 )
 
 type unknownContext struct {
-	Time  time.Time
-	Name  string
-	Group models.AlertKeys
+	Time     time.Time
+	Name     string
+	Group    models.AlertKeys
+	States   *models.IncidentState
+	makeLink func(string, *url.Values) string
+}
+
+func (u *unknownContext) IncidentUnknownLink(i int64) string {
+	return u.makeLink("/incident", &url.Values{
+		"id": []string{fmt.Sprint(i)},
+	})
 }
 
 var defaultUnknownTemplate = &Template{
@@ -44,11 +53,13 @@ func init() {
 	unknownDefaults.body = template.Must(template.New("body").Parse(body))
 }
 
-func (n *Notification) PrepareUnknown(t *Template, c SystemConfProvider, name string, aks []models.AlertKey) *PreparedNotifications {
+func (n *Notification) PrepareUnknown(t *Template, c SystemConfProvider, name string, aks []models.AlertKey, states *models.IncidentState) *PreparedNotifications {
 	ctx := &unknownContext{
-		Time:  time.Now().UTC(),
-		Name:  name,
-		Group: aks,
+		Time:     time.Now().UTC(),
+		Name:     name,
+		Group:    aks,
+		States:   states,
+		makeLink: c.MakeLink,
 	}
 	pn := &PreparedNotifications{}
 	buf := &bytes.Buffer{}
@@ -101,8 +112,8 @@ func (n *Notification) PrepareUnknown(t *Template, c SystemConfProvider, name st
 	return pn
 }
 
-func (n *Notification) NotifyUnknown(t *Template, c SystemConfProvider, name string, aks []models.AlertKey) {
-	go n.PrepareUnknown(t, c, name, aks).Send(c)
+func (n *Notification) NotifyUnknown(t *Template, c SystemConfProvider, name string, aks []models.AlertKey, states *models.IncidentState) {
+	go n.PrepareUnknown(t, c, name, aks, states).Send(c)
 }
 
 var unknownMultiDefaults defaultTemplates
@@ -111,6 +122,7 @@ type unknownMultiContext struct {
 	Time      time.Time
 	Threshold int
 	Groups    map[string]models.AlertKeys
+	States    []*models.IncidentState
 }
 
 func init() {
@@ -135,11 +147,12 @@ func init() {
 	unknownMultiDefaults.body = template.Must(template.New("body").Parse(body))
 }
 
-func (n *Notification) PrepareMultipleUnknowns(t *Template, c SystemConfProvider, groups map[string]models.AlertKeys) *PreparedNotifications {
+func (n *Notification) PrepareMultipleUnknowns(t *Template, c SystemConfProvider, groups map[string]models.AlertKeys, states []*models.IncidentState) *PreparedNotifications {
 	ctx := &unknownMultiContext{
 		Time:      time.Now().UTC(),
 		Threshold: c.GetUnknownThreshold(),
 		Groups:    groups,
+		States:    states,
 	}
 	pn := &PreparedNotifications{}
 	buf := &bytes.Buffer{}
@@ -180,8 +193,8 @@ func (n *Notification) PrepareMultipleUnknowns(t *Template, c SystemConfProvider
 	return pn
 }
 
-func (n *Notification) NotifyMultipleUnknowns(t *Template, c SystemConfProvider, groups map[string]models.AlertKeys) {
-	n.PrepareMultipleUnknowns(t, c, groups).Send(c)
+func (n *Notification) NotifyMultipleUnknowns(t *Template, c SystemConfProvider, groups map[string]models.AlertKeys, states []*models.IncidentState) {
+	n.PrepareMultipleUnknowns(t, c, groups, states).Send(c)
 }
 
 // code common to PrepareAction / PrepareUnknown / PrepareMultipleUnknowns

--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -196,6 +196,8 @@ Variables and function available to the unknown template:
 * Group: list of names of alerts
 * Name: group name
 * Time: [time](http://golang.org/pkg/time/#Time) this group triggered unknown
+* States: unknown incident states (only use when grouping unknown disabled using [unknownMinGroupSize](http://bosun.org/definitions#unknownmingroupsize))
+* IncidentUnknownLink: creates a link to Bosun’s incident view same as `.Incident` (require incident id)
 
 Example:
 
@@ -212,6 +214,21 @@ template ut {
 }
 
 unknownTemplate = ut
+```
+
+```
+template testunknownBody {
+    subject = {{.Name}}{{ if .States.Tags }}.{{ replace .States.Tags "," "." -1 }}{{else}}{{end}}
+    body = `
+    <p>Time: {{.Time}}
+    <p>Name: {{.Name}}
+    <p>AlertKey: {{.States.AlertKey}}
+    <p>Incident Id: {{.States.Id}}
+    <p>Link: {{.IncidentUnknownLink .States.Id}}
+    `
+}
+
+unknownBody = testunknownBody
 ```
 
 In general it is better to stick with the system default by not defining an unknown template. The system default is:


### PR DESCRIPTION
Currently, we have a very limited number of variable available to the unknown templates which prevent us to match the alert and action notification template (includes incident states) and sometimes unknowns are getting unnoticed due inconsistency (when using external notification systems e.g. pagerduty).

With this patch, I tried to include the alert states to unknown which is very useful when grouping disable using [unknownMinGroupSize](http://bosun.org/definitions#unknownmingroupsize).

Please let me know your thoughts.