### PR TITLE
Fix crash while try to get silenced + redis down

### DIFF
--- a/cmd/bosun/ping/ping.go
+++ b/cmd/bosun/ping/ping.go
@@ -30,7 +30,7 @@ func PingHosts(search *search.Search, duration time.Duration) {
 	for range time.Tick(pingFreq) {
 		hosts, err := search.TagValuesByTagKey("host", duration)
 		if err != nil {
-			slog.Error(err)
+			slog.Errorf("Error while search TagValuesByTagKey host: %s", err)
 			continue
 		}
 		for _, host := range hosts {

--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -84,7 +84,11 @@ func (s *Schedule) NewRunHistory(start time.Time, cache *cache.Cache) *RunHistor
 // RunHistory processes an event history and triggers notifications if needed.
 func (s *Schedule) RunHistory(r *RunHistory) {
 	checkNotify := false
-	silenced := s.Silenced()
+	silenced, err := s.Silenced()
+	if err != nil {
+		slog.Errorf("Error while get silenced: %s.", err)
+		return
+	}
 	for ak, event := range r.Events {
 		shouldNotify, err := s.runHistory(r, ak, event, silenced)
 		checkNotify = checkNotify || shouldNotify

--- a/cmd/bosun/sched/host.go
+++ b/cmd/bosun/sched/host.go
@@ -24,7 +24,10 @@ func (s *Schedule) Host(filter string) (map[string]*HostData, error) {
 	if err != nil {
 		return nil, err
 	}
-	silences := s.Silenced()
+	silences, err := s.Silenced()
+	if err != nil {
+		return nil, err
+	}
 	// These are all fetched by metric since that is how we store it in redis,
 	// so this makes for the fastest response
 	tagsByKey := func(metric, hostKey string) (map[string][]opentsdb.TagSet, error) {

--- a/cmd/bosun/sched/notify.go
+++ b/cmd/bosun/sched/notify.go
@@ -55,7 +55,11 @@ func (s *Schedule) Notify(st *models.IncidentState, rt *models.RenderedTemplates
 
 // CheckNotifications processes past notification events. It returns the next time a notification is needed.
 func (s *Schedule) CheckNotifications() time.Time {
-	silenced := s.Silenced()
+	silenced, err := s.Silenced()
+	if err != nil {
+		slog.Error("Error getting silenced", err)
+		return utcNow().Add(time.Minute)
+	}
 	s.Lock("CheckNotifications")
 	defer s.Unlock()
 	latestTime := utcNow()

--- a/cmd/bosun/web/incident.go
+++ b/cmd/bosun/web/incident.go
@@ -16,9 +16,9 @@ func ListOpenIncidents(t miniprofiler.Timer, w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		return nil, err
 	}
-	suppressor := schedule.Silenced()
-	if suppressor == nil {
-		return nil, fmt.Errorf("failed to get silences")
+	suppressor, err := schedule.Silenced()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get silences: %v", err)
 	}
 	summaries := []*sched.IncidentSummaryView{}
 	filterText := r.FormValue("filter")

--- a/cmd/bosun/web/web.go
+++ b/cmd/bosun/web/web.go
@@ -651,8 +651,10 @@ func IncidentEvents(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request
 		ExtStatus: ExtStatus{IncidentState: state, RenderedTemplates: rt, Subject: state.Subject},
 		IsActive:  state.IsActive(),
 	}
-	silence := schedule.GetSilence(t, state.AlertKey)
-	if silence != nil {
+	silence, err := schedule.GetSilence(t, state.AlertKey)
+	if err != nil {
+		slog.Errorf("Error while get silenced: %s", err)
+	} else if silence != nil {
 		st.Silence = silence
 		st.SilenceId = silence.ID()
 	}


### PR DESCRIPTION
+ Improve some errors logs

# Description

While Redis is down sometimes we are crashing:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x13f6f01]

goroutine 12648760 [running]:
bosun.org/cmd/bosun/sched.(*Schedule).CheckNotifications(0xc0110fc600, 0x0, 0x0, 0x0)
        /builddir/build/BUILD/bosun-0.8.0/GO/src/bosun.org/cmd/bosun/sched/notify.go:68 +0x1e1
bosun.org/cmd/bosun/sched.(*Schedule).dispatchNotifications(0xc0110fc600)
        /builddir/build/BUILD/bosun-0.8.0/GO/src/bosun.org/cmd/bosun/sched/notify.go:30 +0x1ee
created by bosun.org/cmd/bosun/sched.(*Schedule).Run
        /builddir/build/BUILD/bosun-0.8.0/GO/src/bosun.org/cmd/bosun/sched/alertRunner.go:18 +0xa4
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

- [x] Interaction test with Redis crashing emulation

# Checklist:

- [x] This contribution follows the project's [code of conduct](https://github.com/bosun-monitor/bosun/blob/master/CODE_OF_CONDUCT.md)
- [x] This contribution follows the project's [contributing guidelines](https://github.com/bosun-monitor/bosun/blob/master/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
