### PR TITLE
cmd/bosun: purge old incident state

### DIFF
--- a/cmd/bosun/conf/conf.go
+++ b/cmd/bosun/conf/conf.go
@@ -71,6 +71,7 @@ type SystemConfProvider interface {
 	GetAuthConf() *AuthConf
 
 	GetMaxRenderedTemplateAge() int
+	GetMaxClosedIncidentAge() int
 
 	GetExampleExpression() string
 

--- a/cmd/bosun/conf/system.go
+++ b/cmd/bosun/conf/system.go
@@ -67,6 +67,7 @@ type SystemConf struct {
 	AuthConf *AuthConf
 
 	MaxRenderedTemplateAge int // in days
+	MaxClosedIncidentAge   int // in days
 
 	EnableSave      bool
 	EnableReload    bool
@@ -500,10 +501,16 @@ func (sc *SystemConf) GetInternetProxy() string {
 	return sc.InternetProxy
 }
 
-// MaxRenderedTemplateAge returns the maximum time in days to keep rendered templates
+// GetMaxRenderedTemplateAge returns the maximum time in days to keep rendered templates
 // after the incident end date.
 func (sc *SystemConf) GetMaxRenderedTemplateAge() int {
 	return sc.MaxRenderedTemplateAge
+}
+
+// GetMaxClosedIncidentAge returns the maximum time in days to keep closed incidents
+// after the incident end date.
+func (sc *SystemConf) GetMaxClosedIncidentAge() int {
+	return sc.MaxClosedIncidentAge
 }
 
 // SaveEnabled returns if saving via the UI and config editing API endpoints should be enabled

--- a/cmd/bosun/database/test/state_data_test.go
+++ b/cmd/bosun/database/test/state_data_test.go
@@ -1,0 +1,124 @@
+package dbtest
+
+import (
+	"bosun.org/cmd/bosun/database"
+	"bosun.org/models"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestNoCleanupIfDurationZero(t *testing.T) {
+	doneNotify := make(chan int64, 1)
+	func() {
+		testData.State().StartTTLEnforcerLoop(time.Duration(0), time.Duration(0))
+		doneNotify <- 0
+	}()
+	select {
+	case res := <-doneNotify:
+		assert.EqualValues(t, 0, res)
+	case <-time.After(10 * time.Second):
+		assert.Fail(t, "timeout waiting for ttl enforcer loop to return")
+	}
+}
+
+func TestCleanupOnlyRemovesIncidentsBeyondRetention(t *testing.T) {
+	incidentBeyondRetention := buildIncident(1, time.Now().Add(-time.Hour*2))
+	incidentWithinRetention := buildIncident(2, time.Now().Add(-time.Minute*2))
+
+	testData.State().UpdateIncidentState(&incidentBeyondRetention)
+	testData.State().UpdateIncidentState(&incidentWithinRetention)
+	testData.State().SetRenderedTemplates(incidentBeyondRetention.Id, &models.RenderedTemplates{Subject: "NotNil"})
+	testData.State().SetRenderedTemplates(incidentWithinRetention.Id, &models.RenderedTemplates{Subject: "NotNil"})
+
+	assertIncidentExists(t, incidentBeyondRetention)
+	assertRenderedTemplateExists(t, incidentBeyondRetention)
+
+	config := database.NewRetentionConfig(time.Duration(time.Hour*1), time.Duration(time.Hour*1))
+	testData.State().CleanupOldIncidents(config)
+
+	assertIncidentRemoved(t, incidentBeyondRetention)
+	assertIncidentExists(t, incidentWithinRetention)
+
+	assertRenderedTemplateRemoved(t, incidentBeyondRetention)
+	assertRenderedTemplateExists(t, incidentWithinRetention)
+}
+
+func TestCleanupRenderedTemplatesWithoutIncidentCleanup(t *testing.T) {
+	incidentBeyondRetention := buildIncident(1, time.Now().Add(-time.Hour*2))
+
+	testData.State().UpdateIncidentState(&incidentBeyondRetention)
+	testData.State().SetRenderedTemplates(incidentBeyondRetention.Id, &models.RenderedTemplates{Subject: "NotNil"})
+
+	assertIncidentExists(t, incidentBeyondRetention)
+	assertRenderedTemplateExists(t, incidentBeyondRetention)
+
+	config := database.NewRetentionConfig(time.Duration(time.Hour*1), time.Duration(0))
+	testData.State().CleanupOldIncidents(config)
+
+	assertIncidentExists(t, incidentBeyondRetention)
+	assertRenderedTemplateRemoved(t, incidentBeyondRetention)
+}
+
+func TestCleanupIncidentCleanupRemovesReferences(t *testing.T) {
+	incidentBeyondRetention := buildIncident(0, time.Now().Add(-time.Hour*2))
+
+	testData.State().UpdateIncidentState(&incidentBeyondRetention)
+	testData.State().SetRenderedTemplates(incidentBeyondRetention.Id, &models.RenderedTemplates{Subject: "NotNil"})
+
+	incidents, _ := testData.State().GetAllIncidentsByAlertKey(models.AlertKey("TestAlertKey"))
+	assert.NotEmpty(t, incidents)
+	assertIncidentExists(t, incidentBeyondRetention)
+	assertRenderedTemplateExists(t, incidentBeyondRetention)
+
+	config := database.NewRetentionConfig(time.Duration(0), time.Duration(time.Hour*1))
+	testData.State().CleanupOldIncidents(config)
+
+	incidents, _ = testData.State().GetAllIncidentsByAlertKey(models.AlertKey("TestAlertKey"))
+	assert.Empty(t, incidents)
+	assertIncidentRemoved(t, incidentBeyondRetention)
+	assertRenderedTemplateRemoved(t, incidentBeyondRetention)
+}
+
+func assertIncidentRemoved(t *testing.T, incident models.IncidentState) {
+	state, _ := testData.State().GetIncidentState(incident.Id)
+	assert.Nil(t, state)
+}
+
+func assertIncidentExists(t *testing.T, incident models.IncidentState) {
+	state, _ := testData.State().GetIncidentState(incident.Id)
+	assert.NotNil(t, state)
+}
+
+func assertRenderedTemplateExists(t *testing.T, incident models.IncidentState) {
+	template, _ := testData.State().GetRenderedTemplates(incident.Id)
+	assert.NotEmpty(t, template.Subject)
+}
+
+func assertRenderedTemplateRemoved(t *testing.T, incident models.IncidentState) {
+	template, _ := testData.State().GetRenderedTemplates(incident.Id)
+	assert.Empty(t, template.Subject)
+}
+
+func buildIncident(id int64, end time.Time) models.IncidentState {
+	return models.IncidentState{
+		Id:                 id,
+		Start:              end.Add(-time.Hour),
+		End:                &end,
+		AlertKey:           "TestAlertKey",
+		Alert:              "",
+		Tags:               "",
+		Result:             nil,
+		Events:             nil,
+		Actions:            nil,
+		Subject:            "",
+		NeedAck:            false,
+		Open:               false,
+		Unevaluated:        false,
+		CurrentStatus:      0,
+		WorstStatus:        0,
+		LastAbnormalStatus: 0,
+		LastAbnormalTime:   models.Epoch{},
+		Notifications:      nil,
+	}
+}

--- a/cmd/bosun/main.go
+++ b/cmd/bosun/main.go
@@ -152,9 +152,7 @@ func main() {
 	if err != nil {
 		slog.Fatal(err)
 	}
-	if sysProvider.GetMaxRenderedTemplateAge() != 0 {
-		go da.State().CleanupOldRenderedTemplates(time.Hour * 24 * time.Duration(sysProvider.GetMaxRenderedTemplateAge()))
-	}
+	go da.State().StartTTLEnforcerLoop(time.Hour*24*time.Duration(sysProvider.GetMaxRenderedTemplateAge()), time.Hour*24*time.Duration(sysProvider.GetMaxClosedIncidentAge()))
 	var annotateBackend backend.Backend
 	if sysProvider.AnnotateEnabled() {
 		index := sysProvider.GetAnnotateIndex()

--- a/docs/system_configuration.md
+++ b/docs/system_configuration.md
@@ -133,6 +133,12 @@ It will remove all rendered templates for alerts that have been closed for longe
 
 Example: `MaxRenderedTemplateAge = 30 # retain old templates for only 30 days`
 
+### MaxClosedIncidentAge
+If set, Bosun will automatically delete closed incidents from its data store.
+It will remove incidents and references to those incidents, which ended beyond this time (in days).
+
+Example: `MaxClosedIncidentAge = 180 # retain closed incidents for 180 days`
+
 ### TimeAndDate
 Used to configure time zones that will be linked to in Bosun's
 dashboard. It is an array of timeanddate.com zones (the page that gets


### PR DESCRIPTION
Based on the ideas introduced in https://github.com/bosun-monitor/bosun/pull/2167, this allows purging of keys under incidentById:*.  State for closed incidents which are beyond retention will be removed if the MaxClosedIncidentAge option is specified.

This fixes #2363.  It's discussed in #1974.