### PR TITLE
Add tsdb query functions with end duration parameter.

### DIFF
--- a/cmd/bosun/expr/expr_test.go
+++ b/cmd/bosun/expr/expr_test.go
@@ -122,6 +122,19 @@ var queryTime = time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC)
 
 func TestQueryExpr(t *testing.T) {
 	queries := map[string]opentsdb.ResponseSet{
+		`q("avg:m{a=*}", "9.467277e+08", "9.46728e+08")`: {
+			{
+				Metric: "m",
+				Tags:   opentsdb.TagSet{"a": "b"},
+				DPS:    map[string]opentsdb.Point{"0": 0, "1": 3},
+			},
+			{
+				Metric: "m",
+				Tags:   opentsdb.TagSet{"a": "c"},
+				DPS:    map[string]opentsdb.Point{"5": 1, "7": 4},
+			},
+		},
+
 		`q("avg:m{a=*}", "9.467241e+08", "9.467244e+08")`: {
 			{
 				Metric: "m",
@@ -151,7 +164,7 @@ func TestQueryExpr(t *testing.T) {
 	tests := map[string]map[string]Value{
 		`window("avg:m{a=*}", "5m", "1h", 2, "max")`: {
 			"a=b": Series{
-				d: 2,
+				d:                      2,
 				d.Add(time.Second * 2): 6,
 			},
 			"a=c": Series{
@@ -163,7 +176,7 @@ func TestQueryExpr(t *testing.T) {
 		},
 		`window("avg:m{a=*}", "5m", "1h", 2, "avg")`: {
 			"a=b": Series{
-				d: 1.5,
+				d:                      1.5,
 				d.Add(time.Second * 2): 5,
 			},
 			"a=c": Series{
@@ -171,6 +184,66 @@ func TestQueryExpr(t *testing.T) {
 			},
 			"a=d": Series{
 				d.Add(time.Second * 8): 8.5,
+			},
+		},
+		`over("avg:m{a=*}", "5m", "1h", 3)`: {
+			"a=b,shift=0s": Series{
+				d:                      0,
+				d.Add(time.Second * 1): 3,
+			},
+			"a=b,shift=1h0m0s": Series{
+				d.Add(time.Hour):                 1,
+				d.Add(time.Hour + time.Second*1): 2,
+			},
+			"a=b,shift=2h0m0s": Series{
+				d.Add(time.Hour*2 + time.Second*2): 6,
+				d.Add(time.Hour*2 + time.Second*3): 4,
+			},
+			"a=c,shift=0s": Series{
+				d.Add(time.Second * 5): 1,
+				d.Add(time.Second * 7): 4,
+			},
+			"a=c,shift=1h0m0s": Series{
+				d.Add(time.Hour + time.Second*3): 7,
+				d.Add(time.Hour + time.Second*1): 8,
+			},
+			"a=d,shift=2h0m0s": Series{
+				d.Add(time.Hour*2 + time.Second*8): 8,
+				d.Add(time.Hour*2 + time.Second*9): 9,
+			},
+		},
+		`band("avg:m{a=*}", "5m", "1h", 2)`: {
+			"a=b": Series{
+				d:                      1,
+				d.Add(time.Second * 1): 2,
+				d.Add(time.Second * 2): 6,
+				d.Add(time.Second * 3): 4,
+			},
+			"a=c": Series{
+				d.Add(time.Second * 3): 7,
+				d.Add(time.Second * 1): 8,
+			},
+			"a=d": Series{
+				d.Add(time.Second * 8): 8,
+				d.Add(time.Second * 9): 9,
+			},
+		},
+		`shiftBand("avg:m{a=*}", "5m", "1h", 2)`: {
+			"a=b,shift=1h0m0s": Series{
+				d.Add(time.Hour):                 1,
+				d.Add(time.Hour + time.Second*1): 2,
+			},
+			"a=b,shift=2h0m0s": Series{
+				d.Add(time.Hour*2 + time.Second*2): 6,
+				d.Add(time.Hour*2 + time.Second*3): 4,
+			},
+			"a=c,shift=1h0m0s": Series{
+				d.Add(time.Hour + time.Second*3): 7,
+				d.Add(time.Hour + time.Second*1): 8,
+			},
+			"a=d,shift=2h0m0s": Series{
+				d.Add(time.Hour*2 + time.Second*8): 8,
+				d.Add(time.Hour*2 + time.Second*9): 9,
 			},
 		},
 		`abs(-1)`: {"": Number(1)},

--- a/cmd/bosun/expr/expr_test.go
+++ b/cmd/bosun/expr/expr_test.go
@@ -164,7 +164,7 @@ func TestQueryExpr(t *testing.T) {
 	tests := map[string]map[string]Value{
 		`window("avg:m{a=*}", "5m", "1h", 2, "max")`: {
 			"a=b": Series{
-				d:                      2,
+				d: 2,
 				d.Add(time.Second * 2): 6,
 			},
 			"a=c": Series{
@@ -176,7 +176,7 @@ func TestQueryExpr(t *testing.T) {
 		},
 		`window("avg:m{a=*}", "5m", "1h", 2, "avg")`: {
 			"a=b": Series{
-				d:                      1.5,
+				d: 1.5,
 				d.Add(time.Second * 2): 5,
 			},
 			"a=c": Series{
@@ -188,7 +188,7 @@ func TestQueryExpr(t *testing.T) {
 		},
 		`over("avg:m{a=*}", "5m", "1h", 3)`: {
 			"a=b,shift=0s": Series{
-				d:                      0,
+				d: 0,
 				d.Add(time.Second * 1): 3,
 			},
 			"a=b,shift=1h0m0s": Series{
@@ -214,7 +214,7 @@ func TestQueryExpr(t *testing.T) {
 		},
 		`band("avg:m{a=*}", "5m", "1h", 2)`: {
 			"a=b": Series{
-				d:                      1,
+				d: 1,
 				d.Add(time.Second * 1): 2,
 				d.Add(time.Second * 2): 6,
 				d.Add(time.Second * 3): 4,

--- a/cmd/bosun/expr/tsdb.go
+++ b/cmd/bosun/expr/tsdb.go
@@ -288,11 +288,6 @@ func windowCheck(t *parse.Tree, f *parse.FuncNode) error {
 	return nil
 }
 
-func Band(e *State, query, duration, period string, num float64) (r *Results, err error) {
-	// existing Band behaviour is to end 'period' ago, so pass period as eduration.
-	return BandQuery(e, query, duration, period, period, num)
-}
-
 func BandQuery(e *State, query, duration, period, eduration string, num float64) (r *Results, err error) {
 	r, err = bandTSDB(e, query, duration, period, eduration, num, func(r *Results, res *opentsdb.Response, offset time.Duration) error {
 		newarr := true
@@ -331,8 +326,8 @@ func BandQuery(e *State, query, duration, period, eduration string, num float64)
 	return
 }
 
-func ShiftBand(e *State, query, duration, period string, num float64) (r *Results, err error) {
-	r, err = bandTSDB(e, query, duration, period, period, num, func(r *Results, res *opentsdb.Response, offset time.Duration) error {
+func OverQuery(e *State, query, duration, period, eduration string, num float64) (r *Results, err error) {
+	r, err = bandTSDB(e, query, duration, period, eduration, num, func(r *Results, res *opentsdb.Response, offset time.Duration) error {
 		values := make(Series)
 		a := &Result{Group: res.Tags.Merge(opentsdb.TagSet{"shift": offset.String()})}
 		for k, v := range res.DPS {
@@ -352,80 +347,17 @@ func ShiftBand(e *State, query, duration, period string, num float64) (r *Result
 	return
 }
 
-func Over(e *State, query, duration, period string, num float64) (r *Results, err error) {
-	return OverQuery(e, query, duration, period, "", num)
+func Band(e *State, query, duration, period string, num float64) (r *Results, err error) {
+	// existing Band behaviour is to end 'period' ago, so pass period as eduration.
+	return BandQuery(e, query, duration, period, period, num)
 }
 
-func OverQuery(e *State, query, duration, period, eduration string, num float64) (r *Results, err error) {
-	r = new(Results)
-	r.IgnoreOtherUnjoined = true
-	r.IgnoreUnjoined = true
-	e.Timer.Step("band", func(T miniprofiler.Timer) {
-		var d, p opentsdb.Duration
-		d, err = opentsdb.ParseDuration(duration)
-		if err != nil {
-			return
-		}
-		p, err = opentsdb.ParseDuration(period)
-		if err != nil {
-			return
-		}
-		if num < 1 || num > 100 {
-			err = fmt.Errorf("num out of bounds")
-		}
-		var q *opentsdb.Query
-		q, err = opentsdb.ParseQuery(query, e.TSDBContext.Version())
-		if err != nil {
-			return
-		}
-		if !e.TSDBContext.Version().FilterSupport() {
-			if err = e.Search.Expand(q); err != nil {
-				return
-			}
-		}
-		req := opentsdb.Request{
-			Queries: []*opentsdb.Query{q},
-		}
-		end := e.now
-		if eduration != "" {
-			var ed opentsdb.Duration
-			ed, err = opentsdb.ParseDuration(eduration)
-			if err != nil {
-				return
-			}
-			end = end.Add(time.Duration(-ed))
-		}
-		req.End = end.Unix()
-		req.Start = end.Add(time.Duration(-d)).Unix()
-		for i := 0; i < int(num); i++ {
-			var s opentsdb.ResponseSet
-			s, err = timeTSDBRequest(e, &req)
-			if err != nil {
-				return
-			}
-			offset := e.now.Sub(end)
-			for _, res := range s {
-				if e.Squelched(res.Tags) {
-					continue
-				}
-				values := make(Series)
-				a := &Result{Group: res.Tags.Merge(opentsdb.TagSet{"shift": offset.String()})}
-				for k, v := range res.DPS {
-					i, err := strconv.ParseInt(k, 10, 64)
-					if err != nil {
-						return
-					}
-					values[time.Unix(i, 0).Add(offset).UTC()] = float64(v)
-				}
-				a.Value = values
-				r.Results = append(r.Results, a)
-			}
-			end = end.Add(time.Duration(-p))
-			req.End = end.Unix()
-			req.Start = end.Add(time.Duration(-d)).Unix()
-		}
-	})
-	return
+func ShiftBand(e *State, query, duration, period string, num float64) (r *Results, err error) {
+	return OverQuery(e, query, duration, period, period, num)
+}
+
+func Over(e *State, query, duration, period string, num float64) (r *Results, err error) {
+	return OverQuery(e, query, duration, period, "", num)
 }
 
 func Query(e *State, query, sduration, eduration string) (r *Results, err error) {

--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -374,10 +374,19 @@ Generic query from endDuration to startDuration ago. If endDuration is the empty
 
 Band performs `num` queries of `duration` each, `period` apart and concatenates them together, starting `period` ago. So `band("avg:os.cpu", "1h", "1d", 7)` will return a series comprising of the given metric from 1d to 1d-1h-ago, 2d to 2d-1h-ago, etc, until 8d. This is a good way to get a time block from a certain hour of a day or certain day of a week over a long time period.
 
+Note: this function wraps a more general version `bandQuery(query string, duration string, period string, eduration string, num scalar) seriesSet`, where `eduration` specifies the end duration for the query to stop at, as with `q()`.
+
 ### over(query string, duration string, period string, num scalar) seriesSet
 {: .exprFunc}
 
-Over's arguments behave the same way as band. However over shifts the time of previous periods to be now, tags them with duration that each period was shifted, and merges those shifted periods into a single seriesSet. This is useful for displaying time over time graphs. For example, the same day week over week would be `over("avg:1h-avg:rate:os.cpu{host=ny-bosun01}", "1d", "1w", 4)`.
+Over's arguments behave the same way as band. However over shifts the time of previous periods to be now, tags them with duration that each period was shifted, and merges those shifted periods into a single seriesSet, which includes the most recent period. This is useful for displaying time over time graphs. For example, the same day week over week would be `over("avg:1h-avg:rate:os.cpu{host=ny-bosun01}", "1d", "1w", 4)`.
+
+Note: this function wraps a more general version `overQuery(query string, duration string, period string, eduration string, num scalar) seriesSet`, where `eduration` specifies the end duration for the query to stop at, as with `q`. Results are still shifted to end at current time.
+
+### shiftBand(query string, duration string, period string, num scalar) seriesSet
+{: .exprFunc}
+
+shiftBand's behaviour is very similar to `over`, however the most recent period is not included in the seriesSet. This function could be useful for anomaly detection when used with `aggr`, to calculate historical distributions to compare against.
 
 ### change(query string, startDuration string, endDuration string) numberSet
 {: .exprFunc}


### PR DESCRIPTION
This PR adds two functions for querying against openTSDB – `overQuery` and `bandQuery`. These functions slightly generalise the existing `over` and `band` functions to include an end duration parameter `eduration`, which specifies when a query should end, as is done with `q`. This enables queries for a historical distribution that does not include recent outliers – related discussion in #2297 .

The existing `over` and `band` functions are changed to wrap the more general functions. The undocumented and very related `shiftBand` function was found during this work, and is added to the documentation.

The third commit f61259a refactors the functions to reuse `bandTSDB`, as `shiftBand` used this function to achieve comparable functionality to `over`.

Tests were written based on the existing function of `over`, `band` and `shiftBand` to ensure same behaviour remains.