### PR TITLE
Removing erroneous spacing due to min-height

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -49,7 +49,6 @@
 
 	<style>
 		body {
-			min-height: 2000px;
 			padding-top: 65px;
 			padding-bottom: 65px;
 		}


### PR DESCRIPTION
Primarily noticeable on pages with little content (eg. home page), large additional space below page content.

This is now on the correct file in the correct branch unlike my previous attempt in #2350 