### PR TITLE
cmd/scollector: pull index data from non-master hosts

### DIFF
--- a/cmd/scollector/collectors/elasticsearch.go
+++ b/cmd/scollector/collectors/elasticsearch.go
@@ -266,7 +266,7 @@ func c_elasticsearch(collectIndices bool, instance conf.Elastic) (opentsdb.Multi
 	// As we're pulling _local stats here, this will only process 1 node.
 	for nodeID, nodeStats := range clusterStats.Nodes {
 		isMaster = nodeID == clusterState.MasterNode
-		if isMaster {
+		if isMaster || instance.CollectAllMetrics {
 			s.add("elastic.health.cluster", clusterHealth, ts)
 			if statusCode, ok := elasticStatusMap[clusterHealth.Status]; ok {
 				Add(&md, "elastic.health.cluster.status", statusCode, ts, metadata.Gauge, metadata.StatusCode, "The current status of the cluster. Zero for green, one for yellow, two for red.")
@@ -289,7 +289,7 @@ func c_elasticsearch(collectIndices bool, instance conf.Elastic) (opentsdb.Multi
 		s.add("elastic.jvm.gc", nodeStats.JVM.GC.Collectors.Old, opentsdb.TagSet{"gc": "old"}.Merge(ts))
 		s.add("elastic.jvm.gc", nodeStats.JVM.GC.Collectors.Young, opentsdb.TagSet{"gc": "young"}.Merge(ts))
 	}
-	if collectIndices && (isMaster || instance.AlwaysCollectIndices) {
+	if collectIndices && (isMaster || instance.CollectAllMetrics) {
 		for k, index := range indexStats.Indices {
 			if esSkipIndex(k) {
 				slog.Infof("Skipping index: %v", k)

--- a/cmd/scollector/collectors/elasticsearch.go
+++ b/cmd/scollector/collectors/elasticsearch.go
@@ -289,7 +289,7 @@ func c_elasticsearch(collectIndices bool, instance conf.Elastic) (opentsdb.Multi
 		s.add("elastic.jvm.gc", nodeStats.JVM.GC.Collectors.Old, opentsdb.TagSet{"gc": "old"}.Merge(ts))
 		s.add("elastic.jvm.gc", nodeStats.JVM.GC.Collectors.Young, opentsdb.TagSet{"gc": "young"}.Merge(ts))
 	}
-	if collectIndices && isMaster {
+	if collectIndices {
 		for k, index := range indexStats.Indices {
 			if esSkipIndex(k) {
 				slog.Infof("Skipping index: %v", k)

--- a/cmd/scollector/collectors/elasticsearch.go
+++ b/cmd/scollector/collectors/elasticsearch.go
@@ -289,7 +289,7 @@ func c_elasticsearch(collectIndices bool, instance conf.Elastic) (opentsdb.Multi
 		s.add("elastic.jvm.gc", nodeStats.JVM.GC.Collectors.Old, opentsdb.TagSet{"gc": "old"}.Merge(ts))
 		s.add("elastic.jvm.gc", nodeStats.JVM.GC.Collectors.Young, opentsdb.TagSet{"gc": "young"}.Merge(ts))
 	}
-	if collectIndices {
+	if collectIndices && (isMaster || instance.AlwaysCollectIndices) {
 		for k, index := range indexStats.Indices {
 			if esSkipIndex(k) {
 				slog.Infof("Skipping index: %v", k)

--- a/cmd/scollector/conf/conf.go
+++ b/cmd/scollector/conf/conf.go
@@ -271,13 +271,14 @@ type OracleInstance struct {
 // Optional Elastic instance configuration - if omitted then the defaults are used
 // You can also define multiple instances where more than one node is running
 type Elastic struct {
-	Host            string // default is localhost
-	Port            uint16 // default is 9200
-	ClusterInterval string // default is DefaultFreq
-	IndexInterval   string // default is 15 mins
-	User            string // default is empty
-	Password        string // default is empty
-	Disable         bool   // default is false.
-	Name            string // default is host_port
-	Scheme          string // default is http
+	Host                 string // default is localhost
+	Port                 uint16 // default is 9200
+	ClusterInterval      string // default is DefaultFreq
+	IndexInterval        string // default is 15 mins
+	User                 string // default is empty
+	Password             string // default is empty
+	Disable              bool   // default is false.
+	Name                 string // default is host_port
+	Scheme               string // default is http
+	AlwaysCollectIndices bool   // default is false
 }

--- a/cmd/scollector/conf/conf.go
+++ b/cmd/scollector/conf/conf.go
@@ -271,14 +271,14 @@ type OracleInstance struct {
 // Optional Elastic instance configuration - if omitted then the defaults are used
 // You can also define multiple instances where more than one node is running
 type Elastic struct {
-	Host                 string // default is localhost
-	Port                 uint16 // default is 9200
-	ClusterInterval      string // default is DefaultFreq
-	IndexInterval        string // default is 15 mins
-	User                 string // default is empty
-	Password             string // default is empty
-	Disable              bool   // default is false.
-	Name                 string // default is host_port
-	Scheme               string // default is http
-	AlwaysCollectIndices bool   // default is false
+	Host              string // default is localhost
+	Port              uint16 // default is 9200
+	ClusterInterval   string // default is DefaultFreq
+	IndexInterval     string // default is 15 mins
+	User              string // default is empty
+	Password          string // default is empty
+	Disable           bool   // default is false.
+	Name              string // default is host_port
+	Scheme            string // default is http
+	CollectAllMetrics bool   // default is false
 }

--- a/cmd/scollector/doc.go
+++ b/cmd/scollector/doc.go
@@ -436,7 +436,6 @@ Collecting indices metrics from all nodes may flood database with tags. By
 default they are collected, only if current node is master. You can
 override this with AlwaysCollectIndices.
 
-
 Windows
 
 scollector has full Windows support. It can be run standalone, or installed as a

--- a/cmd/scollector/doc.go
+++ b/cmd/scollector/doc.go
@@ -432,9 +432,8 @@ you specify basic auth credentials and using TLS by setting the Scheme to https:
 	  ClusterInterval = "10s"
 	  IndexInterval = "1m"
 
-Collecting indices metrics from all nodes may flood database with tags. By
-default they are collected, only if current node is master. You can
-override this with AlwaysCollectIndices.
+By default cluster-wide metrics are collected, only if current node is master.
+You can override this behaviour with CollectAllMetrics switch.
 
 Windows
 

--- a/cmd/scollector/doc.go
+++ b/cmd/scollector/doc.go
@@ -432,6 +432,11 @@ you specify basic auth credentials and using TLS by setting the Scheme to https:
 	  ClusterInterval = "10s"
 	  IndexInterval = "1m"
 
+Collecting indices metrics from all nodes may flood database with tags. By
+default they are collected, only if current node is master. You can
+override this with AlwaysCollectIndices.
+
+
 Windows
 
 scollector has full Windows support. It can be run standalone, or installed as a


### PR DESCRIPTION
Related to issue #2259.
I think, there's no reason to require target node to be master - correct me, if I'm wrong. I have setup, where masters have no HTTP interface for querying statistics, so ability to collect data from non-master hosts is crucial.