### PR TITLE
cmd/bosun: add origin to expr state

### DIFF
--- a/cmd/bosun/expr/expr_test.go
+++ b/cmd/bosun/expr/expr_test.go
@@ -68,7 +68,7 @@ func TestExprSimple(t *testing.T) {
 			InfluxConfig: client.HTTPConfig{},
 		}
 		providers := &BosunProviders{}
-		r, _, err := e.Execute(backends, providers, nil, time.Now(), 0, false)
+		r, _, err := e.Execute(backends, providers, nil, time.Now(), 0, false, t.Name())
 		if err != nil {
 			t.Error(err)
 			break
@@ -287,7 +287,7 @@ func TestQueryExpr(t *testing.T) {
 			InfluxConfig: client.HTTPConfig{},
 		}
 		providers := &BosunProviders{}
-		results, _, err := e.Execute(backends, providers, nil, queryTime, 0, false)
+		results, _, err := e.Execute(backends, providers, nil, queryTime, 0, false, t.Name())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/bosun/expr/expr_test.go
+++ b/cmd/bosun/expr/expr_test.go
@@ -397,7 +397,7 @@ func TestSetVariant(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		err := testExpression(test)
+		err := testExpression(test, t)
 		if err != nil {
 			t.Error(err)
 		}
@@ -458,7 +458,7 @@ func TestSeriesOperations(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		err := testExpression(test)
+		err := testExpression(test, t)
 		if err != nil {
 			t.Error(err)
 		}

--- a/cmd/bosun/expr/funcs_test.go
+++ b/cmd/bosun/expr/funcs_test.go
@@ -17,7 +17,7 @@ type exprInOut struct {
 	shouldParseErr bool
 }
 
-func testExpression(eio exprInOut) error {
+func testExpression(eio exprInOut, t *testing.T) error {
 	e, err := New(eio.expr, builtins)
 	if eio.shouldParseErr {
 		if err == nil {
@@ -54,7 +54,7 @@ func TestDuration(t *testing.T) {
 		},
 		false,
 	}
-	err := testExpression(d)
+	err := testExpression(d, t)
 	if err != nil {
 		t.Error(err)
 	}
@@ -92,7 +92,7 @@ func TestToDuration(t *testing.T) {
 			},
 			false,
 		}
-		err := testExpression(d)
+		err := testExpression(d, t)
 		if err != nil {
 			t.Error(err)
 		}
@@ -114,7 +114,7 @@ func TestUngroup(t *testing.T) {
 			},
 		},
 		false,
-	})
+	}, t)
 
 	if err != nil {
 		t.Error(err)
@@ -143,7 +143,7 @@ func TestMerge(t *testing.T) {
 			},
 		},
 		false,
-	})
+	}, t)
 	if err != nil {
 		t.Error(err)
 	}
@@ -168,7 +168,7 @@ func TestMerge(t *testing.T) {
 			},
 		},
 		false,
-	})
+	}, t)
 	if err == nil {
 		t.Errorf("error expected due to identical groups in merge but did not get one")
 	}
@@ -205,7 +205,7 @@ func TestTimedelta(t *testing.T) {
 				},
 			},
 			false,
-		})
+		}, t)
 
 		if err != nil {
 			t.Error(err)
@@ -251,7 +251,7 @@ func TestTail(t *testing.T) {
 				},
 			},
 			false,
-		})
+		}, t)
 
 		if err != nil {
 			t.Error(err)
@@ -491,7 +491,7 @@ func TestAggr(t *testing.T) {
 			expr:           tc.expr,
 			out:            tc.want,
 			shouldParseErr: false,
-		})
+		}, t)
 		if !tc.shouldErr && err != nil {
 			t.Errorf("Case %q: Got error: %v", tc.name, err)
 		} else if tc.shouldErr && err == nil {

--- a/cmd/bosun/expr/funcs_test.go
+++ b/cmd/bosun/expr/funcs_test.go
@@ -32,7 +32,7 @@ func testExpression(eio exprInOut) error {
 		InfluxConfig: client.HTTPConfig{},
 	}
 	providers := &BosunProviders{}
-	r, _, err := e.Execute(backends, providers, nil, queryTime, 0, false)
+	r, _, err := e.Execute(backends, providers, nil, queryTime, 0, false, t.Name())
 	if err != nil {
 		return err
 	}
@@ -529,7 +529,7 @@ func TestAggrNaNHandling(t *testing.T) {
 		InfluxConfig: client.HTTPConfig{},
 	}
 	providers := &BosunProviders{}
-	_, _, err = e.Execute(backends, providers, nil, queryTime, 0, false)
+	_, _, err = e.Execute(backends, providers, nil, queryTime, 0, false, t.Name())
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/cmd/bosun/expr/map_test.go
+++ b/cmd/bosun/expr/map_test.go
@@ -22,7 +22,7 @@ func TestMap(t *testing.T) {
 			},
 		},
 		false,
