### PR TITLE
cmd/bosun/web: use DefaultServeMux for /debug/pprof requests

### DIFF
--- a/cmd/bosun/web/web.go
+++ b/cmd/bosun/web/web.go
@@ -206,6 +206,9 @@ func Listen(httpAddr, httpsAddr, certFile, keyFile string, devMode bool, tsdbHos
 	var miniprofilerRoutes = http.StripPrefix(miniprofiler.PATH, http.HandlerFunc(miniprofiler.MiniProfilerHandler))
 	router.PathPrefix(miniprofiler.PATH).Handler(baseChain.Then(miniprofilerRoutes)).Name("miniprofiler")
 
+	//use default mux for pprof
+	router.PathPrefix("/debug/pprof").Handler(http.DefaultServeMux)
+
 	router.PathPrefix("/api").HandlerFunc(http.NotFound)
 	//MUST BE LAST!
 	router.PathPrefix("/").Handler(baseChain.Then(auth.Wrap(JSON(Index), canViewDash))).Name("index")


### PR DESCRIPTION
When trying to get a pprof profile of the bosun server, I discovered that the path to `/debug/pprof` was being redirected back to the homepage of our bosun instance.

[Apparently](https://stackoverflow.com/questions/19591065/profiling-go-web-application-built-with-gorillas-mux-with-net-http-pprof) the `gorilla/mux` web framework clobbers the path to pprof, so this line of code allows the `http.DefaultServeMux` to handle the url at `/debug/pprof`, and opens the bosun server back up for profiling.