### PR TITLE
Use unknownTemplate if it is configured

### DIFF
--- a/cmd/bosun/conf/conf.go
+++ b/cmd/bosun/conf/conf.go
@@ -123,6 +123,7 @@ type RuleConfProvider interface {
 	GetNotification(string) *Notification
 
 	GetLookup(string) *Lookup
+	GetUnknownTemplate() *Template
 
 	AlertSquelched(*Alert) func(opentsdb.TagSet) bool
 	Squelched(*Alert, opentsdb.TagSet) bool

--- a/cmd/bosun/conf/rule/rule.go
+++ b/cmd/bosun/conf/rule/rule.go
@@ -784,6 +784,14 @@ func (c *Conf) GetLookup(s string) *conf.Lookup {
 	return c.Lookups[s]
 }
 
+func (c *Conf) GetUnknownTemplate() *conf.Template {
+	if len(c.unknownTemplate) == 0 {
+		return nil
+	}
+
+	return c.GetTemplate(c.unknownTemplate)
+}
+
 func (c *Conf) GetSquelches() conf.Squelches {
 	return c.Squelch
 }

--- a/cmd/bosun/sched/alertRunner.go
+++ b/cmd/bosun/sched/alertRunner.go
@@ -49,6 +49,7 @@ func (s *Schedule) Run() error {
 	for {
 		select {
 		case <-s.runnerContext.Done():
+			slog.Infoln("Stopping main scheduler routine")
 			return nil
 		default:
 		}


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

# Description

Currently it is possible to specify name of unknownTemplate in rules configuration file. The issue is that unknown template name are parsed and assigned (bosun/conf/rule/rule.go line 195) but never actually used in code. As a result only static internal template are used.


Fixes #2446 (fill in)
https://github.com/bosun-monitor/bosun/issues/2446

## Type of change

From the following, please check the options that are relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Currently running in our internal environment.

# Checklist:

- [X] This contribution follows the project's [code of conduct](https://github.com/bosun-monitor/bosun/blob/master/CODE_OF_CONDUCT.md)
- [X] This contribution follows the project's [contributing guidelines](https://github.com/bosun-monitor/bosun/blob/master/CONTRIBUTING.md)
- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
