### PR TITLE
Add series aggregation DSL function `aggregate`

### DIFF
--- a/cmd/bosun/expr/expr.go
+++ b/cmd/bosun/expr/expr.go
@@ -287,7 +287,7 @@ func (a *Results) Equal(b *Results) (bool, error) {
 	if a.IgnoreOtherUnjoined != b.IgnoreOtherUnjoined {
 		return false, fmt.Errorf("ignoreUnjoined flag does not match a: %v, b: %v", a.IgnoreOtherUnjoined, b.IgnoreOtherUnjoined)
 	}
-	if a.NaNValue != a.NaNValue {
+	if a.NaNValue != b.NaNValue {
 		return false, fmt.Errorf("NaNValue does not match a: %v, b: %v", a.NaNValue, b.NaNValue)
 	}
 	sortedA := ResultSliceByGroup(a.Results)

--- a/cmd/bosun/expr/funcs.go
+++ b/cmd/bosun/expr/funcs.go
@@ -13,7 +13,7 @@ import (
 	"github.com/GaryBoone/GoStats/stats"
 	"github.com/MiniProfiler/go/miniprofiler"
 	"github.com/jinzhu/now"
-	)
+)
 
 func tagQuery(args []parse.Node) (parse.Tags, error) {
 	n := args[0].(*parse.StringNode)
@@ -54,7 +54,7 @@ func aggregateFuncTags(args []parse.Node) (parse.Tags, error) {
 	return tagsFromString(s)
 }
 
-func tagsFromString(text string) (parse.Tags, error){
+func tagsFromString(text string) (parse.Tags, error) {
 	t := make(parse.Tags)
 	if text == "" {
 		return t, nil
@@ -514,10 +514,10 @@ func aggregateMedian(series ResultSlice) Series {
 	for t := range merged {
 		sort.Float64s(merged[t])
 		l := len(merged[t])
-		if l % 2 == 1 {
-			newSeries[t] = merged[t][l / 2]
+		if l%2 == 1 {
+			newSeries[t] = merged[t][l/2]
 		} else {
-			newSeries[t] = (merged[t][l / 2 - 1] + merged[t][l / 2]) / 2
+			newSeries[t] = (merged[t][l/2-1] + merged[t][l/2]) / 2
 		}
 	}
 	return newSeries

--- a/cmd/bosun/expr/funcs.go
+++ b/cmd/bosun/expr/funcs.go
@@ -403,13 +403,13 @@ var builtins = map[string]parse.Func{
 // Aggregate combines multiple series matching the specified groups using an aggregator function. If group
 // is empty, all given series are combined, regardless of existing groups.
 // Available aggregator functions include: avg (average), p50 (median), min (minimum) and max (maximum).
-func Aggregate(e *State, T miniprofiler.Timer, series *Results, groups string, aggregator string) (*Results, error) {
+func Aggregate(e *State, series *Results, groups string, aggregator string) (*Results, error) {
 	results := Results{}
 
 	grps := splitGroups(groups)
 	if len(grps) == 0 {
 		// no groups specified, so we merge all group values
-		res, err := aggregate(e, T, series, aggregator)
+		res, err := aggregate(e, series, aggregator)
 		if err != nil {
 			return &results, err
 		}
@@ -438,7 +438,7 @@ func Aggregate(e *State, T miniprofiler.Timer, series *Results, groups string, a
 	}
 
 	for groupName, series := range newGroups {
-		res, err := aggregate(e, T, series, aggregator)
+		res, err := aggregate(e, series, aggregator)
 		if err != nil {
 			return &results, err
 		}
@@ -466,7 +466,7 @@ func splitGroups(groups string) []string {
 	return grps
 }
 
-func aggregate(e *State, T miniprofiler.Timer, series *Results, aggregator string) (*Result, error) {
+func aggregate(e *State, series *Results, aggregator string) (*Result, error) {
 	res := Result{}
 	newSeries := make(Series)
 

--- a/cmd/bosun/expr/funcs.go
+++ b/cmd/bosun/expr/funcs.go
@@ -413,7 +413,9 @@ var builtins = map[string]parse.Func{
 
 // Aggr combines multiple series matching the specified groups using an aggregator function. If group
 // is empty, all given series are combined, regardless of existing groups.
-// Available aggregator functions include: avg (average), p50 (median), min (minimum) and max (maximum).
+// Available aggregator functions include: avg, min, max, sum, and pN, where N is a float between
+// 0 and 1 inclusive, e.g. p.50 represents the 50th percentile. p0 and p1 are equal to min and max,
+// respectively, but min and max are preferred for readability.
 func Aggr(e *State, series *Results, groups string, aggregator string) (*Results, error) {
 	results := Results{}
 

--- a/cmd/bosun/expr/funcs_test.go
+++ b/cmd/bosun/expr/funcs_test.go
@@ -2,13 +2,13 @@ package expr
 
 import (
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
 	"bosun.org/opentsdb"
 
 	"github.com/influxdata/influxdb/client/v2"
-	"math"
 )
 
 type exprInOut struct {
@@ -340,7 +340,6 @@ func TestAggregate(t *testing.T) {
 		t.Error(err)
 	}
 
-
 	// check that unknown aggregator errors out
 	err = testExpression(exprInOut{
 		fmt.Sprintf("aggregate(merge(%v, %v, %v), \"\", \"unknown\")", seriesA, seriesB, seriesC),
@@ -410,7 +409,7 @@ func TestAggregateWithGroups(t *testing.T) {
 	}
 }
 
-func TestAggregateNaNHandling(t *testing.T){
+func TestAggregateNaNHandling(t *testing.T) {
 	// test behavior when NaN is encountered.
 	seriesD := `series("foo=bar", 0, 0 / 0, 100, 1)`
 	seriesE := `series("foo=baz", 0, 1, 100, 3)`
@@ -422,7 +421,7 @@ func TestAggregateNaNHandling(t *testing.T){
 			Results: ResultSlice{
 				&Result{
 					Value: Series{
-						time.Unix(0, 0): math.NaN(),
+						time.Unix(0, 0):   math.NaN(),
 						time.Unix(100, 0): 2,
 					},
 					Group: opentsdb.TagSet{},

--- a/cmd/bosun/expr/funcs_test.go
+++ b/cmd/bosun/expr/funcs_test.go
@@ -340,6 +340,44 @@ func TestAggr(t *testing.T) {
 		t.Error(err)
 	}
 
+	// check that min == p0
+	err = testExpression(exprInOut{
+		fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"p0\")", seriesA, seriesB, seriesC),
+		Results{
+			Results: ResultSlice{
+				&Result{
+					Value: Series{
+						time.Unix(0, 0): 1,
+					},
+					Group: opentsdb.TagSet{},
+				},
+			},
+		},
+		false,
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	// check that max == p1.0
+	err = testExpression(exprInOut{
+		fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"p1.0\")", seriesA, seriesB, seriesC),
+		Results{
+			Results: ResultSlice{
+				&Result{
+					Value: Series{
+						time.Unix(0, 0): 5,
+					},
+					Group: opentsdb.TagSet{},
+				},
+			},
+		},
+		false,
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
 	// check that unknown aggregator errors out
 	err = testExpression(exprInOut{
 		fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"unknown\")", seriesA, seriesB, seriesC),

--- a/cmd/bosun/expr/funcs_test.go
+++ b/cmd/bosun/expr/funcs_test.go
@@ -454,6 +454,6 @@ func TestAggregateNaNHandling(t *testing.T){
 	}
 	val1 := results[0].Value.(Series)[time.Unix(100, 0)]
 	if val1 != 2.0 {
-		t.Errorf("got second point = %f, want %f", 2.0)
+		t.Errorf("got second point = %f, want %f", val1, 2.0)
 	}
 }

--- a/cmd/bosun/expr/funcs_test.go
+++ b/cmd/bosun/expr/funcs_test.go
@@ -450,10 +450,10 @@ func TestAggregateNaNHandling(t *testing.T){
 	}
 	val0 := results[0].Value.(Series)[time.Unix(0, 0)]
 	if !math.IsNaN(val0) {
-		t.Errorf("got first point = %d, want NaN", val0)
+		t.Errorf("got first point = %f, want NaN", val0)
 	}
 	val1 := results[0].Value.(Series)[time.Unix(100, 0)]
 	if val1 != 2.0 {
-		t.Errorf("got second point = %d, want %d", 2.0)
+		t.Errorf("got second point = %f, want %f", 2.0)
 	}
 }

--- a/cmd/bosun/expr/funcs_test.go
+++ b/cmd/bosun/expr/funcs_test.go
@@ -259,14 +259,14 @@ func TestTail(t *testing.T) {
 	}
 }
 
-func TestAggregate(t *testing.T) {
+func TestAggr(t *testing.T) {
 	seriesA := `series("foo=bar", 0, 1)`
 	seriesB := `series("foo=baz", 0, 3)`
 	seriesC := `series("foo=bat", 0, 5)`
 
 	// test median aggregator
 	err := testExpression(exprInOut{
-		fmt.Sprintf("aggregate(merge(%v, %v, %v), \"\", \"p50\")", seriesA, seriesB, seriesC),
+		fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"p.50\")", seriesA, seriesB, seriesC),
 		Results{
 			Results: ResultSlice{
 				&Result{
@@ -285,7 +285,7 @@ func TestAggregate(t *testing.T) {
 
 	// test average aggregator
 	err = testExpression(exprInOut{
-		fmt.Sprintf("aggregate(merge(%v, %v, %v), \"\", \"avg\")", seriesA, seriesB, seriesC),
+		fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"avg\")", seriesA, seriesB, seriesC),
 		Results{
 			Results: ResultSlice{
 				&Result{
@@ -304,7 +304,7 @@ func TestAggregate(t *testing.T) {
 
 	// test min aggregator
 	err = testExpression(exprInOut{
-		fmt.Sprintf("aggregate(merge(%v, %v, %v), \"\", \"min\")", seriesA, seriesB, seriesC),
+		fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"min\")", seriesA, seriesB, seriesC),
 		Results{
 			Results: ResultSlice{
 				&Result{
@@ -323,7 +323,7 @@ func TestAggregate(t *testing.T) {
 
 	// test max aggregator
 	err = testExpression(exprInOut{
-		fmt.Sprintf("aggregate(merge(%v, %v, %v), \"\", \"max\")", seriesA, seriesB, seriesC),
+		fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"max\")", seriesA, seriesB, seriesC),
 		Results{
 			Results: ResultSlice{
 				&Result{
@@ -342,7 +342,7 @@ func TestAggregate(t *testing.T) {
 
 	// check that unknown aggregator errors out
 	err = testExpression(exprInOut{
-		fmt.Sprintf("aggregate(merge(%v, %v, %v), \"\", \"unknown\")", seriesA, seriesB, seriesC),
+		fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"unknown\")", seriesA, seriesB, seriesC),
 		Results{},
 		false,
 	})
@@ -351,14 +351,14 @@ func TestAggregate(t *testing.T) {
 	}
 }
 
-func TestAggregateWithGroups(t *testing.T) {
+func TestAggrWithGroups(t *testing.T) {
 	seriesA := `series("color=blue,type=apple,name=bob", 0, 1)`
 	seriesB := `series("color=blue,type=apple", 1, 3)`
 	seriesC := `series("color=green,type=apple", 0, 5)`
 
 	// test aggregator with single group
 	err := testExpression(exprInOut{
-		fmt.Sprintf("aggregate(merge(%v, %v, %v), \"color\", \"p50\")", seriesA, seriesB, seriesC),
+		fmt.Sprintf("aggr(merge(%v, %v, %v), \"color\", \"p.50\")", seriesA, seriesB, seriesC),
 		Results{
 			Results: ResultSlice{
 				&Result{
@@ -384,7 +384,7 @@ func TestAggregateWithGroups(t *testing.T) {
 
 	// test aggregator with multiple groups
 	err = testExpression(exprInOut{
-		fmt.Sprintf("aggregate(merge(%v, %v, %v), \"color,type\", \"p50\")", seriesA, seriesB, seriesC),
+		fmt.Sprintf("aggr(merge(%v, %v, %v), \"color,type\", \"p.50\")", seriesA, seriesB, seriesC),
 		Results{
 			Results: ResultSlice{
 				&Result{
@@ -409,14 +409,14 @@ func TestAggregateWithGroups(t *testing.T) {
 	}
 }
 
-func TestAggregateNaNHandling(t *testing.T) {
+func TestAggrNaNHandling(t *testing.T) {
 	// test behavior when NaN is encountered.
 	seriesD := `series("foo=bar", 0, 0 / 0, 100, 1)`
 	seriesE := `series("foo=baz", 0, 1, 100, 3)`
 
 	// expect NaN points to be dropped
 	eio := exprInOut{
-		fmt.Sprintf("aggregate(merge(%v, %v), \"\", \"p50\")", seriesD, seriesE),
+		fmt.Sprintf("aggr(merge(%v, %v), \"\", \"p.90\")", seriesD, seriesE),
 		Results{
 			Results: ResultSlice{
 				&Result{

--- a/cmd/bosun/expr/funcs_test.go
+++ b/cmd/bosun/expr/funcs_test.go
@@ -260,9 +260,9 @@ func TestTail(t *testing.T) {
 }
 
 func TestAggr(t *testing.T) {
-	seriesA := `series("foo=bar", 0, 1)`
-	seriesB := `series("foo=baz", 0, 3)`
-	seriesC := `series("foo=bat", 0, 5)`
+	seriesA := `series("foo=bar", 0, 1, 100, 2)`
+	seriesB := `series("foo=baz", 0, 3, 100, 4)`
+	seriesC := `series("foo=bat", 0, 5, 100, 6)`
 
 	// test median aggregator
 	err := testExpression(exprInOut{
@@ -271,7 +271,8 @@ func TestAggr(t *testing.T) {
 			Results: ResultSlice{
 				&Result{
 					Value: Series{
-						time.Unix(0, 0): 3,
+						time.Unix(0, 0):   3,
+						time.Unix(100, 0): 4,
 					},
 					Group: opentsdb.TagSet{},
 				},
@@ -290,7 +291,8 @@ func TestAggr(t *testing.T) {
 			Results: ResultSlice{
 				&Result{
 					Value: Series{
-						time.Unix(0, 0): 3,
+						time.Unix(0, 0):   3,
+						time.Unix(100, 0): 4,
 					},
 					Group: opentsdb.TagSet{},
 				},
@@ -309,7 +311,8 @@ func TestAggr(t *testing.T) {
 			Results: ResultSlice{
 				&Result{
 					Value: Series{
-						time.Unix(0, 0): 1,
+						time.Unix(0, 0):   1,
+						time.Unix(100, 0): 2,
 					},
 					Group: opentsdb.TagSet{},
 				},
@@ -328,7 +331,8 @@ func TestAggr(t *testing.T) {
 			Results: ResultSlice{
 				&Result{
 					Value: Series{
-						time.Unix(0, 0): 5,
+						time.Unix(0, 0):   5,
+						time.Unix(100, 0): 6,
 					},
 					Group: opentsdb.TagSet{},
 				},
@@ -347,7 +351,8 @@ func TestAggr(t *testing.T) {
 			Results: ResultSlice{
 				&Result{
 					Value: Series{
-						time.Unix(0, 0): 1,
+						time.Unix(0, 0):   1,
+						time.Unix(100, 0): 2,
 					},
 					Group: opentsdb.TagSet{},
 				},
@@ -359,14 +364,15 @@ func TestAggr(t *testing.T) {
 		t.Error(err)
 	}
 
-	// check that max == p1.0
+	// check that sum aggregator sums up the aligned points in the series
 	err = testExpression(exprInOut{
-		fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"p1.0\")", seriesA, seriesB, seriesC),
+		fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"sum\")", seriesA, seriesB, seriesC),
 		Results{
 			Results: ResultSlice{
 				&Result{
 					Value: Series{
-						time.Unix(0, 0): 5,
+						time.Unix(0, 0):   9,
+						time.Unix(100, 0): 12,
 					},
 					Group: opentsdb.TagSet{},
 				},

--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -600,7 +600,9 @@ Aggregation functions take a seriesSet, and return a new seriesSet.
 ## aggr(series seriesSet, groups string, aggregator string) seriesSet
 {: .exprFunc}
 
-Takes a seriesSet and combines it into a new seriesSet with the groups specified, using an aggregator to merge any series that share the matching group values. If the groups argument is an empty string, all series are combined into a single series, regardless of existing groups. The available aggregator functions are: avg (average), min (minimum), max (maximum), sum and pN (percentile) where N is a floating point number between 0 and 1 inclusive. For example, `"p.25"` will be the 25th percentile, `"p.999"` will be the 99.9th percentile. `"p0"` and `"p1"` are min and max respectively (However, in these cases it is recommended to use `"min"` and `"max"` for the sake of clarity.
+Takes a seriesSet and combines it into a new seriesSet with the groups specified, using an aggregator to merge any series that share the matching group values. If the groups argument is an empty string, all series are combined into a single series, regardless of existing groups. 
+
+The available aggregator functions are: `"avg"` (average), `"min"` (minimum), `"max"` (maximum), `"sum"` and `"pN"` (percentile) where N is a floating point number between 0 and 1 inclusive. For example, `"p.25"` will be the 25th percentile, `"p.999"` will be the 99.9th percentile. `"p0"` and `"p1"` are min and max respectively (However, in these cases it is recommended to use `"min"` and `"max"` for the sake of clarity.
 
 The aggr function can be particularly useful for removing anomalies when comparing timeseries over periods using the over function. 
 
@@ -611,7 +613,7 @@ $weeks = over("sum:1m-avg:os.cpu{region=*,color=*}", "24h", "1w", 3)
 $agg = aggr($weeks, "region,color", "p.50")
 ```
 
-The above example uses `over` to load a 24 hour period over the past 3 weeks. We then use the aggr function to combine the three weeks into one, selecting the median (p.50) value of the 3 weeks at each timestamp. This results in a new seriesSet, grouped by region and color, that represents a "normal" 24 hour period with anomalies removed.
+The above example uses `over` to load a 24 hour period over the past 3 weeks. We then use the aggr function to combine the three weeks into one, selecting the median (`p.50`) value of the 3 weeks at each timestamp. This results in a new seriesSet, grouped by region and color, that represents a "normal" 24 hour period with anomalies removed.
 
 # Group Functions
 

--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -597,7 +597,7 @@ Sum.
 
 Aggregation functions take a seriesSet, and return a new seriesSet.
 
-## aggregate(seriesSet, groups string, aggregator string) seriesSet
+## aggregate(series seriesSet, groups string, aggregator string) seriesSet
 {: .exprFunc}
 
 Takes a seriesSet and combines it into a new seriesSet with the groups specified, using an aggregator to merge any series that share the matching tag values. If groups is empty, all series are combined into a single series, regardless of existing tags. The available aggregator functions are: avg (average), p50 (median), min (minimum) and max (maximum).

--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -593,6 +593,24 @@ Returns the length of the longest streak of values that evaluate to true (i.e. m
 
 Sum.
 
+# Aggregation Functions
+
+Aggregation functions take a seriesSet, and return a new seriesSet.
+
+## aggregate(seriesSet, groups string, aggregator string) seriesSet
+{: .exprFunc}
+
+Takes a seriesSet and combines it into a new seriesSet with the groups specified, using an aggregator to merge any series that share the matching tag values. If groups is empty, all series are combined into a single series, regardless of existing tags. The available aggregator functions are: avg (average), p50 (median), min (minimum) and max (maximum).
+
+This can be particularly useful for removing anomalies when comparing timeseries over periods using the over function. 
+
+Example:
+
+```
+$weeks = over("sum:1m-avg:os.cpu{region=*,color=*}", "24h", "1w", 3)
+$agg = aggregate($weeks, "region,color", "median")
+```
+
 # Group Functions
 
 Group functions modify the OpenTSDB groups.

--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -597,19 +597,21 @@ Sum.
 
 Aggregation functions take a seriesSet, and return a new seriesSet.
 
-## aggregate(series seriesSet, groups string, aggregator string) seriesSet
+## aggr(series seriesSet, groups string, aggregator string) seriesSet
 {: .exprFunc}
 
-Takes a seriesSet and combines it into a new seriesSet with the groups specified, using an aggregator to merge any series that share the matching tag values. If groups is empty, all series are combined into a single series, regardless of existing tags. The available aggregator functions are: avg (average), p50 (median), min (minimum) and max (maximum).
+Takes a seriesSet and combines it into a new seriesSet with the groups specified, using an aggregator to merge any series that share the matching group values. If the groups argument is an empty string, all series are combined into a single series, regardless of existing groups. The available aggregator functions are: avg (average), min (minimum), max (maximum), sum and pN (percentile) where N is a floating point number between 0 and 1 inclusive. For example, `"p.25"` will be the 25th percentile, `"p.999"` will be the 99.9th percentile. `"p0"` and `"p1"` are min and max respectively (However, in these cases it is recommended to use `"min"` and `"max"` for the sake of clarity.
 
-This can be particularly useful for removing anomalies when comparing timeseries over periods using the over function. 
+The aggr function can be particularly useful for removing anomalies when comparing timeseries over periods using the over function. 
 
 Example:
 
 ```
 $weeks = over("sum:1m-avg:os.cpu{region=*,color=*}", "24h", "1w", 3)
-$agg = aggregate($weeks, "region,color", "median")
+$agg = aggr($weeks, "region,color", "p.50")
 ```
+
+The above example uses `over` to load a 24 hour period over the past 3 weeks. We then use the aggr function to combine the three weeks into one, selecting the median (p.50) value of the 3 weeks at each timestamp. This results in a new seriesSet, grouped by region and color, that represents a "normal" 24 hour period with anomalies removed.
 
 # Group Functions
 


### PR DESCRIPTION
This PR adds an `aggregate` DSL function, which allows one to combine different series in a seriesSet using a specified aggregator (currently `min`, `max`, `p50`, `avg`). 

This is particularly useful when comparing data across different weeks (using the `over`) function. In our case, for anomaly detection, we want to compare the current day's data with an aggregated view of the same day in previous weeks. In particular, we want to compare each point in the last day to the _median_ of each point in the corresponding day for the last 3 weeks, so that any anomalies that occurred in a previous week are ignored. This way we compare with a hypothetical "perfect" day.

For example:

```
$weeks = over("avg:10m-avg-zero:os.cpu", "24h", "1w", 3)
$a = aggregate($weeks, "", "p50")
merge($a, $q)
```

Which looks like this:

![screen shot 2018-08-17 at 4 51 27 pm](https://user-images.githubusercontent.com/1121616/44275887-daa8cb00-a23d-11e8-8d7f-a5cd08761570.png)


Or, if we wanted to combine series but maintain the `region` and `color` groups`, that query would look like this:

```
$weeks = over("avg:10m-avg-zero:os.cpu{region=*,color=*}", "24h", "1w", 3)
aggregate($weeks, "region,color", "p50")
```

which would result in one merged series for each unique region/color combination.

I am very happy to take suggestions for changes / improvements. With regards to naming the function, I would have probably chosen "merge", but since that is already taken, I went with the OpenTSDB terminology and used "aggregate". 