### PR TITLE
Update README to refer to bosun.toml instead of outdated conf file

### DIFF
--- a/cmd/bosun/README.md
+++ b/cmd/bosun/README.md
@@ -8,11 +8,11 @@ Time Series Alerting Framework
 
 # usage
 
-`bosun [-c=dev.conf] [-t]`
+`bosun [-c=bosun.toml] [-t]`
 
-`-c` specifies the config file to use, defaults to `dev.conf`. `-t` parses the config file, validates it, and exits.
+`-c` specifies the config file to use, defaults to `bosun.toml`. `-t` parses the config file, validates it, and exits.
 
-You can use the included dev.sample.conf as a basis for your dev.conf
+You can use the included bosun.example.toml as a basis for your bosun.toml.
 
 # installation/binaries
 


### PR DESCRIPTION
This is just to reduce confusion for people starting out with Bosun. 