### PR TITLE
Fix delay close alert notification

### DIFF
--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -147,10 +147,18 @@ func (s *Schedule) runHistory(r *RunHistory, ak models.AlertKey, event *models.E
 					if err != nil {
 						return
 					}
+
 					incident, err = data.GetIncidentState(incident.Id)
 					if err != nil {
 						return
 					}
+
+					// notify action cancel close
+					err = s.ActionNotify(models.ActionCancelClose, "bosun", "cancelled delayed close due to severity increase", []models.AlertKey{ak})
+					if err != nil {
+						return
+					}
+
 					// Continue processing alert after cancelling the delayed close
 					break
 				}
@@ -174,10 +182,18 @@ func (s *Schedule) runHistory(r *RunHistory, ak models.AlertKey, event *models.E
 						if err != nil {
 							return
 						}
+
 						incident, err = data.GetIncidentState(incident.Id)
 						if err != nil {
 							return
 						}
+
+						// notify action close
+						err = s.ActionNotify(models.ActionClose, "bosun", fmt.Sprintf("close on behalf of delayed close by %v", action.User), []models.AlertKey{ak})
+						if err != nil {
+							return
+						}
+
 						incident.Actions[i].Fullfilled = true
 						return
 					}
@@ -189,6 +205,13 @@ func (s *Schedule) runHistory(r *RunHistory, ak models.AlertKey, event *models.E
 					if err != nil {
 						return
 					}
+
+					// notify action force close
+					err = s.ActionNotify(models.ActionForceClose, "bosun", fmt.Sprintf("forceclose on behalf of delayed close by %v", action.User), []models.AlertKey{ak})
+					if err != nil {
+						return
+					}
+
 					incident, err = data.GetIncidentState(incident.Id)
 					if err != nil {
 						return

--- a/cmd/bosun/web/web.go
+++ b/cmd/bosun/web/web.go
@@ -765,6 +765,7 @@ func Action(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (inter
 		if err != nil {
 			return nil, err
 		}
+
 		err = schedule.ActionByAlertKey(data.User, data.Message, at, data.Time, ak)
 		if err != nil {
 			errs[key] = err
@@ -784,6 +785,12 @@ func Action(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (inter
 		return nil, errs
 	}
 	if data.Notify && len(successful) != 0 {
+		// If alert was dealy close, change action type to ActionDelayedClose
+		// insted of ActionClose
+		if at == models.ActionClose && data.Time != nil {
+			at = models.ActionDelayedClose
+		}
+
 		err := schedule.ActionNotify(at, data.User, data.Message, successful)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
We have noticed bosun sending [`actionBodyClose`](http://bosun.org/notifications) instead of [`actionBodyDelayedClose`](http://bosun.org/notifications) when alerts are getting delayed closed. This is causing confusion because users are getting closed notifications immediately whereas it's still active in bosun, also when bosun actually closes the alert (after delay timeout) it's not sending any notifications and can only be viewed in the incident page.

In this pull request we try to solve both problems (sending delay close and notify when actual close happen), could you please review and let us know your thoughts?