### PR TITLE
Redis sentinel support for bosun

### DIFF
--- a/cmd/bosun/conf/conf.go
+++ b/cmd/bosun/conf/conf.go
@@ -42,7 +42,8 @@ type SystemConfProvider interface {
 	GetEmailFrom() string
 	GetLedisDir() string
 	GetLedisBindAddr() string
-	GetRedisHost() string
+	GetRedisHost() []string
+	GetRedisMasterName() string
 	GetRedisDb() int
 	GetRedisPassword() string
 	IsRedisClientSetName() bool

--- a/cmd/bosun/conf/system.go
+++ b/cmd/bosun/conf/system.go
@@ -234,6 +234,8 @@ type DBConf struct {
 	RedisDb            int
 	RedisPassword      string
 	RedisClientSetName bool
+	RedisSentinels     []string
+	RedisMasterName    string
 
 	LedisDir      string
 	LedisBindAddr string
@@ -454,8 +456,20 @@ func (sc *SystemConf) GetLedisBindAddr() string {
 
 // GetRedisHost returns the host to use for Redis. If this is set than Redis
 // will be used instead of Ledis.
-func (sc *SystemConf) GetRedisHost() string {
-	return sc.DBConf.RedisHost
+func (sc *SystemConf) GetRedisHost() []string {
+	if sc.GetRedisMasterName() != "" {
+		return sc.DBConf.RedisSentinels
+	}
+	if sc.DBConf.RedisHost != "" {
+		return []string{sc.DBConf.RedisHost}
+	}
+	return []string{}
+}
+
+// GetRedisMasterName returns master name of redis instance within sentinel.
+// If this is return none empty string redis sentinel will be used
+func (sc *SystemConf) GetRedisMasterName() string {
+	return sc.DBConf.RedisMasterName
 }
 
 // GetRedisDb returns the redis database number to use

--- a/cmd/bosun/database/sentinel/sentinel.go
+++ b/cmd/bosun/database/sentinel/sentinel.go
@@ -1,0 +1,426 @@
+package sentinel
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/garyburd/redigo/redis"
+)
+
+// Sentinel provides a way to add high availability (HA) to Redis Pool using
+// preconfigured addresses of Sentinel servers and name of master which Sentinels
+// monitor. It works with Redis >= 2.8.12 (mostly because of ROLE command that
+// was introduced in that version, it's possible though to support old versions
+// using INFO command).
+//
+// Example of the simplest usage to contact master "mymaster":
+//
+//  func newSentinelPool() *redis.Pool {
+//  	sntnl := &sentinel.Sentinel{
+//  		Addrs:      []string{":26379", ":26380", ":26381"},
+//  		MasterName: "mymaster",
+//  		Dial: func(addr string) (redis.Conn, error) {
+//  			timeout := 500 * time.Millisecond
+//  			c, err := redis.DialTimeout("tcp", addr, timeout, timeout, timeout)
+//  			if err != nil {
+//  				return nil, err
+//  			}
+//  			return c, nil
+//  		},
+//  	}
+//  	return &redis.Pool{
+//  		MaxIdle:     3,
+//  		MaxActive:   64,
+//  		Wait:        true,
+//  		IdleTimeout: 240 * time.Second,
+//  		Dial: func() (redis.Conn, error) {
+//  			masterAddr, err := sntnl.MasterAddr()
+//  			if err != nil {
+//  				return nil, err
+//  			}
+//  			c, err := redis.Dial("tcp", masterAddr)
+//  			if err != nil {
+//  				return nil, err
+//  			}
+//  			return c, nil
+//  		},
+//  		TestOnBorrow: func(c redis.Conn, t time.Time) error {
+//  			if !sentinel.TestRole(c, "master") {
+//  				return errors.New("Role check failed")
+//  			} else {
+//  				return nil
+//  			}
+//  		},
+//  	}
+//  }
+type Sentinel struct {
+	// Addrs is a slice with known Sentinel addresses.
+	Addrs []string
+
+	// MasterName is a name of Redis master Sentinel servers monitor.
+	MasterName string
+
+	// Dial is a user supplied function to connect to Sentinel on given address. This
+	// address will be chosen from Addrs slice.
+	// Note that as per the redis-sentinel client guidelines, a timeout is mandatory
+	// while connecting to Sentinels, and should not be set to 0.
+	Dial func(addr string) (redis.Conn, error)
+
+	// Pool is a user supplied function returning custom connection pool to Sentinel.
+	// This can be useful to tune options if you are not satisfied with what default
+	// Sentinel pool offers. See defaultPool() method for default pool implementation.
+	// In most cases you only need to provide Dial function and let this be nil.
+	Pool func(addr string) *redis.Pool
+
+	mu    sync.RWMutex
+	pools map[string]*redis.Pool
+	addr  string
+}
+
+// NoSentinelsAvailable is returned when all sentinels in the list are exhausted
+// (or none configured), and contains the last error returned by Dial (which
+// may be nil)
+type NoSentinelsAvailable struct {
+	lastError error
+}
+
+func (ns NoSentinelsAvailable) Error() string {
+	if ns.lastError != nil {
+		return fmt.Sprintf("redigo: no sentinels available; last error: %s", ns.lastError.Error())
+	}
+	return fmt.Sprintf("redigo: no sentinels available")
+}
+
+// putToTop puts Sentinel address to the top of address list - this means
+// that all next requests will use Sentinel on this address first.
+//
+// From Sentinel guidelines:
+//
+// The first Sentinel replying to the client request should be put at the
+// start of the list, so that at the next reconnection, we'll try first
+// the Sentinel that was reachable in the previous connection attempt,
+// minimizing latency.
+//
+// Lock must be held by caller.
+func (s *Sentinel) putToTop(addr string) {
+	addrs := s.Addrs
+	if addrs[0] == addr {
+		// Already on top.
+		return
+	}
+	newAddrs := []string{addr}
+	for _, a := range addrs {
+		if a == addr {
+			continue
+		}
+		newAddrs = append(newAddrs, a)
+	}
+	s.Addrs = newAddrs
+}
+
+// putToBottom puts Sentinel address to the bottom of address list.
+// We call this method internally when see that some Sentinel failed to answer
+// on application request so next time we start with another one.
+//
+// Lock must be held by caller.
+func (s *Sentinel) putToBottom(addr string) {
+	addrs := s.Addrs
+	if addrs[len(addrs)-1] == addr {
+		// Already on bottom.
+		return
+	}
+	newAddrs := []string{}
+	for _, a := range addrs {
+		if a == addr {
+			continue
+		}
+		newAddrs = append(newAddrs, a)
+	}
+	newAddrs = append(newAddrs, addr)
+	s.Addrs = newAddrs
+}
+
+// defaultPool returns a connection pool to one Sentinel. This allows
+// us to call concurrent requests to Sentinel using connection Do method.
+func (s *Sentinel) defaultPool(addr string) *redis.Pool {
+	return &redis.Pool{
+		MaxIdle:     3,
+		MaxActive:   10,
+		Wait:        true,
+		IdleTimeout: 240 * time.Second,
+		Dial: func() (redis.Conn, error) {
+			return s.Dial(addr)
+		},
+		TestOnBorrow: func(c redis.Conn, t time.Time) error {
+			_, err := c.Do("PING")
+			return err
+		},
+	}
+}
+
+func (s *Sentinel) get(addr string) redis.Conn {
+	pool := s.poolForAddr(addr)
+	return pool.Get()
+}
+
+func (s *Sentinel) poolForAddr(addr string) *redis.Pool {
+	s.mu.Lock()
+	if s.pools == nil {
+		s.pools = make(map[string]*redis.Pool)
+	}
+	pool, ok := s.pools[addr]
+	if ok {
+		s.mu.Unlock()
+		return pool
+	}
+	s.mu.Unlock()
+	newPool := s.newPool(addr)
+	s.mu.Lock()
+	p, ok := s.pools[addr]
+	if ok {
+		s.mu.Unlock()
+		return p
+	}
+	s.pools[addr] = newPool
+	s.mu.Unlock()
+	return newPool
+}
+
+func (s *Sentinel) newPool(addr string) *redis.Pool {
+	if s.Pool != nil {
+		return s.Pool(addr)
+	}
+	return s.defaultPool(addr)
+}
+
+// close connection pool to Sentinel.
+// Lock must be hold by caller.
+func (s *Sentinel) close() {
+	if s.pools != nil {
+		for _, pool := range s.pools {
+			pool.Close()
+		}
+	}
+	s.pools = nil
+}
+
+func (s *Sentinel) doUntilSuccess(f func(redis.Conn) (interface{}, error)) (interface{}, error) {
+	s.mu.RLock()
+	addrs := s.Addrs
+	s.mu.RUnlock()
+
+	var lastErr error
+
+	for _, addr := range addrs {
+		conn := s.get(addr)
+		reply, err := f(conn)
+		conn.Close()
+		if err != nil {
+			lastErr = err
+			s.mu.Lock()
+			pool, ok := s.pools[addr]
+			if ok {
+				pool.Close()
+				delete(s.pools, addr)
+			}
+			s.putToBottom(addr)
+			s.mu.Unlock()
+			continue
+		}
+		s.putToTop(addr)
+		return reply, nil
+	}
+
+	return nil, NoSentinelsAvailable{lastError: lastErr}
+}
+
+// MasterAddr returns an address of current Redis master instance.
+func (s *Sentinel) MasterAddr() (string, error) {
+	res, err := s.doUntilSuccess(func(c redis.Conn) (interface{}, error) {
+		return queryForMaster(c, s.MasterName)
+	})
+	if err != nil {
+		return "", err
+	}
+	return res.(string), nil
+}
+
+// SlaveAddrs returns a slice with known slave addresses of current master instance.
+func (s *Sentinel) SlaveAddrs() ([]string, error) {
+	res, err := s.doUntilSuccess(func(c redis.Conn) (interface{}, error) {
+		return queryForSlaveAddrs(c, s.MasterName)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.([]string), nil
+}
+
+// Slave represents a Redis slave instance which is known by Sentinel.
+type Slave struct {
+	ip    string
+	port  string
+	flags string
+}
+
+// Addr returns an address of slave.
+func (s *Slave) Addr() string {
+	return net.JoinHostPort(s.ip, s.port)
+}
+
+// Available returns if slave is in working state at moment based on information in slave flags.
+func (s *Slave) Available() bool {
+	return !strings.Contains(s.flags, "disconnected") && !strings.Contains(s.flags, "s_down")
+}
+
+// Slaves returns a slice with known slaves of master instance.
+func (s *Sentinel) Slaves() ([]*Slave, error) {
+	res, err := s.doUntilSuccess(func(c redis.Conn) (interface{}, error) {
+		return queryForSlaves(c, s.MasterName)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.([]*Slave), nil
+}
+
+// SentinelAddrs returns a slice of known Sentinel addresses Sentinel server aware of.
+func (s *Sentinel) SentinelAddrs() ([]string, error) {
+	res, err := s.doUntilSuccess(func(c redis.Conn) (interface{}, error) {
+		return queryForSentinels(c, s.MasterName)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.([]string), nil
+}
+
+// Discover allows to update list of known Sentinel addresses. From docs:
+//
+// A client may update its internal list of Sentinel nodes following this procedure:
+// 1) Obtain a list of other Sentinels for this master using the command SENTINEL sentinels <master-name>.
+// 2) Add every ip:port pair not already existing in our list at the end of the list.
+func (s *Sentinel) Discover() error {
+	addrs, err := s.SentinelAddrs()
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	for _, addr := range addrs {
+		if !stringInSlice(addr, s.Addrs) {
+			s.Addrs = append(s.Addrs, addr)
+		}
+	}
+	s.mu.Unlock()
+	return nil
+}
+
+// Close closes current connection to Sentinel.
+func (s *Sentinel) Close() error {
+	s.mu.Lock()
+	s.close()
+	s.mu.Unlock()
+	return nil
+}
+
+// TestRole wraps GetRole in a test to verify if the role matches an expected
+// role string. If there was any error in querying the supplied connection,
+// the function returns false. Works with Redis >= 2.8.12.
+// It's not goroutine safe, but if you call this method on pooled connections
+// then you are OK.
+func TestRole(c redis.Conn, expectedRole string) bool {
+	role, err := getRole(c)
+	if err != nil || role != expectedRole {
+		return false
+	}
+	return true
+}
+
+// getRole is a convenience function supplied to query an instance (master or
+// slave) for its role. It attempts to use the ROLE command introduced in
+// redis 2.8.12.
+func getRole(c redis.Conn) (string, error) {
+	res, err := c.Do("ROLE")
+	if err != nil {
+		return "", err
+	}
+	rres, ok := res.([]interface{})
+	if ok {
+		return redis.String(rres[0], nil)
+	}
+	return "", errors.New("redigo: can not transform ROLE reply to string")
+}
+
+func queryForMaster(conn redis.Conn, masterName string) (string, error) {
+	res, err := redis.Strings(conn.Do("SENTINEL", "get-master-addr-by-name", masterName))
+	if err != nil {
+		return "", err
+	}
+	if len(res) < 2 {
+		return "", errors.New("redigo: malformed get-master-addr-by-name reply")
+	}
+	masterAddr := net.JoinHostPort(res[0], res[1])
+	return masterAddr, nil
+}
+
+func queryForSlaveAddrs(conn redis.Conn, masterName string) ([]string, error) {
+	slaves, err := queryForSlaves(conn, masterName)
+	if err != nil {
+		return nil, err
+	}
+	slaveAddrs := make([]string, 0)
+	for _, slave := range slaves {
+		slaveAddrs = append(slaveAddrs, slave.Addr())
+	}
+	return slaveAddrs, nil
+}
+
+func queryForSlaves(conn redis.Conn, masterName string) ([]*Slave, error) {
+	res, err := redis.Values(conn.Do("SENTINEL", "slaves", masterName))
+	if err != nil {
+		return nil, err
+	}
+	slaves := make([]*Slave, 0)
+	for _, a := range res {
+		sm, err := redis.StringMap(a, err)
+		if err != nil {
+			return slaves, err
+		}
+		slave := &Slave{
+			ip:    sm["ip"],
+			port:  sm["port"],
+			flags: sm["flags"],
+		}
+		slaves = append(slaves, slave)
+	}
+	return slaves, nil
+}
+
+func queryForSentinels(conn redis.Conn, masterName string) ([]string, error) {
+	res, err := redis.Values(conn.Do("SENTINEL", "sentinels", masterName))
+	if err != nil {
+		return nil, err
+	}
+	sentinels := make([]string, 0)
+	for _, a := range res {
+		sm, err := redis.StringMap(a, err)
+		if err != nil {
+			return sentinels, err
+		}
+		sentinels = append(sentinels, fmt.Sprintf("%s:%s", sm["ip"], sm["port"]))
+	}
+	return sentinels, nil
+}
+
+func stringInSlice(str string, slice []string) bool {
+	for _, s := range slice {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/bosun/database/test/testSetup.go
+++ b/cmd/bosun/database/test/testSetup.go
@@ -18,7 +18,7 @@ func StartTestRedis(port int) (database.DataAccess, func()) {
 	flag.Parse()
 	// For redis tests we just point at an external server.
 	if *flagReddisHost != "" {
-		testData := database.NewDataAccess(*flagReddisHost, true, 0, "")
+		testData := database.NewDataAccess([]string{*flagReddisHost}, true, "", 0, "")
 		if *flagFlushRedis {
 			log.Println("FLUSHING REDIS")
 			c := testData.(database.RedisConnector).Get()
@@ -38,7 +38,7 @@ func StartTestRedis(port int) (database.DataAccess, func()) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	testData := database.NewDataAccess(addr, false, 0, "")
+	testData := database.NewDataAccess([]string{addr}, false, "", 0, "")
 	return testData, func() {
 		stop()
 		os.RemoveAll(testPath)

--- a/cmd/bosun/database/test/util/purge_search_data.go
+++ b/cmd/bosun/database/test/util/purge_search_data.go
@@ -20,7 +20,7 @@ func main() {
 		flag.PrintDefaults()
 		return
 	}
-	db := database.NewDataAccess(*redis, true, 0, "").(interface {
+	db := database.NewDataAccess([]string{*redis}, true, "", 0, "").(interface {
 		PurgeSearchData(string, bool) error
 	})
 	err := db.PurgeSearchData(*metric, *noop)

--- a/docs/system_configuration.md
+++ b/docs/system_configuration.md
@@ -272,6 +272,12 @@ Optional password to use when connecting to Redis.
 Optional key defining the sending of client's name `bosun` to Redis. Defaults to true.
 If you use Netflix/dynomite then RedisClentSetName must be set to false.
 
+#### RedisSentinels
+The redis sentinels list. Redis sentinel list will be used only if parameter `RedisMasterName` was set as well 
+
+#### RedisMasterName
+The redis master name within sentinel. If it is set bosun will use sentinel to receive information about cuurrent redis master.
+
 #### LedisDir
 Directory in which ledis will store data. Default: `LedisDir = "ledis_data"`
 


### PR DESCRIPTION
# Problem
Currently we can have only one redis server. If we want to have some HA for bosun redis only way that we have HAProxy. But it require another service installation. So support of sentinels will allow us to have HA for redis without any extra services.

# Implementation
 Added 2 new options - `RedisSentinels` (array), `RedisMasterName`. If `RedisMasterName` was set we try to connect to redis sentinels (`RedisSentinels` option) for receive current redis master.