### PR TITLE
Initialise host manager when starting tsdbrelay

### DIFF
--- a/cmd/bosun/main.go
+++ b/cmd/bosun/main.go
@@ -3,11 +3,8 @@ package main
 //go:generate go run ../../build/generate/generate.go
 
 import (
-	"bosun.org/_version"
-	"bosun.org/host"
 	"flag"
 	"fmt"
-	"gopkg.in/fsnotify.v1"
 	"net/http"
 	"net/http/httptest"
 	_ "net/http/pprof"
@@ -18,6 +15,9 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	version "bosun.org/_version"
+	"gopkg.in/fsnotify.v1"
 
 	"bosun.org/annotate/backend"
 	"bosun.org/cmd/bosun/conf"
@@ -101,23 +101,6 @@ var (
 	mains []func() // Used to hook up syslog on *nix systems
 )
 
-func initHostManager(customHostname string) {
-	var hm host.Manager
-	var err error
-
-	if customHostname != "" {
-		hm, err = host.NewManagerForHostname(customHostname, false)
-	} else {
-		hm, err = host.NewManager(false)
-	}
-
-	if err != nil {
-		slog.Fatalf("couldn't initialise host factory: %v", err)
-	}
-
-	util.SetHostManager(hm)
-}
-
 func main() {
 	flag.Parse()
 	if *flagVersion {
@@ -132,7 +115,7 @@ func main() {
 		slog.Fatalf("couldn't read system configuration: %v", err)
 	}
 
-	initHostManager(systemConf.Hostname)
+	util.InitHostManager(systemConf.Hostname, false)
 
 	// Check if ES version is set by getting configs on start-up.
 	// Because the current APIs don't return error so calling slog.Fatalf

--- a/cmd/scollector/main.go
+++ b/cmd/scollector/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bosun.org/host"
 	"bytes"
 	"encoding/json"
 	_ "expvar"
@@ -20,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	"bosun.org/_version"
+	version "bosun.org/_version"
 	"bosun.org/cmd/scollector/collectors"
 	"bosun.org/cmd/scollector/conf"
 	"bosun.org/collect"
@@ -60,23 +59,6 @@ func (t *scollectorHTTPTransport) RoundTrip(req *http.Request) (*http.Response, 
 		req.Header.Add("User-Agent", t.UserAgent)
 	}
 	return t.RoundTripper.RoundTrip(req)
-}
-
-func initHostManager(customHostname string, useFullHostName bool) {
-	var hm host.Manager
-	var err error
-
-	if customHostname != "" {
-		hm, err = host.NewManagerForHostname(customHostname, useFullHostName)
-	} else {
-		hm, err = host.NewManager(useFullHostName)
-	}
-
-	if err != nil {
-		slog.Fatalf("couldn't initialise host factory: %v", err)
-	}
-
-	util.SetHostManager(hm)
 }
 
 func main() {
@@ -137,7 +119,7 @@ func main() {
 	}
 	collectors.AddTags = conf.Tags
 
-	initHostManager(conf.Hostname, conf.FullHost)
+	util.InitHostManager(conf.Hostname, conf.FullHost)
 
 	if conf.ColDir != "" {
 		collectors.InitPrograms(conf.ColDir)

--- a/cmd/tsdbrelay/main.go
+++ b/cmd/tsdbrelay/main.go
@@ -30,13 +30,15 @@ import (
 )
 
 var (
-	listenAddr      = flag.String("l", ":4242", "Listen address.")
-	bosunServer     = flag.String("b", "bosun", "Target Bosun server. Can specify port with host:port.")
-	secondaryRelays = flag.String("r", "", "Additional relays to send data to. Intended for secondary data center replication. Only response from primary tsdb server wil be relayed to clients.")
-	tsdbServer      = flag.String("t", "", "Target OpenTSDB server. Can specify port with host:port.")
-	logVerbose      = flag.Bool("v", false, "enable verbose logging")
-	toDenormalize   = flag.String("denormalize", "", "List of metrics to denormalize. Comma seperated list of `metric__tagname__tagname` rules. Will be translated to `__tagvalue.tagvalue.metric`")
-	flagVersion     = flag.Bool("version", false, "Prints the version and exits.")
+	listenAddr       = flag.String("l", ":4242", "Listen address.")
+	bosunServer      = flag.String("b", "bosun", "Target Bosun server. Can specify port with host:port.")
+	secondaryRelays  = flag.String("r", "", "Additional relays to send data to. Intended for secondary data center replication. Only response from primary tsdb server wil be relayed to clients.")
+	tsdbServer       = flag.String("t", "", "Target OpenTSDB server. Can specify port with host:port.")
+	logVerbose       = flag.Bool("v", false, "enable verbose logging")
+	hostnameOverride = flag.String("hostname", "", "Override the own hostname. Especially useful when running in a container.")
+	useFullHostname  = flag.Bool("useFullHostname", false, "Whether to use the fully qualified hostname")
+	toDenormalize    = flag.String("denormalize", "", "List of metrics to denormalize. Comma seperated list of `metric__tagname__tagname` rules. Will be translated to `__tagvalue.tagvalue.metric`")
+	flagVersion      = flag.Bool("version", false, "Prints the version and exits.")
 
 	redisHost = flag.String("redis", "", "redis host for aggregating external counters")
 	redisDb   = flag.Int("db", 0, "redis db to use for counters")
@@ -105,6 +107,8 @@ func main() {
 			slog.Fatal(err)
 		}
 	}
+
+	util.InitHostManager(*hostnameOverride, *useFullHostname)
 
 	tsdbURL, err := parseHost(*tsdbServer, "", true)
 	if err != nil {

--- a/util/util.go
+++ b/util/util.go
@@ -3,12 +3,31 @@ package util // import "bosun.org/util"
 
 import (
 	"bosun.org/host"
+	"bosun.org/slog"
+
 	"regexp"
 )
 
 // This is here only until we manage to refactor more of the system, allowing us to pass a host.Manager around
 // the system, rather than holding onto global state
 var hostManager host.Manager
+
+func InitHostManager(customHostname string, useFullHostName bool) {
+	var hm host.Manager
+	var err error
+
+	if customHostname != "" {
+		hm, err = host.NewManagerForHostname(customHostname, useFullHostName)
+	} else {
+		hm, err = host.NewManager(useFullHostName)
+	}
+
+	if err != nil {
+		slog.Fatalf("couldn't initialise host factory: %v", err)
+	}
+
+	SetHostManager(hm)
+}
 
 func SetHostManager(hm host.Manager) {
 	hostManager = hm


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

# Description

Fixes a bug that was introduced with #2439 which now requires the
initialisation of the HostManager on startup. That was forgotten to add
to the tsdbrelay command, causing it to panic on startup.

Fixes: #2475

## Type of change

From the following, please check the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration

- [x] Tested manually since the fix is part of `main()`
- [x] Automated tests for the HostManagers as added previously

# Checklist:

- [x] This contribution follows the project's [code of conduct](https://github.com/bosun-monitor/bosun/blob/master/CODE_OF_CONDUCT.md)
- [x] This contribution follows the project's [contributing guidelines](https://github.com/bosun-monitor/bosun/blob/master/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] ~Any dependent changes have been merged and published in downstream modules~
