### PR TITLE
Changing the checks and close schedule from sync to async

### DIFF
--- a/cmd/bosun/main.go
+++ b/cmd/bosun/main.go
@@ -303,7 +303,7 @@ func main() {
 				isNeedCheck = false
 				sched.Run()
 			}
-			time.Sleep(1 * time.Minute)
+			time.Sleep(5 * time.Second)
 		}
 	}()
 	//async check end

--- a/cmd/bosun/sched/sched.go
+++ b/cmd/bosun/sched/sched.go
@@ -506,6 +506,10 @@ func Close(reload bool) {
 	DefaultSched.Close(reload)
 }
 
+func CloseAsync(reload bool, s *Schedule) {
+	s.Close(reload)
+}
+
 func (s *Schedule) Close(reload bool) {
 	s.cancelChecks()
 	s.checksRunning.Wait()


### PR DESCRIPTION
We use bosun to provide monitoring and alarm for the company's container platform.When expr is a lot in a alert, it takes a lot of time to close schedule, same thing with reload.So i did.Async check:Not check all, Doing so reduces the number of checks,but does not affect real-time performance.eg: Now, checkChan'size is 10, after reading the first data,isNeedCheck is set to true, and 'sched.Run' goes to work.Finally, when checkChan is finished, check again.Closing schedule is simple,only add it to a goroutines.Can I do that.Looking forward to your reply