### PR TITLE
Changing the checks and close schedule from sync to async

### DIFF
--- a/cmd/bosun/main.go
+++ b/cmd/bosun/main.go
@@ -84,6 +84,8 @@ func init() {
 			},
 		},
 	}
+
+	checkChan = make(chan bool, 1000)
 }
 
 var (
@@ -98,6 +100,11 @@ var (
 	flagVersion  = flag.Bool("version", false, "Prints the version and exits")
 
 	mains []func() // Used to hook up syslog on *nix systems
+
+	checkChan   chan bool // When add a alert, checkChan is used to set 'isNeedCheck', indirect notification check
+	// When isNeedCheck is true, the checks appears. The Checks completed,
+	// set the isNeedCheck to false.Only checkChan has data, set the isNeedCheck to true.
+	isNeedCheck bool
 )
 
 func main() {
@@ -248,12 +255,13 @@ func main() {
 		newConf.SetReload(reload)
 		oldSched := sched.DefaultSched
 		oldSearch := oldSched.Search
-		sched.Close(true)
+		go func() {
+			sched.CloseAsync(true, oldSched)
+		}()
 		sched.Reset()
 		newSched := sched.DefaultSched
 		newSched.Search = oldSearch
 		slog.Infoln("schedule shutdown, loading new schedule")
-
 		// Load does not set the DataAccess or Search if it is already set
 		if err := sched.Load(sysProvider, newConf, da, annotateBackend, *flagSkipLast, *flagQuiet); err != nil {
 			slog.Fatal(err)
@@ -262,13 +270,12 @@ func main() {
 		go func() {
 			slog.Infoln("running new schedule")
 			if !*flagNoChecks {
-				sched.Run()
+				checkChan <- true
 			}
 		}()
 		slog.Infoln("config reload complete")
 		return nil
 	}
-
 	ruleProvider.SetReload(reload)
 
 	go func() {
@@ -276,6 +283,31 @@ func main() {
 			sysProvider.GetTLSCertFile(), sysProvider.GetTLSKeyFile(), *flagDev,
 			sysProvider.GetTSDBHost(), reload, sysProvider.GetAuthConf(), startTime))
 	}()
+	// async check
+	// Not check all, Doing so reduces the number of checks,
+	// but does not affect real-time performance.
+	// eg: Now, checkChan'size is 10, after reading the first data,
+	// isNeedCheck is set to true, and 'sched.Run' goes to work.
+	// Finally, when checkChan is finished, check again.
+	go func() {
+		for {
+			select {
+			case <-checkChan:
+				isNeedCheck = true
+			}
+		}
+	}()
+	go func() {
+		for {
+			if isNeedCheck {
+				isNeedCheck = false
+				sched.Run()
+			}
+			time.Sleep(5 * time.Second)
+		}
+	}()
+	//async check end
+
 	go func() {
 		if !*flagNoChecks {
 			sched.Run()

--- a/cmd/bosun/sched/sched.go
+++ b/cmd/bosun/sched/sched.go
@@ -506,6 +506,10 @@ func Close(reload bool) {
 	DefaultSched.Close(reload)
 }
 
+func CloseAsync(reload bool, s *Schedule) {
+	s.Close(reload)
+}
+
 func (s *Schedule) Close(reload bool) {
 	s.cancelChecks()
 	s.checksRunning.Wait()


### PR DESCRIPTION
We use bosun to provide monitoring and alarm for the company's container platform.When expr is a lot in a alert, it takes a lot of time to close schedule, same thing with reload.So i did.Async check:Not check all, Doing so reduces the number of checks,but does not affect real-time performance.eg: Now, checkChan'size is 10, after reading the first data,isNeedCheck is set to true, and 'sched.Run' goes to work.Finally, when checkChan is finished, check again.Closing schedule is simple,only add it to a goroutines.Can I do that.Looking forward to your reply.