### PR TITLE
Change error response format for API multi errors

### DIFF
--- a/cmd/bosun/web/web.go
+++ b/cmd/bosun/web/web.go
@@ -798,7 +798,23 @@ func Action(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (inter
 type MultiError map[string]error
 
 func (m MultiError) Error() string {
-	return fmt.Sprint(map[string]error(m))
+	data, err := json.Marshal(m)
+	if err != nil {
+		return fmt.Sprint(map[string]error(m))
+	}
+	return string(data)
+}
+
+func (m MultiError) MarshalJSON() ([]byte, error) {
+	res := make(map[string]interface{})
+	for i, e := range m {
+		if _, ok := e.(json.Marshaler); ok {
+			res[i] = e
+		} else {
+			res[i] = e.Error()
+		}
+	}
+	return json.Marshal(res)
 }
 
 func SilenceGet(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (interface{}, error) {


### PR DESCRIPTION
Not we are just returning stringify of golang MultiError. So it is very difficult to parse it if we want to know what was failed. This patch will change this behavior - we return json as body for error response.

Use case:
```
curl -v -XPOST -H 'X-Access-Token: xxx' https://bosun.com/api/action -d '{"User":"user","Type":"ack","Message":"some message","Ids":[000001]}'
> POST /api/action HTTP/1.1
> User-Agent: curl/7.29.0
> Host: bosun.com
> Accept: */*
> X-Access-Token: xxx
> Content-Length: 121
> Content-Type: application/x-www-form-urlencoded
>
* upload completely sent off: 121 out of 121 bytes
< HTTP/1.1 500 Internal Server Error
< Server: nginx
< Date: Fri, 11 Jan 2019 15:24:30 GMT
< Content-Type: text/plain; charset=utf-8
< Content-Length: 39
< Vary: Accept-Encoding
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 1; mode=block
<
map[000001:alert already acknowledged]
```
Basically this error can be ignored, because we had a goal to ack incident. If it was already acknowledged  so it's ok. If we return value '{"000001": "alert already acknowledged"}' I can just check that error was "alert already acknowledged" and ignore this error. With current situation I should parse response via regexp.