### PR TITLE
Removing erroneous spacing due to min-height

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -48,7 +48,6 @@
 
 	<style>
 		body {
-			min-height: 2000px;
 			padding-top: 65px;
 		}
 


### PR DESCRIPTION
Primarily noticeable on pages with little content (eg. home page), large additional space below page content