### PR TITLE
Cleanup influxdb http client connection resources

### DIFF
--- a/cmd/bosun/expr/influx.go
+++ b/cmd/bosun/expr/influx.go
@@ -195,6 +195,7 @@ func timeInfluxRequest(e *State, db, query, startDuration, endDuration, groupByI
 	if err != nil {
 		return nil, err
 	}
+	defer conn.Close()
 	q_key := fmt.Sprintf("%s: %s", db, q)
 	e.Timer.StepCustomTiming("influx", "query", q_key, func() {
 		getFn := func() (interface{}, error) {


### PR DESCRIPTION
Fixes a tcp session leak by calling Close() on the influxdb client connection before exiting.

Our InfluxDB was crashing and having issues on an older version, and then bosun was getting back invalid Influx result errors even though other programs could query it.  Upon investigation it was discovered we had over 39,000 connections to the InfluxDB instance running on localhost from bosun and no new connections could be made.

The influxdb client close method properly frees these sessions after a query and connection counts are below 30 now.
