### PR TITLE
Fix actionPost* not being accepted

### DIFF
--- a/cmd/bosun/conf/rule/loaders.go
+++ b/cmd/bosun/conf/rule/loaders.go
@@ -441,7 +441,7 @@ func (c *Conf) loadNotification(s *parse.SectionNode) {
 				// look for and trim suffix if there
 				// trim the templateKey and explicitly match actiontype
 				for s, t := range models.ActionShortNames {
-					for _, e := range []string{"Body", "Get", "EmailSubject"} {
+					for _, e := range []string{"Body", "Get", "Post", "EmailSubject"} {
 						if strings.Compare(strings.TrimPrefix(keyType, e), s) == 0 {
 							at = t
 							keyType = keyType[:len(keyType)-len(s)]


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

# Description

The config parser currently rejects `actionPost*` where `*` is either nothing or an action type. This is because it is missing from an array in the configuration parsing logic. This patch adds it to the array.

## Type of change

From the following, please check the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

This is cherry-picked from our branch. We were seeing unknown field errors when attempting to use `actionPost`. This patch allows the fields to work.

# Checklist:

- [x] This contribution follows the project's [code of conduct](https://github.com/bosun-monitor/bosun/blob/master/CODE_OF_CONDUCT.md)
- [x] This contribution follows the project's [contributing guidelines](https://github.com/bosun-monitor/bosun/blob/master/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
