### PR TITLE
cmd/bosun: (wip) raw promql query support

### DIFF
--- a/cmd/bosun/expr/prom.go
+++ b/cmd/bosun/expr/prom.go
@@ -129,6 +129,8 @@ var Prom = map[string]parse.Func{
 	},
 }
 
+var promMultiKey = "bosun_prefix"
+
 // promGroupTags parses the csv tags argument of the prom based functions
 func promGroupTags(args []parse.Node) (parse.Tags, error) {
 	tags := make(parse.Tags)
@@ -140,13 +142,13 @@ func promGroupTags(args []parse.Node) (parse.Tags, error) {
 }
 
 // promMGroupTags parses the csv tags argument of the prom based functions
-// and also adds the "bosun_prefix" tag
+// and also adds the promMultiKey tag
 func promMGroupTags(args []parse.Node) (parse.Tags, error) {
 	tags, err := promGroupTags(args)
 	if err != nil {
 		return nil, err
 	}
-	tags["bosun_prefix"] = struct{}{}
+	tags[promMultiKey] = struct{}{}
 	return tags, nil
 }
 
@@ -174,7 +176,7 @@ func promMAggregateRawTags(args []parse.Node) (parse.Tags, error) {
 	if err != nil {
 		return nil, err
 	}
-	tags["bosun_prefix"] = struct{}{}
+	tags[promMultiKey] = struct{}{}
 	return tags, nil
 }
 
@@ -288,7 +290,7 @@ func PromMRate(prefix string, e *State, metric, groupBy, filter, agType, rateDur
 }
 
 // promMQuery makes call to multiple prometheus TSDBs and combines the results into a single series set.
-// It adds the "bosun_prefix" tag key with the value of prefix label to the results. Queries are executed in parallel.
+// It adds the promMultiKey tag key with the value of prefix label to the results. Queries are executed in parallel.
 func promMQuery(prefix string, e *State, metric, groupBy, filter, agType, rateDuration, stepDuration, sdur, edur string) (r *Results, err error) {
 	r = new(Results)
 	prefixes := strings.Split(prefix, ",")
@@ -458,7 +460,7 @@ func promMatrixToResults(prefix string, e *State, res promModels.Value, expected
 			continue
 		}
 		if addPrefix {
-			tags["bosun_prefix"] = prefix
+			tags[promMultiKey] = prefix
 		}
 		if e.Squelched(tags) {
 			continue

--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -591,6 +591,35 @@ In the above example `$q` will be a seriesSet with the tag keys of `container_na
 
 promratem (Prometheus Rate Multiple) is like the `promm` function is to the `prom` function. It allows you to do a per-second rate query against multiple Prometheus TSDBs and combines the result into a single seriesSet -- adding the `bosun_prefix` tag key to the result. It behaves the same as the `promm` function, but like `promrate`, it has the extra `rateStepDuration` argument.
 
+### promras(promql, stepDuration, startDuration, endDuration string) seriesSet
+{: .exprFunc}
+
+Instead of building a promql query like the `prom` and `promrate` functions, promras (Prometheus Aggregate Raw Series) allows you to query Prometheus using promql with some restrictions:
+
+ 1. The query must return a time series (a Prometheus matrix)
+ 2. The top level function in promql must be an [Prometheus Aggregation Operator](https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators) with a `by` clause.
+
+Example:
+
+```
+promras(''' sum(rate(container_fs_reads_total[1m]) + rate(container_fs_writes_total[1m])) by (namespace) ''', "2m", "2h", "")
+```
+
+### prommras(promql, stepDuration, startDuration, endDuration string) seriestSet
+{: .exprFunc}
+
+prommras (Prometheus Raw Aggregate Raw Multiple) is like the `promras` function excepts that it queries multiple prometheus instances and adds the "bosun_prefix" tag to the results like the `promm` and `prommrate` functions.
+
+Example:
+
+```
+# You can still use string interpolation of $variables in promras and prommras
+$step = 1m
+$reads = container_fs_reads_total[$step]
+$writes = container_fs_writes_total[$step]
+["default,it"]prommras(''' sum(rate($reads) + rate($writes)) by (namespace) ''', "2m", "2h", "")
+```
+
 ### prommetrics() Info
 {: .exprFunc}
 


### PR DESCRIPTION
Example:

```
$step = 1m
promras(''' sum(rate(container_fs_reads_total[$step]) + rate(container_fs_writes_total[$step])) by (namespace) ''', "2m", "2h", "")
```

top level expression must be an aggregation operation with `by ()`.

Todo:
 - [x] Docs
 - [x] Reduce code duplication

Follow up from conversation with @pdf in https://github.com/bosun-monitor/bosun/pull/2366