### PR TITLE
Allow Elasticsearch Auth and TLS

### DIFF
--- a/cmd/scollector/collectors/elasticsearch.go
+++ b/cmd/scollector/collectors/elasticsearch.go
@@ -64,36 +64,30 @@ func init() {
 				creds = ""
 			}
 			url := fmt.Sprintf("%v://%v%v:%v", instance.Scheme, creds, instance.Host, instance.Port)
-			var instanceName string
-			if instance.Name == "" {
-				instanceName = fmt.Sprintf("%v_%v", instance.Host, instance.Port)
-			} else {
-				instanceName = instance.Name
-			}
 			if instance.IndexInterval != "" {
 				indexInterval, err = time.ParseDuration(instance.IndexInterval)
 				if err != nil {
 					panic(fmt.Errorf("Failed to parse IndexInterval: %v, err: %v", instance.IndexInterval, err))
 				}
-				slog.Infof("Using IndexInterval: %v for %v", indexInterval, instanceName)
+				slog.Infof("Using IndexInterval: %v for %v", indexInterval, instance.Name)
 			} else {
-				slog.Infof("Using default IndexInterval: %v for %v", indexInterval, instanceName)
+				slog.Infof("Using default IndexInterval: %v for %v", indexInterval, instance.Name)
 			}
 			if instance.ClusterInterval != "" {
 				clusterInterval, err = time.ParseDuration(instance.ClusterInterval)
 				if err != nil {
 					panic(fmt.Errorf("Failed to parse ClusterInterval: %v, err: %v", instance.ClusterInterval, err))
 				}
-				slog.Infof("Using ClusterInterval: %v for %v", clusterInterval, instanceName)
+				slog.Infof("Using ClusterInterval: %v for %v", clusterInterval, instance.Name)
 			} else {
-				slog.Infof("Using default ClusterInterval: %v for %v", clusterInterval, instanceName)
+				slog.Infof("Using default ClusterInterval: %v for %v", clusterInterval, instance.Name)
 			}
 			// for legacy reasons, keep localhost:9200 named elasticsearch / elasticsearch-indices
 			var name string
-			if instanceName == "localhost_9200" {
+			if instance.Name == "localhost_9200" {
 				name = "elasticsearch"
 			} else {
-				name = fmt.Sprintf("elasticsearch-%v", instanceName)
+				name = fmt.Sprintf("elasticsearch-%v", instance.Name)
 			}
 			collectors = append(collectors, &IntervalCollector{
 				F: func() (opentsdb.MultiDataPoint, error) {
@@ -104,10 +98,10 @@ func init() {
 				Enable:   enableURL(url),
 			})
 			// keep legacy collector name if localhost_9200
-			if instanceName == "localhost_9200" {
+			if instance.Name == "localhost_9200" {
 				name = "elasticsearch-indices"
 			} else {
-				name = fmt.Sprintf("elasticsearch-indices-%v", instanceName)
+				name = fmt.Sprintf("elasticsearch-indices-%v", instance.Name)
 			}
 			collectors = append(collectors, &IntervalCollector{
 				F: func() (opentsdb.MultiDataPoint, error) {

--- a/cmd/scollector/collectors/elasticsearch.go
+++ b/cmd/scollector/collectors/elasticsearch.go
@@ -40,13 +40,6 @@ func init() {
 			var indexInterval = time.Minute * 15
 			var clusterInterval = DefaultFreq
 			var err error
-			if instance.Name == "" {
-				instance.Name = fmt.Sprintf("%v_%v", instance.Host, instance.Port)
-			}
-			if instance.Disable {
-				slog.Infof("Elastic instance %v is disabled. Skipping.", instance.Name)
-				continue
-			}
 			// preserve defaults of localhost:9200
 			if instance.Host == "" {
 				instance.Host = "localhost"
@@ -56,6 +49,13 @@ func init() {
 			}
 			if instance.Scheme == "" {
 				instance.Scheme = "http"
+			}
+			if instance.Name == "" {
+				instance.Name = fmt.Sprintf("%v_%v", instance.Host, instance.Port)
+			}
+			if instance.Disable {
+				slog.Infof("Elastic instance %v is disabled. Skipping.", instance.Name)
+				continue
 			}
 			var creds string
 			if instance.User != "" || instance.Password != "" {

--- a/cmd/scollector/collectors/interval.go
+++ b/cmd/scollector/collectors/interval.go
@@ -117,6 +117,7 @@ func enableURL(url string, regexes ...string) func() bool {
 			resp.Body.Close()
 		}()
 		if resp.StatusCode != 200 {
+			slog.Infof("URL not enabled: %v; HTTP Response not 200, but %v", url, resp.StatusCode)
 			return false
 		}
 		if len(res) == 0 {

--- a/cmd/scollector/conf/conf.go
+++ b/cmd/scollector/conf/conf.go
@@ -275,4 +275,9 @@ type Elastic struct {
 	Port            uint16 // default is 9200
 	ClusterInterval string // default is DefaultFreq
 	IndexInterval   string // default is 15 mins
+	User            string // default is empty
+	Password        string // default is empty
+	Disable         bool   // default is false.
+	Name            string // default is host_port
+	Scheme          string // default is http
 }

--- a/cmd/scollector/doc.go
+++ b/cmd/scollector/doc.go
@@ -414,19 +414,23 @@ ConnectionString and Role, which are the same as using sqlplus.
 
 By default Elastic nodes are auto-detected on localhost:9200, but if you have a
 node running on another network interface, a non-standard port or even multiple
-nodes running on the same host you can use the Elastic configuration:
+nodes running on the same host you can use the Elastic configuration. Also lets
+you specify basic auth credentials and using TLS by setting the Scheme to https:
 
-  [[Elastic]]
-    Host = "192.168.1.1"
-    Port = 9201
-    ClusterInterval = "10s"
-    IndexInterval = "1m"
+	[[Elastic]]
+	  Host = "192.168.1.1"
+	  Port = 9201
+	  ClusterInterval = "10s"
+	  IndexInterval = "1m"
+	  User = "user"
+	  Password = "pass"
+	  Scheme = "https"
 
-  [[Elastic]]
-    Host = "192.168.1.1"
-    Port = 9202
-    ClusterInterval = "10s"
-    IndexInterval = "1m"
+	[[Elastic]]
+	  Host = "192.168.1.1"
+	  Port = 9202
+	  ClusterInterval = "10s"
+	  IndexInterval = "1m"
 
 Windows
 


### PR DESCRIPTION
Adds new configuration options for Elastic, allowing to establish encrypted (https) connections, and providing HTTP basic auth credentials.
Also adds a convenience flag to easily disable an Elastic block without actually having to remove it.