### PR TITLE
Fix panic in timedelta expression if series are empty

### DIFF
--- a/cmd/bosun/expr/funcs.go
+++ b/cmd/bosun/expr/funcs.go
@@ -1134,6 +1134,9 @@ func TimeDelta(e *State, series *Results) (*Results, error) {
 	for _, res := range series.Results {
 		sorted := NewSortedSeries(res.Value.Value().(Series))
 		newSeries := make(Series)
+		if len(sorted) == 0 {
+			continue
+		}
 		if len(sorted) < 2 {
 			newSeries[sorted[0].T] = 0
 			res.Value = newSeries

--- a/cmd/bosun/expr/funcs_test.go
+++ b/cmd/bosun/expr/funcs_test.go
@@ -192,6 +192,10 @@ func TestTimedelta(t *testing.T) {
 				time.Unix(1466133600, 0): 0,
 			},
 		},
+		{
+			`timedelta(series("foo=bar"))`,
+			Series{},
+		},
 	} {
 
 		err := testExpression(exprInOut{


### PR DESCRIPTION
# Description

Fix panic in timedelta expression if series are empty

Fixes #2467

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

- [x] TestTimedelta

# Checklist:

- [x] This contribution follows the project's [code of conduct](https://github.com/bosun-monitor/bosun/blob/master/CODE_OF_CONDUCT.md)
- [x] This contribution follows the project's [contributing guidelines](https://github.com/bosun-monitor/bosun/blob/master/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
