### PR TITLE
Improve logs

### DIFF
--- a/cmd/bosun/conf/actionNotify.go
+++ b/cmd/bosun/conf/actionNotify.go
@@ -75,7 +75,7 @@ func (n *Notification) RunOnActionType(at models.ActionType) bool {
 
 // Prepate an action notification, but don't send yet.
 func (n *Notification) PrepareAction(at models.ActionType, t *Template, c SystemConfProvider, states []*models.IncidentState, user, message string) *PreparedNotifications {
-	pn := &PreparedNotifications{}
+	pn := &PreparedNotifications{Name: n.Name}
 	// get template keys to use for actions. Merge with default sets
 	tks := n.ActionTemplateKeys[at].Combine(n.ActionTemplateKeys[models.ActionNone])
 	buf := &bytes.Buffer{}

--- a/cmd/bosun/conf/actionNotify.go
+++ b/cmd/bosun/conf/actionNotify.go
@@ -75,7 +75,7 @@ func (n *Notification) RunOnActionType(at models.ActionType) bool {
 
 // Prepate an action notification, but don't send yet.
 func (n *Notification) PrepareAction(at models.ActionType, t *Template, c SystemConfProvider, states []*models.IncidentState, user, message string) *PreparedNotifications {
-	pn := &PreparedNotifications{Name: n.Name}
+	pn := &PreparedNotifications{Name: n.Name, Print: n.Print}
 	// get template keys to use for actions. Merge with default sets
 	tks := n.ActionTemplateKeys[at].Combine(n.ActionTemplateKeys[models.ActionNone])
 	buf := &bytes.Buffer{}

--- a/cmd/bosun/conf/notify.go
+++ b/cmd/bosun/conf/notify.go
@@ -38,6 +38,7 @@ func init() {
 type PreparedNotifications struct {
 	Email  *PreparedEmail
 	HTTP   []*PreparedHttp
+	Print  bool
 	Name   string
 	Errors []string
 }
@@ -47,7 +48,7 @@ func (p *PreparedNotifications) Send(c SystemConfProvider) (errs []error) {
 		if err := p.Email.Send(c); err != nil {
 			slog.Errorln("status: error; name: " + p.Name + "; subject: " + p.Email.Subject + "; transport: email; address: " + strings.Join(p.Email.To, ",") + "; body: " + p.Email.Body + "; error: " + err.Error())
 			errs = append(errs, err)
-		} else {
+		} else if p.Print {
 			slog.Infoln("status: success; name: " + p.Name + "; subject: " + p.Email.Subject + "; transport: email; address: " + strings.Join(p.Email.To, ",") + "; body: " + p.Email.Body)
 		}
 	}
@@ -55,7 +56,7 @@ func (p *PreparedNotifications) Send(c SystemConfProvider) (errs []error) {
 		if _, err := h.Send(); err != nil {
 			slog.Errorln("status: error; type: " + h.Details.At + "; name: " + h.Details.NotifyName + "; transport: http_" + h.Method + "; url: " + h.URL + "; body: " + h.Body + "; error: " + err.Error())
 			errs = append(errs, err)
-		} else {
+		} else if p.Print {
 			slog.Infoln("status: success; type: " + h.Details.At + "; name: " + h.Details.NotifyName + "; transport: http_" + h.Method + "; url: " + h.URL + "; body: " + h.Body)
 		}
 	}
@@ -66,7 +67,7 @@ func (p *PreparedNotifications) Send(c SystemConfProvider) (errs []error) {
 // PrepareAlert does all of the work of selecting what content to send to which sources. It does not actually send any notifications,
 // but the returned object can be used to send them.
 func (n *Notification) PrepareAlert(rt *models.RenderedTemplates, ak string, attachments ...*models.Attachment) *PreparedNotifications {
-	pn := &PreparedNotifications{Name: n.Name}
+	pn := &PreparedNotifications{Name: n.Name, Print: n.Print}
 	if len(n.Email) > 0 {
 		subject := rt.GetDefault(n.EmailSubjectTemplate, "emailSubject")
 		body := rt.GetDefault(n.BodyTemplate, "emailBody")

--- a/cmd/bosun/conf/unknownNotify.go
+++ b/cmd/bosun/conf/unknownNotify.go
@@ -186,7 +186,6 @@ func (n *Notification) NotifyMultipleUnknowns(t *Template, c SystemConfProvider,
 
 // code common to PrepareAction / PrepareUnknown / PrepareMultipleUnknowns
 func (n *Notification) prepareFromTemplateKeys(pn *PreparedNotifications, tks NotificationTemplateKeys, render func(string, *template.Template) (string, error), defaults defaultTemplates, alertDetails *NotificationDetails) {
-
 	if len(n.Email) > 0 || n.Post != nil || tks.PostTemplate != "" {
 		body, _ := render(tks.BodyTemplate, defaults.body)
 		if subject, err := render(tks.EmailSubjectTemplate, defaults.subject); err == nil {

--- a/cmd/bosun/web/web.go
+++ b/cmd/bosun/web/web.go
@@ -790,7 +790,7 @@ func Action(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (inter
 			return nil, err
 		}
 	} else {
-		slog.Infoln(fmt.Sprintf("action without notification. user: %s, type: %s, keys: %v, ids: %v", data.User, data.Type, data.Keys, data.Ids))
+		slog.Infof("action without notification. user: %s, type: %s, keys: %v, ids: %v", data.User, data.Type, data.Keys, data.Ids)
 	}
 	return nil, nil
 }

--- a/cmd/bosun/web/web.go
+++ b/cmd/bosun/web/web.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	"bosun.org/_version"
+	version "bosun.org/_version"
 	"bosun.org/annotate/backend"
 	"bosun.org/annotate/web"
 	"bosun.org/cmd/bosun/conf"
@@ -789,6 +789,8 @@ func Action(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (inter
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		slog.Infoln(fmt.Sprintf("action without notification. user: %s, type: %s, keys: %v, ids: %v", data.User, data.Type, data.Keys, data.Ids))
 	}
 	return nil, nil
 }


### PR DESCRIPTION
# problem
Sometimes people would complain that notifications about close/ack were not delivered to them
it seems that it's not possible to easily debug that now with current state of logs.

There is no log entries about successfull sending acks and closes. Only log failures (e.g. 400 response)
- notifications option 'print = true' also seems to not do anything for action notifications (even for failed notifications that are logged)
- logs don't allow you to understand if 'Send notifications' checkbox was on or off

# goal
- log successful actions (similar to how it logs alert notifications)
- print new logs according to 'notification' settings
- improve error log format - write extra data about notification that has delivery problem
- log actions if there wasn't set checkbox notification

# changes:
- add logging if there was action without notification
- add logging for any actions/alerts
- add extra felds to log messages