### PR TITLE
cmd/bosun: (wip) fix tags calculation on prefix nodes

### DIFF
--- a/cmd/bosun/expr/parse/node.go
+++ b/cmd/bosun/expr/parse/node.go
@@ -336,7 +336,14 @@ func (p *PrefixNode) Return() models.FuncType {
 }
 
 func (p *PrefixNode) Tags() (Tags, error) {
-	return nil, nil
+	prefixFuncNode, ok := p.Arg.(*FuncNode)
+	if !ok {
+		return nil, fmt.Errorf("unexpected arg to prefix node, expected funcNode")
+	}
+	if prefixFuncNode.F.Tags == nil {
+		return nil, nil
+	}
+	return prefixFuncNode.F.Tags(prefixFuncNode.Args)
 }
 
 // BinaryNode holds two arguments and an operator.

--- a/cmd/bosun/expr/parse/node.go
+++ b/cmd/bosun/expr/parse/node.go
@@ -336,14 +336,7 @@ func (p *PrefixNode) Return() models.FuncType {
 }
 
 func (p *PrefixNode) Tags() (Tags, error) {
-	prefixFuncNode, ok := p.Arg.(*FuncNode)
-	if !ok {
-		return nil, fmt.Errorf("unexpected arg to prefix node, expected funcNode")
-	}
-	if prefixFuncNode.F.Tags == nil {
-		return nil, nil
-	}
-	return prefixFuncNode.F.Tags(prefixFuncNode.Args)
+	return p.Arg.Tags()
 }
 
 // BinaryNode holds two arguments and an operator.


### PR DESCRIPTION
Want  to make a test to show this problem before merging, but before something like the following would incorrectly error:

```
$q = ["default,it"]promm("up", "job,instance", "", "max", "30s", "4h", "")
$status = max($q)
$transposed = t($status, "bosun_prefix")
$sum = sum($transposed)
$sum - $sum
```