-	})
+	}, t)
 	if err != nil {
 		t.Error(err)
 	}
@@ -38,7 +38,7 @@ func TestMap(t *testing.T) {
 			},
 		},
 		false,
-	})
+	}, t)
 	if err != nil {
 		t.Error(err)
 	}
@@ -54,7 +54,7 @@ func TestMap(t *testing.T) {
 			},
 		},
 		false,
-	})
+	}, t)
 	if err != nil {
 		t.Error(err)
 	}
@@ -70,7 +70,7 @@ func TestMap(t *testing.T) {
 			},
 		},
 		false,
-	})
+	}, t)
 	if err != nil {
 		t.Error(err)
 	}
@@ -89,7 +89,7 @@ func TestMap(t *testing.T) {
 			},
 		},
 		false,
-	})
+	}, t)
 	if err != nil {
 		t.Error(err)
 	}
@@ -108,7 +108,7 @@ func TestMap(t *testing.T) {
 			},
 		},
 		false,
-	})
+	}, t)
 	if err != nil {
 		t.Error(err)
 	}
@@ -124,7 +124,7 @@ func TestMap(t *testing.T) {
 			},
 		},
 		true, // expect parse error here, series result not valid as TypeNumberExpr
-	})
+	}, t)
 	if err != nil {
 		t.Error(err)
 	}
@@ -140,7 +140,7 @@ func TestMap(t *testing.T) {
 			},
 		},
 		true, // v() is not valid outside a map expression
-	})
+	}, t)
 	if err != nil {
 		t.Error(err)
 	}
@@ -159,7 +159,7 @@ func TestMap(t *testing.T) {
 			},
 		},
 		false,
-	})
+	}, t)
 	if err != nil {
 		t.Error(err)
 	}

--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -643,7 +643,8 @@ func (s *Schedule) executeExpr(T miniprofiler.Timer, rh *RunHistory, a *conf.Ale
 		History:   s,
 		Annotate:  s.annotate,
 	}
-	results, _, err := e.Execute(rh.Backends, providers, T, rh.Start, 0, a.UnjoinedOK)
+	origin := fmt.Sprintf("Schedule: Alert Name: %s", a.Name)
+	results, _, err := e.Execute(rh.Backends, providers, T, rh.Start, 0, a.UnjoinedOK, origin)
 	return results, err
 }
 

--- a/cmd/bosun/sched/template.go
+++ b/cmd/bosun/sched/template.go
@@ -303,7 +303,8 @@ func (c *Context) evalExpr(e *expr.Expr, filter bool, series bool, autods int) (
 		Squelched: c.schedule.RuleConf.AlertSquelched(c.Alert),
 		History:   c.schedule,
 	}
-	res, _, err := e.Execute(c.runHistory.Backends, providers, nil, c.runHistory.Start, autods, c.Alert.UnjoinedOK)
+	origin := fmt.Sprintf("Template: Alert Key: %v", c.AlertKey)
+	res, _, err := e.Execute(c.runHistory.Backends, providers, nil, c.runHistory.Start, autods, c.Alert.UnjoinedOK, origin)
 	if err != nil {
 		return nil, "", fmt.Errorf("%s: %v", e, err)
 	}

--- a/cmd/bosun/web/chart.go
+++ b/cmd/bosun/web/chart.go
@@ -253,7 +253,7 @@ func ExprGraph(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (in
 		Squelched: nil,
 		History:   nil,
 	}
-	res, _, err := e.Execute(backends, providers, t, now, autods, false)
+	res, _, err := e.Execute(backends, providers, t, now, autods, false, "Web: chart creation")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/bosun/web/expr.go
+++ b/cmd/bosun/web/expr.go
@@ -95,7 +95,7 @@ func Expr(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (v inter
 		History:   nil,
 		Annotate:  AnnotateBackend,
 	}
-	res, queries, err := e.Execute(backends, providers, t, now, 0, false)
+	res, queries, err := e.Execute(backends, providers, t, now, 0, false, "Web: expression execution")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
this way when we attempt to recover or panic we can identify the source of the issue