### PR TITLE
Fix rulecheck indicator in /api/health API

### DIFF
--- a/cmd/bosun/sched/alertRunner.go
+++ b/cmd/bosun/sched/alertRunner.go
@@ -14,6 +14,7 @@ func (s *Schedule) Run() error {
 	if s.RuleConf == nil || s.SystemConf == nil {
 		return fmt.Errorf("sched: nil configuration")
 	}
+	s.run = true
 	s.nc = make(chan interface{}, 1)
 	go s.dispatchNotifications()
 	type alertCh struct {

--- a/cmd/bosun/sched/sched.go
+++ b/cmd/bosun/sched/sched.go
@@ -46,6 +46,7 @@ type Schedule struct {
 
 	skipLast bool
 	quiet    bool
+	run      bool
 
 	//channel signals an alert has added notifications, and notifications should be processed.
 	nc chan interface{}
@@ -719,6 +720,10 @@ func (s *Schedule) getErrorCounts() (failing, total int) {
 
 func (s *Schedule) GetQuiet() bool {
 	return s.quiet
+}
+
+func (s *Schedule) IsRunning() bool {
+	return s.run
 }
 
 // GetCheckFrequency returns the duration between checks for the named alert. If the alert

--- a/cmd/bosun/web/web.go
+++ b/cmd/bosun/web/web.go
@@ -481,7 +481,7 @@ func Quiet(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (interf
 func HealthCheck(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	var h Health
 	var n NotificationStats
-	h.RuleCheck = schedule.LastCheck.After(time.Now().Add(-schedule.SystemConf.GetCheckFrequency()))
+	h.RuleCheck = schedule.IsRunning()
 	h.Quiet = schedule.GetQuiet()
 	h.UptimeSeconds = int64(time.Since(startTime).Seconds())
 	h.StartEpoch = startTime.Unix()


### PR DESCRIPTION
# Description
Nodes with no-checks flag are returning RuleCheck in /api/health as true

```
$ ./main -c node1/bosun.toml -n
2020/01/15 16:57:50 info: migrate.go:138: checking migrations
2020/01/15 16:57:50 info: search.go:208: Loading last datapoints from redis
2020/01/15 16:57:50 info: search.go:215: Done
2020/01/15 16:57:50 info: web.go:216: tsdb host: 127.0.0.1:4242
2020/01/15 16:57:50 info: web.go:220: bosun web listening http on: :8071
...
$ curl -s 127.0.0.1:8071/api/health | jq .RuleCheck
false
$ curl -XPOST 127.0.0.1:8071/api/reload -d '{ "Reload": true }'
"reloaded"
$ curl -s 127.0.0.1:8071/api/health | jq .RuleCheck            
true
```

If node has no-checks flags RuleCheck should be false all time

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

- [x] Integration test

no-checks was set:
```
$ ./main -c node1/bosun.toml -n
2020/01/15 17:02:47 info: migrate.go:138: checking migrations
2020/01/15 17:02:47 info: search.go:208: Loading last datapoints from redis
2020/01/15 17:02:47 info: search.go:215: Done
2020/01/15 17:02:47 info: web.go:216: tsdb host: 127.0.0.1:4242
2020/01/15 17:02:47 info: web.go:220: bosun web listening http on: :8071
$ curl -s 127.0.0.1:8071/api/health | jq .RuleCheck
false
$ curl -XPOST 127.0.0.1:8071/api/reload -d '{ "Reload": true }'
"reloaded"
$ curl -s 127.0.0.1:8071/api/health | jq .RuleCheck            
false
```

no-checks is false:
```
$ ./main -c node1/bosun.toml   
2020/01/15 17:05:11 info: migrate.go:138: checking migrations
2020/01/15 17:05:11 info: search.go:208: Loading last datapoints from redis
2020/01/15 17:05:11 info: search.go:215: Done
2020/01/15 17:05:11 info: check.go:561: check alert bosun_uptime start with now set to 2020-01-15 16:05:11.481449306
2020/01/15 17:05:11 info: web.go:216: tsdb host: 127.0.0.1:4242
2020/01/15 17:05:11 info: web.go:220: bosun web listening http on: :8071
2020/01/15 17:05:11 info: check.go:609: check alert bosun_uptime done (3.135856ms): 1 crits, 0 warns, 0 unevaluated, 0 unknown
2020/01/15 17:05:11 info: alertRunner.go:105: runHistory on bosun_uptime took 23.743938ms
2020/01/15 17:05:11 error: notify.go:84: type: alert; name: default; transport: http_POST; dst: http://127.0.0.1:8000/; body: <html><head></head><body>&#39;&#39;</body></html>; error: Post http://127.0.0.1:8000/: dial tcp 127.0.0.1:8000: connect: connection refused
2020/01/15 17:05:19 info: alertRunner.go:86: Stopping alert routine for bosun_uptime
2020/01/15 17:05:19 info: main.go:255: schedule shutdown, loading new schedule
2020/01/15 17:05:19 info: main.go:268: config reload complete
2020/01/15 17:05:19 info: main.go:263: running new schedule
2020/01/15 17:05:19 info: check.go:561: check alert bosun_uptime start with now set to 2020-01-15 16:05:19.184973544
2020/01/15 17:05:19 info: check.go:609: check alert bosun_uptime done (642.76µs): 1 crits, 0 warns, 0 unevaluated, 0 unknown
2020/01/15 17:05:19 info: alertRunner.go:105: runHistory on bosun_uptime took 3.392522ms
...
$ curl -s 127.0.0.1:8071/api/health | jq .RuleCheck
true
$ curl -XPOST 127.0.0.1:8071/api/reload -d '{ "Reload": true }'
"reloaded"
$ curl -s 127.0.0.1:8071/api/health | jq .RuleCheck            
true
```

# Checklist:

- [x] This contribution follows the project's [code of conduct](https://github.com/bosun-monitor/bosun/blob/master/CODE_OF_CONDUCT.md)
- [x] This contribution follows the project's [contributing guidelines](https://github.com/bosun-monitor/bosun/blob/master/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
