### PR TITLE
Update Github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,15 +8,21 @@ assignees: ""
 
 # Expected behaviour
 
-> Please describe the behaviour you are expecting
+<!--
+Please describe the behaviour you are expecting
+-->
 
 # Current behaviour
 
-> What is the current behaviour?
+<!--
+What is the current behaviour?
+-->
 
 ## Steps to reproduce
 
-> Please provide detailed steps for reproducing the issue.
+<!--
+Please provide detailed steps for reproducing the issue.
+-->
 
 1. step 1
 2. step 2
@@ -24,10 +30,14 @@ assignees: ""
 
 ## Context
 
-> Please provide any relevant information about your setup. 
-> This is important in case the issue is not reproducible except for under certain conditions.
+<!--
+Please provide any relevant information about your setup. 
+This is important in case the issue is not reproducible except for under certain conditions.
+ -->
 
 
 ## Logs
 
-> Please include any relevant log snippets or files here.
+<!--
+Please include any relevant log snippets or files here.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,24 +1,30 @@
+<!--
 ## Please follow the guide below
 
 - You will be asked some questions, please read them **carefully** and answer honestly
 - Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
 - Use *Preview* tab to see how your *pull request* will actually look like
+-->
 
 ---
 
 # Description
 
+<!--
 Please describe your contribution in an issue first, to see if it fits the roadmap of the project. This makes it easier 
 for us and you to accept your contribution without requiring too much rework.
 Please include a summary of the change and which issue is fixed. 
 Please also include relevant motivation and context. 
-List any dependencies that are required for this change.
+List any dependencies that are required for this change. 
+-->
 
 Fixes #0000 (fill in)
 
 ## Type of change
 
+<!--
 From the following, please check the options that are relevant.
+-->
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
@@ -27,9 +33,11 @@ From the following, please check the options that are relevant.
 
 # How has this been tested?
 
+<!--
 Please describe the tests that you ran to verify your changes. 
 Provide instructions so we can reproduce. 
 Please also list any relevant details for your test configuration
+-->
 
 - [ ] Test A
 - [ ] Test B


### PR DESCRIPTION
# Description

Wraps the help text into comments so that they are still visible to
contributors, but won't show up on the PR itself.

Example for the PR template:
<img width="672" alt="image" src="https://user-images.githubusercontent.com/12208771/81820333-668d7b00-9528-11ea-8bd0-5f265f5abf94.png">


## Type of change

From the following, please check the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

- [x] Sent through a markdown renderer

# Checklist:

- [x] This contribution follows the project's [code of conduct](https://github.com/bosun-monitor/bosun/blob/master/CODE_OF_CONDUCT.md)
- [x] This contribution follows the project's [contributing guidelines](https://github.com/bosun-monitor/bosun/blob/master/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests pass locally with my changes
- [ ] ~Any dependent changes have been merged and published in downstream modules~
