### PR TITLE
cmd/bosun: Check LastAbnormalStatus for unknown notification grouping

### DIFF
--- a/cmd/bosun/sched/notify.go
+++ b/cmd/bosun/sched/notify.go
@@ -143,7 +143,8 @@ func (s *Schedule) sendNotifications(silenced SilenceTester) {
 				continue
 			}
 			silenced := silenced(ak) != nil
-			if st.CurrentStatus == models.StUnknown {
+			// Incident state CurrentStatus may go back to normal, check if the LastAbnormalStatus 
+			if st.LastAbnormalStatus == models.StUnknown {
 				if silenced {
 					slog.Infoln("silencing unknown", ak)
 					continue

--- a/cmd/bosun/sched/notify.go
+++ b/cmd/bosun/sched/notify.go
@@ -143,7 +143,7 @@ func (s *Schedule) sendNotifications(silenced SilenceTester) {
 				continue
 			}
 			silenced := silenced(ak) != nil
-			// Incident state CurrentStatus may go back to normal, check if the LastAbnormalStatus 
+			// Incident state CurrentStatus may go back to normal, check if the LastAbnormalStatus
 			if st.LastAbnormalStatus == models.StUnknown {
 				if silenced {
 					slog.Infoln("silencing unknown", ak)


### PR DESCRIPTION
Fixes: https://github.com/bosun-monitor/bosun/issues/2393

For incidents in the unknown state it is possible for CurrentStatus to go back to normal.  In such a case if the incidents are not acknowledged and closed, bosun continues to send out blank e-mail notifications.

If the LastAbnormalStatus is unknown then I believe we can assume the notification is being sent for an unknown state and the notifications should be grouped as such.