### PR TITLE
cmd/scollector: OiD for session.count changed

### DIFF
--- a/cmd/scollector/collectors/snmp_fortinet.go
+++ b/cmd/scollector/collectors/snmp_fortinet.go
@@ -25,7 +25,7 @@ func SNMPFortinet(cfg conf.SNMP) {
 		Metrics: []conf.MIBMetric{
 			{Metric: "fortinet.disk.used", Oid: ".4.1.6.0", Unit: "MiB", RateType: "gauge", Description: "Disk space used", FallbackOid: "", Tags: "", Scale: 0},
 			{Metric: "fortinet.disk.total", Oid: ".4.1.7.0", Unit: "MiB", RateType: "gauge", Description: "Disk space total", FallbackOid: "", Tags: "", Scale: 0},
-			{Metric: "fortinet.session.count", Oid: ".11.2.2.1.1.1", Unit: "sessions", RateType: "gauge", Description: "Total number of current sessions being tracked", FallbackOid: "", Tags: "", Scale: 0},
+			{Metric: "fortinet.session.count", Oid: ".4.1.8.0", Unit: "sessions", RateType: "gauge", Description: "Total number of current sessions being tracked", FallbackOid: ".11.2.2.1.1.1", Tags: "", Scale: 0},
 			{Metric: "fortinet.vpn.tunnel_up_count", Oid: ".12.1.1.0", Unit: "tunnel count", RateType: "gauge", Description: "Total number of up VPN tunnels", FallbackOid: "", Tags: "", Scale: 0},
 		},
 		Trees: []conf.MIBTree{


### PR DESCRIPTION
new OiD tested with 1500D on 5.2.13 and on 200D with 5.4.6.
(Added old OiD to FallbackOid, not tested as I don't have matching HW)

More proof here: 
http://www.oidview.com/mibs/12356/FORTINET-FORTIGATE-MIB.html
and here:
https://forum.fortinet.com/tm.aspx?m=146470