### PR TITLE
Make it possible to control decision about unknown state

### DIFF
--- a/cmd/bosun/conf/conf.go
+++ b/cmd/bosun/conf/conf.go
@@ -74,6 +74,8 @@ type SystemConfProvider interface {
 
 	GetMaxRenderedTemplateAge() int
 
+	GetProblemRunsToUnknown() time.Duration
+
 	GetExampleExpression() string
 
 	// Contexts

--- a/cmd/bosun/conf/system.go
+++ b/cmd/bosun/conf/system.go
@@ -46,6 +46,7 @@ type SystemConf struct {
 	MinGroupSize  int
 
 	UnknownThreshold       int
+	ProblemRunsToUnknown   int
 	CheckFrequency         Duration // Time between alert checks: 5m
 	DefaultRunEvery        int      // Default number of check intervals to run each alert: 1
 	AlertCheckDistribution string   // Method to distribute alet checks. No distribution if equals ""
@@ -720,6 +721,15 @@ func (sc *SystemConf) GetAzureMonitorContext() expr.AzureMonitorClients {
 		allClients[prefix] = cc
 	}
 	return allClients
+}
+
+// how many runs can by skipped because the errors of some stuck within the bosun
+// before we assume the alert should go to the unknown state
+func (sc *SystemConf) GetProblemRunsToUnknown() time.Duration {
+	if sc.ProblemRunsToUnknown <= 0 {
+		sc.ProblemRunsToUnknown = 1
+	}
+	return time.Duration(1 + sc.ProblemRunsToUnknown)
 }
 
 // azureLogRequest outputs HTTP requests to Azure to the logs

--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -540,7 +540,7 @@ func (s *Schedule) findUnknownAlerts(now time.Time, alert string) []models.Alert
 		if a.RunEvery != 0 {
 			runEvery = a.RunEvery
 		}
-		t = s.SystemConf.GetCheckFrequency() * 2 * time.Duration(runEvery)
+		t = s.SystemConf.GetCheckFrequency() * time.Duration(runEvery) * s.SystemConf.GetProblemRunsToUnknown()
 	}
 	maxTouched := now.UTC().Unix() - int64(t.Seconds())
 	untouched, err := s.DataAccess.State().GetUntouchedSince(alert, maxTouched)

