### PR TITLE
cmd/bosun: pass alert variables to unknown notification templates

### DIFF
--- a/cmd/bosun/sched/notify.go
+++ b/cmd/bosun/sched/notify.go
@@ -217,7 +217,8 @@ func (s *Schedule) sendUnknownNotifications() {
 			}
 		}
 		if len(overThresholdSets) > 0 {
-			n.NotifyMultipleUnknowns(gk.template, s.SystemConf, overThresholdSets, multiUstates, s.RuleConf)		}
+			n.NotifyMultipleUnknowns(gk.template, s.SystemConf, overThresholdSets, multiUstates, s.RuleConf)
+		}
 	}
 	s.pendingUnknowns = make(map[notificationGroupKey][]*models.IncidentState)
 }

--- a/cmd/bosun/sched/notify.go
+++ b/cmd/bosun/sched/notify.go
@@ -205,20 +205,19 @@ func (s *Schedule) sendUnknownNotifications() {
 				if c >= threshold && threshold > 0 {
 					if !hitThreshold && len(groupSets) == c {
 						// If the threshold is hit but only 1 email remains, just send the normal unknown
-						n.NotifyUnknown(gk.template, s.SystemConf, name, group, ustates[ak])
+						n.NotifyUnknown(gk.template, s.SystemConf, name, group, ustates[ak], s.RuleConf)
 						break
 					}
 					hitThreshold = true
 					overThresholdSets[name] = group
 					multiUstates = append(multiUstates, ustates[ak])
 				} else {
-					n.NotifyUnknown(gk.template, s.SystemConf, name, group, ustates[ak])
+					n.NotifyUnknown(gk.template, s.SystemConf, name, group, ustates[ak], s.RuleConf)
 				}
 			}
 		}
 		if len(overThresholdSets) > 0 {
-			n.NotifyMultipleUnknowns(gk.template, s.SystemConf, overThresholdSets, multiUstates)
-		}
+			n.NotifyMultipleUnknowns(gk.template, s.SystemConf, overThresholdSets, multiUstates, s.RuleConf)		}
 	}
 	s.pendingUnknowns = make(map[notificationGroupKey][]*models.IncidentState)
 }


### PR DESCRIPTION
#2275 allows to pass alert variables to action notifications. 
This PR allows this for unknown and multiple unknown notifications.