### PR TITLE
Fix math operations on results of aggr

### DIFF
--- a/cmd/bosun/expr/expr_test.go
+++ b/cmd/bosun/expr/expr_test.go
@@ -359,7 +359,7 @@ func TestSeriesOperations(t *testing.T) {
 				Results: ResultSlice{
 					&Result{
 						Value: Series{
-						// Should be empty
+							// Should be empty
 						},
 						Group: opentsdb.TagSet{"key": "a"},
 					},

--- a/cmd/bosun/expr/expr_test.go
+++ b/cmd/bosun/expr/expr_test.go
@@ -359,7 +359,7 @@ func TestSeriesOperations(t *testing.T) {
 				Results: ResultSlice{
 					&Result{
 						Value: Series{
-							// Should be empty
+						// Should be empty
 						},
 						Group: opentsdb.TagSet{"key": "a"},
 					},

--- a/cmd/bosun/expr/funcs.go
+++ b/cmd/bosun/expr/funcs.go
@@ -58,7 +58,11 @@ func aggrFuncTags(args []parse.Node) (parse.Tags, error) {
 		return nil, errors.New("aggr: expect group to be string")
 	}
 	s := args[1].(*parse.StringNode).Text
-	return tagsFromString(s)
+	tags := strings.Split(s, ",")
+	for i := range tags {
+		tags[i] += "=*"
+	}
+	return tagsFromString(strings.Join(tags, ","))
 }
 
 func tagsFromString(text string) (parse.Tags, error) {

--- a/cmd/bosun/expr/funcs.go
+++ b/cmd/bosun/expr/funcs.go
@@ -58,6 +58,9 @@ func aggrFuncTags(args []parse.Node) (parse.Tags, error) {
 		return nil, errors.New("aggr: expect group to be string")
 	}
 	s := args[1].(*parse.StringNode).Text
+	if s == "" {
+		return tagsFromString(s)
+	}
 	tags := strings.Split(s, ",")
 	for i := range tags {
 		tags[i] += "=*"

--- a/cmd/bosun/expr/funcs_test.go
+++ b/cmd/bosun/expr/funcs_test.go
@@ -264,250 +264,239 @@ func TestAggr(t *testing.T) {
 	seriesB := `series("foo=baz", 0, 3, 100, 4)`
 	seriesC := `series("foo=bat", 0, 5, 100, 6)`
 
-	// test median aggregator
-	err := testExpression(exprInOut{
-		fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"p.50\")", seriesA, seriesB, seriesC),
-		Results{
-			Results: ResultSlice{
-				&Result{
-					Value: Series{
-						time.Unix(0, 0):   3,
-						time.Unix(100, 0): 4,
+	seriesGroupsA := `series("color=blue,type=apple,name=bob", 0, 1)`
+	seriesGroupsB := `series("color=blue,type=apple", 1, 3)`
+	seriesGroupsC := `series("color=green,type=apple", 0, 5)`
+
+	seriesMathA := `series("color=blue,type=apple,name=bob", 0, 1)`
+	seriesMathB := `series("color=blue,type=apple", 1, 3)`
+	seriesMathC := `series("color=green,type=apple", 0, 5)`
+
+	aggrTestCases := []struct{
+		name      string
+		expr      string
+		want      Results
+		shouldErr bool
+	}{
+		{
+			name: "median aggregator",
+			expr: fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"p.50\")", seriesA, seriesB, seriesC),
+			want: Results{
+				Results: ResultSlice{
+					&Result{
+						Value: Series{
+							time.Unix(0, 0):   3,
+							time.Unix(100, 0): 4,
+						},
+						Group: opentsdb.TagSet{},
 					},
-					Group: opentsdb.TagSet{},
 				},
 			},
+			shouldErr: false,
 		},
-		false,
-	})
-	if err != nil {
-		t.Error(err)
-	}
-
-	// test average aggregator
-	err = testExpression(exprInOut{
-		fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"avg\")", seriesA, seriesB, seriesC),
-		Results{
-			Results: ResultSlice{
-				&Result{
-					Value: Series{
-						time.Unix(0, 0):   3,
-						time.Unix(100, 0): 4,
+		{
+			name: "average aggregator",
+			expr: fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"avg\")", seriesA, seriesB, seriesC),
+			want: Results{
+				Results: ResultSlice{
+					&Result{
+						Value: Series{
+							time.Unix(0, 0):   3,
+							time.Unix(100, 0): 4,
+						},
+						Group: opentsdb.TagSet{},
 					},
-					Group: opentsdb.TagSet{},
 				},
 			},
+			shouldErr: false,
 		},
-		false,
-	})
-	if err != nil {
-		t.Error(err)
-	}
-
-	// test min aggregator
-	err = testExpression(exprInOut{
-		fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"min\")", seriesA, seriesB, seriesC),
-		Results{
-			Results: ResultSlice{
-				&Result{
-					Value: Series{
-						time.Unix(0, 0):   1,
-						time.Unix(100, 0): 2,
+		{
+			name: "min aggregator",
+			expr: fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"min\")", seriesA, seriesB, seriesC),
+			want: Results{
+				Results: ResultSlice{
+					&Result{
+						Value: Series{
+							time.Unix(0, 0):   1,
+							time.Unix(100, 0): 2,
+						},
+						Group: opentsdb.TagSet{},
 					},
-					Group: opentsdb.TagSet{},
 				},
 			},
+			shouldErr: false,
 		},
-		false,
-	})
-	if err != nil {
-		t.Error(err)
-	}
-
-	// test max aggregator
-	err = testExpression(exprInOut{
-		fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"max\")", seriesA, seriesB, seriesC),
-		Results{
-			Results: ResultSlice{
-				&Result{
-					Value: Series{
-						time.Unix(0, 0):   5,
-						time.Unix(100, 0): 6,
+		{
+			name: "max aggregator",
+			expr: fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"max\")", seriesA, seriesB, seriesC),
+			want: Results{
+				Results: ResultSlice{
+					&Result{
+						Value: Series{
+							time.Unix(0, 0):   5,
+							time.Unix(100, 0): 6,
+						},
+						Group: opentsdb.TagSet{},
 					},
-					Group: opentsdb.TagSet{},
 				},
 			},
+			shouldErr: false,
 		},
-		false,
-	})
-	if err != nil {
-		t.Error(err)
-	}
-
-	// check that min == p0
-	err = testExpression(exprInOut{
-		fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"p0\")", seriesA, seriesB, seriesC),
-		Results{
-			Results: ResultSlice{
-				&Result{
-					Value: Series{
-						time.Unix(0, 0):   1,
-						time.Unix(100, 0): 2,
+		{
+			name: "check p0 == min",
+			expr: fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"p0\")", seriesA, seriesB, seriesC),
+			want: Results{
+				Results: ResultSlice{
+					&Result{
+						Value: Series{
+							time.Unix(0, 0):   1,
+							time.Unix(100, 0): 2,
+						},
+						Group: opentsdb.TagSet{},
 					},
-					Group: opentsdb.TagSet{},
 				},
 			},
+			shouldErr: false,
 		},
-		false,
-	})
-	if err != nil {
-		t.Error(err)
-	}
-
-	// check that sum aggregator sums up the aligned points in the series
-	err = testExpression(exprInOut{
-		fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"sum\")", seriesA, seriesB, seriesC),
-		Results{
-			Results: ResultSlice{
-				&Result{
-					Value: Series{
-						time.Unix(0, 0):   9,
-						time.Unix(100, 0): 12,
+		{
+			name: "check that sum aggregator sums up the aligned points in the series",
+			expr: fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"sum\")", seriesA, seriesB, seriesC),
+			want: Results{
+				Results: ResultSlice{
+					&Result{
+						Value: Series{
+							time.Unix(0, 0):   9,
+							time.Unix(100, 0): 12,
+						},
+						Group: opentsdb.TagSet{},
 					},
-					Group: opentsdb.TagSet{},
 				},
 			},
+			shouldErr: false,
 		},
-		false,
-	})
-	if err != nil {
-		t.Error(err)
-	}
-
-	// check that unknown aggregator errors out
-	err = testExpression(exprInOut{
-		fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"unknown\")", seriesA, seriesB, seriesC),
-		Results{},
-		false,
-	})
-	if err == nil {
-		t.Errorf("expected unknown aggregator to return error")
-	}
-}
-
-func TestAggrWithGroups(t *testing.T) {
-	seriesA := `series("color=blue,type=apple,name=bob", 0, 1)`
-	seriesB := `series("color=blue,type=apple", 1, 3)`
-	seriesC := `series("color=green,type=apple", 0, 5)`
-
-	// test aggregator with single group
-	err := testExpression(exprInOut{
-		fmt.Sprintf("aggr(merge(%v, %v, %v), \"color\", \"p.50\")", seriesA, seriesB, seriesC),
-		Results{
-			Results: ResultSlice{
-				&Result{
-					Value: Series{
-						time.Unix(0, 0): 1,
-						time.Unix(1, 0): 3,
+		{
+			name: "check that unknown aggregator errors out",
+			expr: fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"unknown\")", seriesA, seriesB, seriesC),
+			want: Results{},
+			shouldErr: false,
+		},
+		{
+			name: "single group",
+			expr: fmt.Sprintf("aggr(merge(%v, %v, %v), \"color\", \"p.50\")", seriesGroupsA, seriesGroupsB, seriesGroupsC),
+			want: Results{
+				Results: ResultSlice{
+					&Result{
+						Value: Series{
+							time.Unix(0, 0): 1,
+							time.Unix(1, 0): 3,
+						},
+						Group: opentsdb.TagSet{"color": "blue"},
 					},
-					Group: opentsdb.TagSet{"color": "blue"},
-				},
-				&Result{
-					Value: Series{
-						time.Unix(0, 0): 5,
+					&Result{
+						Value: Series{
+							time.Unix(0, 0): 5,
+						},
+						Group: opentsdb.TagSet{"color": "green"},
 					},
-					Group: opentsdb.TagSet{"color": "green"},
 				},
 			},
+			shouldErr: false,
 		},
-		false,
-	})
-	if err != nil {
-		t.Error(err)
-	}
-
-	// test aggregator with multiple groups
-	err = testExpression(exprInOut{
-		fmt.Sprintf("aggr(merge(%v, %v, %v), \"color,type\", \"p.50\")", seriesA, seriesB, seriesC),
-		Results{
-			Results: ResultSlice{
-				&Result{
-					Value: Series{
-						time.Unix(0, 0): 1,
-						time.Unix(1, 0): 3,
+		{
+			name: "multiple groups",
+			expr: fmt.Sprintf("aggr(merge(%v, %v, %v), \"color,type\", \"p.50\")", seriesGroupsA, seriesGroupsB, seriesGroupsC),
+			want: Results{
+				Results: ResultSlice{
+					&Result{
+						Value: Series{
+							time.Unix(0, 0): 1,
+							time.Unix(1, 0): 3,
+						},
+						Group: opentsdb.TagSet{"color": "blue", "type": "apple"},
 					},
-					Group: opentsdb.TagSet{"color": "blue", "type": "apple"},
-				},
-				&Result{
-					Value: Series{
-						time.Unix(0, 0): 5,
+					&Result{
+						Value: Series{
+							time.Unix(0, 0): 5,
+						},
+						Group: opentsdb.TagSet{"color": "green", "type": "apple"},
 					},
-					Group: opentsdb.TagSet{"color": "green", "type": "apple"},
 				},
 			},
+			shouldErr: false,
 		},
-		false,
-	})
-	if err != nil {
-		t.Error(err)
-	}
-}
-
-func TestAggrWithGroupsAndMathOperation(t *testing.T) {
-	seriesA := `series("color=blue,type=apple,name=bob", 0, 1)`
-	seriesB := `series("color=blue,type=apple", 1, 3)`
-	seriesC := `series("color=green,type=apple", 0, 5)`
-
-	// test aggregator with single group
-	err := testExpression(exprInOut{
-		fmt.Sprintf("aggr(merge(%v, %v, %v), \"color\", \"p.50\") * 2", seriesA, seriesB, seriesC),
-		Results{
-			Results: ResultSlice{
-				&Result{
-					Value: Series{
-						time.Unix(0, 0): 2,
-						time.Unix(1, 0): 6,
+		{
+			name: "aggregator with no groups and math operation",
+			expr: fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"p.50\") * 2", seriesMathA, seriesMathB, seriesMathC),
+			want: Results{
+				Results: ResultSlice{
+					&Result{
+						Value: Series{
+							time.Unix(0, 0): 10,
+							time.Unix(1, 0): 6,
+						},
+						Group: opentsdb.TagSet{},
 					},
-					Group: opentsdb.TagSet{"color": "blue"},
-				},
-				&Result{
-					Value: Series{
-						time.Unix(0, 0): 10,
-					},
-					Group: opentsdb.TagSet{"color": "green"},
 				},
 			},
+			shouldErr: false,
 		},
-		false,
-	})
-	if err != nil {
-		t.Error(err)
-	}
-
-	// test aggregator with multiple groups and math operation
-	err = testExpression(exprInOut{
-		fmt.Sprintf("aggr(merge(%v, %v, %v), \"color,type\", \"p.50\") * 2", seriesA, seriesB, seriesC),
-		Results{
-			Results: ResultSlice{
-				&Result{
-					Value: Series{
-						time.Unix(0, 0): 2,
-						time.Unix(1, 0): 6,
+		{
+			name: "aggregator with one group and math operation",
+			expr: fmt.Sprintf("aggr(merge(%v, %v, %v), \"color\", \"p.50\") * 2", seriesMathA, seriesMathB, seriesMathC),
+			want: Results{
+				Results: ResultSlice{
+					&Result{
+						Value: Series{
+							time.Unix(0, 0): 2,
+							time.Unix(1, 0): 6,
+						},
+						Group: opentsdb.TagSet{"color": "blue"},
 					},
-					Group: opentsdb.TagSet{"color": "blue", "type": "apple"},
-				},
-				&Result{
-					Value: Series{
-						time.Unix(0, 0): 10,
+					&Result{
+						Value: Series{
+							time.Unix(0, 0): 10,
+						},
+						Group: opentsdb.TagSet{"color": "green"},
 					},
-					Group: opentsdb.TagSet{"color": "green", "type": "apple"},
 				},
 			},
+			shouldErr: false,
 		},
-		false,
-	})
-	if err != nil {
-		t.Error(err)
+		{
+			name: "aggregator with multiple groups and math operation",
+			expr: fmt.Sprintf("aggr(merge(%v, %v, %v), \"color,type\", \"p.50\") * 2", seriesMathA, seriesMathB, seriesMathC),
+			want: Results{
+				Results: ResultSlice{
+					&Result{
+						Value: Series{
+							time.Unix(0, 0): 2,
+							time.Unix(1, 0): 6,
+						},
+						Group: opentsdb.TagSet{"color": "blue", "type": "apple"},
+					},
+					&Result{
+						Value: Series{
+							time.Unix(0, 0): 10,
+						},
+						Group: opentsdb.TagSet{"color": "green", "type": "apple"},
+					},
+				},
+			},
+			shouldErr: false,
+		},
+	}
+
+	for _, tc := range aggrTestCases {
+		err := testExpression(exprInOut{
+			expr: tc.expr,
+			out: tc.want,
+			shouldParseErr: false,
+		})
+		if tc.shouldErr && err != nil {
+			t.Errorf("Case %q: Got error: %v", tc.name, err)
+		} else if tc.shouldErr && err == nil {
+			t.Errorf("Case %q: Expected parse error, but got nil", tc.name)
+		}
 	}
 }
 

--- a/cmd/bosun/expr/funcs_test.go
+++ b/cmd/bosun/expr/funcs_test.go
@@ -378,7 +378,7 @@ func TestAggr(t *testing.T) {
 			name: "check that unknown aggregator errors out",
 			expr: fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"unknown\")", seriesA, seriesB, seriesC),
 			want: Results{},
-			shouldErr: false,
+			shouldErr: true,
 		},
 		{
 			name: "single group",
@@ -492,7 +492,7 @@ func TestAggr(t *testing.T) {
 			out: tc.want,
 			shouldParseErr: false,
 		})
-		if tc.shouldErr && err != nil {
+		if !tc.shouldErr && err != nil {
 			t.Errorf("Case %q: Got error: %v", tc.name, err)
 		} else if tc.shouldErr && err == nil {
 			t.Errorf("Case %q: Expected parse error, but got nil", tc.name)

--- a/cmd/bosun/expr/funcs_test.go
+++ b/cmd/bosun/expr/funcs_test.go
@@ -272,7 +272,7 @@ func TestAggr(t *testing.T) {
 	seriesMathB := `series("color=blue,type=apple", 1, 3)`
 	seriesMathC := `series("color=green,type=apple", 0, 5)`
 
-	aggrTestCases := []struct{
+	aggrTestCases := []struct {
 		name      string
 		expr      string
 		want      Results
@@ -375,9 +375,9 @@ func TestAggr(t *testing.T) {
 			shouldErr: false,
 		},
 		{
-			name: "check that unknown aggregator errors out",
-			expr: fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"unknown\")", seriesA, seriesB, seriesC),
-			want: Results{},
+			name:      "check that unknown aggregator errors out",
+			expr:      fmt.Sprintf("aggr(merge(%v, %v, %v), \"\", \"unknown\")", seriesA, seriesB, seriesC),
+			want:      Results{},
 			shouldErr: true,
 		},
 		{
@@ -488,8 +488,8 @@ func TestAggr(t *testing.T) {
 
 	for _, tc := range aggrTestCases {
 		err := testExpression(exprInOut{
-			expr: tc.expr,
-			out: tc.want,
+			expr:           tc.expr,
+			out:            tc.want,
 			shouldParseErr: false,
 		})
 		if !tc.shouldErr && err != nil {


### PR DESCRIPTION
This PR fixes a bug in `aggr` that causes math operations on the resulting series to fail. It also adds tests for such cases, and refactors the `aggr` tests to be [table-driven](https://github.com/golang/go/wiki/TableDrivenTests).

Without this fix, math operations cause an error like expr: opentsdb: bad tag: color. The tests included here were failing before the fix with such an error.

CC @kylebrandt