--- a/cmd/bosun/sched/check_test.go
+++ b/cmd/bosun/sched/check_test.go
@@ -1,8 +1,6 @@
 package sched
 
 import (
-	"bosun.org/host"
-	"bosun.org/util"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -10,6 +8,9 @@ import (
 	"net/url"
 	"testing"
 	"time"
+
+	"bosun.org/host"
+	"bosun.org/util"
 
 	"bosun.org/cmd/bosun/conf"
 	"bosun.org/cmd/bosun/conf/rule"
@@ -455,6 +456,9 @@ Loop:
 	if !gotExpected {
 		t.Errorf("didn't get expected result")
 	}
+}
+
+func TestCheckNotifyDelayedUnknown(t *testing.T) {
 }
 
 // TestCheckNotifyUnknownDefault tests the default unknownTemplate.

--- a/cmd/bosun/sched/depends_test.go
+++ b/cmd/bosun/sched/depends_test.go
@@ -12,7 +12,7 @@ import (
 // Result should be {a=c} only.
 func TestDependency_Simple(t *testing.T) {
 	defer setup()()
-	testSched(t, &schedTest{
+	testSched(t, nil, &schedTest{
 		conf: `alert a {
 			crit = avg(q("avg:c{a=*}", "5m", "")) > 0
 			depends = avg(q("avg:d{a=*}", "5m", "")) > 0
@@ -52,7 +52,7 @@ func TestDependency_Simple(t *testing.T) {
 // Crit and depends don't have same tag sets.
 func TestDependency_Overlap(t *testing.T) {
 	defer setup()()
-	testSched(t, &schedTest{
+	testSched(t, nil, &schedTest{
 		conf: `alert a {
 			crit = avg(q("avg:c{a=*,b=*}", "5m", "")) > 0
 			depends = avg(q("avg:d{a=*,d=*}", "5m", "")) > 0
@@ -91,7 +91,7 @@ func TestDependency_Overlap(t *testing.T) {
 
 func TestDependency_OtherAlert(t *testing.T) {
 	defer setup()()
-	testSched(t, &schedTest{
+	testSched(t, nil, &schedTest{
 		conf: `alert a {
 			crit = avg(q("avg:a{host=*,cpu=*}", "5m", "")) > 0
 		}
@@ -134,7 +134,7 @@ func TestDependency_OtherAlert(t *testing.T) {
 func TestDependency_OtherAlert_Unknown(t *testing.T) {
 	defer setup()()
 
-	testSched(t, &schedTest{
+	testSched(t, nil, &schedTest{
 		conf: `alert a {
 			warn = avg(q("avg:a{host=*}", "5m", "")) > 0
 		}
@@ -182,7 +182,7 @@ func TestDependency_OtherAlert_UnknownChain(t *testing.T) {
 	bb := models.AlertKey("b{host=b}")
 	cb := models.AlertKey("c{host=b}")
 
-	s := testSched(t, &schedTest{
+	s := testSched(t, nil, &schedTest{
 		conf: `
 		alert a {
 			warn = avg(q("avg:a{host=*}", "5m", "")) && 0
@@ -240,7 +240,7 @@ func TestDependency_OtherAlert_UnknownChain(t *testing.T) {
 
 func TestDependency_Blocks_Unknown(t *testing.T) {
 	defer setup()()
-	testSched(t, &schedTest{
+	testSched(t, nil, &schedTest{
 		conf: `alert a {
 			depends = avg(q("avg:b{host=*}", "5m", "")) > 0
 			warn = avg(q("avg:a{host=*}", "5m", "")) > 0
@@ -267,7 +267,7 @@ func TestDependency_Blocks_Unknown(t *testing.T) {
 func TestDependency_AlertFunctionHasNoResults(t *testing.T) {
 	defer setup()()
 
-	testSched(t, &schedTest{
+	testSched(t, nil, &schedTest{
 		conf: `
 alert a {
     warn = max(rename(q("sum:bosun.ping.timeout{dst_host=*,host=*}", "5m", ""), "host=source,dst_host=host"))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,6 +81,7 @@ Config items:
 * httpListen: HTTP listen address, defaults to `:8070`
 * hostname: when generating links in templates, use this value as the hostname instead of using the system's hostname
 * minGroupSize: minimum group size for alerts to be grouped together on dashboard. Default `5`.
+* problemRunsToUnknown: how many runs of the alert we should be able to skip (because an error while query the redis as instance) before we decide that alert should go to `unknown` (untouched) state. By default we will decide that alert was untouched and should be in `unknown` state on next run after an error (As an example: We have `defaultRunEvery` = 1, `checkFrequency` = 5m. We have an alert was successfully executed at the time 0 (second), the error was while query redis database at the time 300 (0 + 5 minutes). Next check at the time 600 will generate the `unknown` state). Default `1`. 
 * ping: if present, will ping all values tagged with host
 * responseLimit: number of bytes to limit OpenTSDB responses, defaults to 1MB (`1048576`)
 * searchSince: duration of time to filter by during certain searches, defaults to `3d`; currently used by the hosts list on the items page


### PR DESCRIPTION
# Description
Make it possible to control decisions about unknown states based on the time an alert was untouched by adding system config parameter `ProblemRunsToUnknown`.
Description in the https://github.com/bosun-monitor/bosun/issues/2470

Fixes #2470 (fill in)

## Type of change

From the following, please check the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How has this been tested?
- [x] TestDelayedUnknown

# Checklist:

- [x] This contribution follows the project's [code of conduct](https://github.com/bosun-monitor/bosun/blob/master/CODE_OF_CONDUCT.md)
- [x] This contribution follows the project's [contributing guidelines](https://github.com/bosun-monitor/bosun/blob/master/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
