### PR TITLE
close influx http handler

### DIFF
--- a/cmd/bosun/expr/influx.go
+++ b/cmd/bosun/expr/influx.go
@@ -195,6 +195,7 @@ func timeInfluxRequest(e *State, db, query, startDuration, endDuration, groupByI
 	if err != nil {
 		return nil, err
 	}
+	defer conn.Close()
 	q_key := fmt.Sprintf("%s: %s", db, q)
 	e.Timer.StepCustomTiming("influx", "query", q_key, func() {
 		getFn := func() (interface{}, error) {


### PR DESCRIPTION
close the http connection, without close, will cause the influxdb cannot accept any request. 