### PR TITLE
Upgraded go version in the Dockerfile for bosun build

### DIFF
--- a/cmd/bosun/docker/build/Dockerfile
+++ b/cmd/bosun/docker/build/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir -p /hbase \
     | tar -xzC /hbase \
     && mv /hbase/hbase-$HBASEVER /hbase/hbase
 
-RUN curl -SL https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz \
+RUN curl -SL https://storage.googleapis.com/golang/go1.11.linux-amd64.tar.gz \
     | tar -xzC /usr/local
 
 COPY bosun $GOPATH/src/bosun.org/

--- a/cmd/bosun/docker/build/Dockerfile
+++ b/cmd/bosun/docker/build/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir -p /hbase \
     | tar -xzC /hbase \
     && mv /hbase/hbase-$HBASEVER /hbase/hbase
 
-RUN curl -SL https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz \
+RUN curl -SL https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz \
     | tar -xzC /usr/local
 
 COPY bosun $GOPATH/src/bosun.org/


### PR DESCRIPTION
The Bosun compilation by running [`bosun/cmd/bosun/docker/docker.sh`](https://github.com/bosun-monitor/bosun/blob/03ad93d1efaf9a14d95f9a8da7e9cf08974ae67c/cmd/bosun/docker/docker.sh) currently fails:

```
> ./docker.sh
> ...
> Step 14/14 : RUN go run build/build.go     && bosun -version     && scollector -version     && tsdbrelay -version
> building bosun
> go install -ldflags -X bosun.org/_version.VersionSHA=03ad93d1efaf9a14d95f9a8da7e9cf08974ae67c -X bosun.org/_version.VersionDate=20181215204533 bosun.org/cmd/bosun
# bosun.org/cmd/bosun/database
cmd/bosun/database/migrate.go:109: undefined: sort.Slice
2018/12/15 20:46:33 exit status 2
exit status 1
```

This happens because the build is using `go1.7`, while `sort.Slice` was introduced in `1.8`, see https://golang.org/pkg/sort/#Slice

This commit contains the `golang` version upgrade `1.7` → `1.8` needed for compilation to proceed.

@kylebrandt @captncraig please have a look.

Perhaps, it makes sense to upgrade to an even higher version, not just to `1.8`.