### PR TITLE
Add test coverage report generation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,27 +23,7 @@ jobs:
         run: make goimports-check
       - name: Check if modules were tidied up
         run: make tidy-check
-  sonarcloud:
-    name: Sonar static analysis
-    runs-on: ubuntu-18.04
-    steps:
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ^1.13
-        id: go
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          # Disabling shallow clone is recommended for improving relevancy of reporting
-          fetch-depth: 0
-      - name: generate
-        run: make test-coverprofile
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
   generated:
     name: Generated code
     runs-on: ubuntu-18.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,27 @@ jobs:
         run: make goimports-check
       - name: Check if modules were tidied up
         run: make tidy-check
-
+  sonarcloud:
+    name: Sonar static analysis
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.13
+        id: go
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # Disabling shallow clone is recommended for improving relevancy of reporting
+          fetch-depth: 0
+      - name: generate
+        run: make test-coverprofile
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   generated:
     name: Generated code
     runs-on: ubuntu-18.04

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,27 @@
+name: sonarcloud
+
+on:
+  push:
+    branches: [ master ]
+jobs:
+  sonarcloud:
+    name: Sonar static analysis
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.13
+        id: go
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # Disabling shallow clone is recommended for improving relevancy of reporting
+          fetch-depth: 0
+      - name: generate
+        run: make test-coverprofile
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ cmd/bosun/bosun.toml
 cmd/bosun/bosunrules.conf
 cmd/scollector/scollector
 buildoutput
+test-report.out
+coverage.out

--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,8 @@ coverage:
 	$(GOTEST) -covermode=count -coverprofile=coverage.out  $$($(GOLIST) ./... | grep -v integration)
 	$(GOTOOL) cover -html=coverage.out
 
-.PHOHY: checks
-checks: goimports-check vet generate tidy-check test-coverprofile
+.PHONY: checks
+checks: goimports-check vet generate tidy-check
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,17 @@ staticcheck:
 test:
 	$(GOTEST) -v ./...
 
+.PHONY: test-coverprofile
+test-coverprofile:
+	go test -covermode=count -coverprofile=coverage.out `go list ./... | grep -v integration` -json > test-report.out
+
+.PHONY: coverage
+coverage:
+	go test -covermode=count -coverprofile=coverage.out `go list ./... | grep -v integration`
+	go tool cover -html=coverage.out
+
 .PHOHY: checks
-checks: goimports-check vet generate tidy-check
+checks: goimports-check vet generate tidy-check test-coverprofile
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GOLIST=$(GOCMD) list
 GOMOD=$(GOCMD) mod
 GOTEST=$(GOCMD) test
 GOVET=$(GOCMD) vet
-
+GOTOOL=$(GOCMD) tool
 BINARY_NAME=bosun
 BINARY_UNIX=$(BINARY_NAME)_unix
 BINARY_MAC=$(BINARY_NAME)_mac
@@ -118,12 +118,12 @@ test:
 
 .PHONY: test-coverprofile
 test-coverprofile:
-	go test -covermode=count -coverprofile=coverage.out `go list ./... | grep -v integration` -json > test-report.out
+	$(GOTEST) -covermode=count -coverprofile=coverage.out $$($(GOLIST) ./... | grep -v integration) -json > test-report.out
 
 .PHONY: coverage
 coverage:
-	go test -covermode=count -coverprofile=coverage.out `go list ./... | grep -v integration`
-	go tool cover -html=coverage.out
+	$(GOTEST) -covermode=count -coverprofile=coverage.out  $$($(GOLIST) ./... | grep -v integration)
+	$(GOTOOL) cover -html=coverage.out
 
 .PHOHY: checks
 checks: goimports-check vet generate tidy-check test-coverprofile

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,9 @@
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8
 
+sonar.organization=bosun-monitor
+sonar.projectKey=bosun-monitor_bosun
+
 sonar.sources=.
 sonar.exclusions=**/*_test.go,**/vendor/**,**/tests/**
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,9 @@
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8
+
+sonar.sources=.
+sonar.exclusions=**/*_test.go,**/vendor/**,**/tests/**
+
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go
+sonar.test.exclusions=**/vendor/**


### PR DESCRIPTION
Add targets for generating coverage reports. Initial version of sonar config to exclude tests and vendored packages

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

# Description

Add two features.
Short cut for generating and viewing coverage reports by running `make coverage`
Added step to generate coverage report as part of checks for use by sonarcloud

## Type of change

From the following, please check the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
Makefile steps verified locally

# Checklist:

- [x ] This contribution follows the project's [code of conduct](https://github.com/bosun-monitor/bosun/blob/master/CODE_OF_CONDUCT.md)
- [x] This contribution follows the project's [contributing guidelines](https://github.com/bosun-monitor/bosun/blob/master/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules