### PR TITLE
Adds support for directly querying cloudwatch metrics via the AWS SDK

### DIFF
--- a/cloudwatch/cloudwatch.go
+++ b/cloudwatch/cloudwatch.go
@@ -1,0 +1,412 @@
+// Package cloudwatch defines structures for interacting with Cloudwatch Metrics.
+package cloudwatch // import "bosun.org/cloudwatch"
+
+import (
+	"bosun.org/opentsdb"
+	"bosun.org/slog"
+	"errors"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	cw "github.com/aws/aws-sdk-go/service/cloudwatch"
+	cwi "github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
+	"github.com/ryanuber/go-glob"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	once    sync.Once
+	context Context
+)
+
+const DefaultConcurrency = 4
+const DefaultPageLimit = 10
+const DefaultExpansionLimit = 500
+
+var ErrExpansionLimit = errors.New("Hit dimension expansion limit")
+var ErrPagingLimit = errors.New("Hit the page limit when retrieving metrics")
+var ErrInvalidPeriod = errors.New("Period must be greater than 0")
+
+// Request holds query objects. Currently only absolute times are supported.
+type Request struct {
+	Start           *time.Time
+	End             *time.Time
+	Region          string
+	Namespace       string
+	Metric          string
+	Period          int64
+	Statistic       string
+	DimensionString string
+	Dimensions      [][]Dimension
+	Profile         string
+}
+type LookupRequest struct {
+	Region     string
+	Namespace  string
+	Metric     string
+	Dimensions [][]Dimension
+	Profile    string
+}
+
+type Response struct {
+	Raw    cw.GetMetricDataOutput
+	TagSet map[string]opentsdb.TagSet
+}
+
+type Series struct {
+	Datapoints []DataPoint
+	Label      string
+}
+
+type DataPoint struct {
+	Aggregator string
+	Timestamp  string
+	Unit       string
+}
+
+type Dimension struct {
+	Name  string
+	Value string
+}
+
+type Wildcards map[string]string
+
+type DimensionSet map[string]bool
+
+func (d Dimension) String() string {
+	return fmt.Sprintf("%s:%s", d.Name, d.Value)
+}
+
+type DimensionList struct {
+	Groups [][]Dimension
+}
+
+func (r *Request) CacheKey() string {
+	return fmt.Sprintf("cloudwatch-%d-%d-%s-%s-%s-%d-%s-%s-%s",
+		r.Start.Unix(),
+		r.End.Unix(),
+		r.Region,
+		r.Namespace,
+		r.Metric,
+		r.Period,
+		r.Statistic,
+		r.DimensionString,
+		r.Profile,
+	)
+}
+
+// Context is the interface for querying CloudWatch.
+type Context interface {
+	Query(*Request) (Response, error)
+	LookupDimensions(request *LookupRequest) ([][]Dimension, error)
+	GetExpansionLimit() int
+	GetPagesLimit() int
+	GetConcurrency() int
+}
+
+type cloudWatchContext struct {
+	profileProvider ProfileProvider
+	profiles        map[string]cwi.CloudWatchAPI
+	profilesLock    sync.RWMutex
+	ExpansionLimit  int
+	PagesLimit      int
+	Concurrency     int
+}
+
+type ProfileProvider interface {
+	NewProfile(name, region string) cwi.CloudWatchAPI
+}
+
+type profileProvider struct{}
+
+func (p profileProvider) NewProfile(name, region string) cwi.CloudWatchAPI {
+	enableVerboseLogging := true
+	conf := aws.Config{
+		CredentialsChainVerboseErrors: &enableVerboseLogging,
+		Region:                        aws.String(region),
+	}
+
+	sess, err := session.NewSessionWithOptions(session.Options{
+		Profile: name,
+		Config:  conf,
+		// Force enable Shared Config support
+		SharedConfigState: session.SharedConfigEnable,
+	})
+
+	if err != nil {
+		slog.Error(err.Error())
+	}
+
+	return cw.New(sess)
+}
+
+// getProfile returns a previously created profile or creates a new one for the given profile name and region
+func (c *cloudWatchContext) getProfile(awsProfileName, region string) cwi.CloudWatchAPI {
+	var fullProfileName string
+
+	if awsProfileName == "default" {
+		fullProfileName = "bosun-default"
+	} else {
+		fullProfileName = fmt.Sprintf("user-%s", awsProfileName)
+	}
+
+	fullProfileName = fmt.Sprintf("%s-%s", fullProfileName, region)
+
+	// We don't want to concurrently modify the c.profiles map
+	c.profilesLock.Lock()
+	defer c.profilesLock.Unlock()
+
+	if cwAPI, ok := c.profiles[fullProfileName]; ok {
+		return cwAPI
+	}
+
+	cwAPI := c.profileProvider.NewProfile(awsProfileName, region)
+	c.profiles[fullProfileName] = cwAPI
+
+	return cwAPI
+}
+
+func (c *cloudWatchContext) GetPagesLimit() int {
+	if c.PagesLimit == 0 {
+		return DefaultPageLimit
+	} else {
+		return c.PagesLimit
+
+	}
+}
+
+func (c *cloudWatchContext) GetExpansionLimit() int {
+	if c.ExpansionLimit == 0 {
+		return DefaultExpansionLimit
+	} else {
+		return c.ExpansionLimit
+
+	}
+}
+
+func (c *cloudWatchContext) GetConcurrency() int {
+	if c.Concurrency == 0 {
+		return DefaultConcurrency
+	} else {
+		return c.Concurrency
+
+	}
+}
+
+func GetContext() Context {
+	return GetContextWithProvider(profileProvider{})
+}
+
+func GetContextWithProvider(p ProfileProvider) Context {
+	once.Do(func() {
+		context = &cloudWatchContext{
+			profileProvider: p,
+			profiles:        make(map[string]cwi.CloudWatchAPI),
+		}
+	})
+	return context
+}
+
+func buildQuery(r *Request, id string, dimensions []Dimension) cw.MetricDataQuery {
+	awsPeriod := r.Period
+	d := make([]*cw.Dimension, 0)
+
+	for _, i := range dimensions {
+		n := i.Name
+		v := i.Value
+		d = append(d, &cw.Dimension{Name: &n, Value: &v})
+	}
+
+	metric := cw.Metric{
+		Dimensions: d,
+		MetricName: &r.Metric,
+		Namespace:  &r.Namespace,
+	}
+	stat := cw.MetricStat{
+		Metric: &metric,
+		Period: &awsPeriod,
+		Stat:   &r.Statistic,
+		Unit:   nil,
+	}
+
+	returndata := true
+	dq := cw.MetricDataQuery{
+		Expression: nil,
+		Id:         &id,
+		Label:      nil,
+		MetricStat: &stat,
+		Period:     nil,
+		ReturnData: &returndata,
+	}
+	return dq
+}
+
+func buildTags(dims []Dimension) opentsdb.TagSet {
+	var tags opentsdb.TagSet
+
+	tags = make(opentsdb.TagSet)
+	for _, d := range dims {
+		tags[d.Name] = d.Value
+	}
+
+	return tags
+}
+
+// Query performs a CloudWatch request to aws.
+func (c cloudWatchContext) Query(r *Request) (Response, error) {
+	var response Response
+	var dqs []*cw.MetricDataQuery
+	var tagSet = make(map[string]opentsdb.TagSet)
+	var id string
+
+	api := c.getProfile(r.Profile, r.Region)
+
+	if r.Period <= 0 {
+		return response, ErrInvalidPeriod
+	}
+	// custom metrics can have no dimensions
+	if len(r.Dimensions) == 0 {
+		id = fmt.Sprintf("q0")
+		dq := buildQuery(r, id, nil)
+		dqs = append(dqs, &dq)
+		tagSet[id] = buildTags(nil)
+	} else {
+		for i, j := range r.Dimensions {
+			id = fmt.Sprintf("q%d", i)
+			dq := buildQuery(r, id, j)
+			dqs = append(dqs, &dq)
+			tagSet[id] = buildTags(j)
+		}
+	}
+
+	q := &cw.GetMetricDataInput{
+		EndTime:           aws.Time(*r.End),
+		MaxDatapoints:     nil,
+		MetricDataQueries: dqs,
+		NextToken:         nil,
+		ScanBy:            nil,
+		StartTime:         aws.Time(*r.Start),
+	}
+
+	resp, err := api.GetMetricData(q)
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		slog.Error(err.Error())
+		return response, err
+	}
+	response.Raw = *resp
+	response.TagSet = tagSet
+	return response, nil
+
+}
+
+func match(d *cw.Dimension, wc Wildcards) bool {
+	if len(*d.Value) == 0 {
+		return false
+	}
+	return glob.Glob(wc[*d.Name], *d.Value)
+}
+
+func filter(metric *cw.Metric, wildcard Wildcards, dimSet DimensionSet) (matches int, dims []Dimension) {
+	matches = 0
+	dl := make([]Dimension, 0)
+
+	for _, dim := range metric.Dimensions {
+		// if the metric contains a dimension that isn't in the list
+		// we searched for we should skip it.
+		if !dimSet[*dim.Name] {
+			return 0, nil
+		}
+
+		if wildcard[*dim.Name] != "" {
+			if !match(dim, wildcard) {
+				return 0, nil
+			}
+			matches++
+		}
+
+		d := Dimension{
+			Name:  *dim.Name,
+			Value: *dim.Value,
+		}
+		dl = append(dl, d)
+	}
+	return matches, dl
+
+}
+
+func filterDimensions(metrics []*cw.Metric, wildcard Wildcards, ds DimensionSet, limit int) ([][]Dimension, error) {
+	dimensions := make([][]Dimension, 0)
+
+	for _, m := range metrics {
+		if len(m.Dimensions) == 0 {
+			continue
+		}
+		matches, dl := filter(m, wildcard, ds)
+		// all wildcard dimensions need to be present for it to count as match
+		if matches < len(wildcard) {
+			continue
+		}
+		dimensions = append(dimensions, dl)
+		if len(dimensions) >= limit {
+			return nil, ErrExpansionLimit
+		}
+	}
+	return dimensions, nil
+}
+
+// Query performs a CloudWatch request to aws.
+func (c cloudWatchContext) LookupDimensions(lr *LookupRequest) ([][]Dimension, error) {
+	api := c.getProfile(lr.Profile, lr.Region)
+	var metrics []*cw.Metric
+	var literal []*cw.DimensionFilter
+	var wildcard = make(Wildcards)
+	var dimensionSet = make(DimensionSet)
+
+	for _, i := range lr.Dimensions {
+		for _, j := range i {
+			dimensionSet[j.Name] = true
+
+			if strings.Contains(j.Value, "*") {
+				wildcard[j.Name] = j.Value
+			} else {
+				name := j.Name
+				value := j.Value
+				literal = append(literal, &cw.DimensionFilter{
+					Name:  &name,
+					Value: &value,
+				})
+			}
+		}
+	}
+
+	mi := cw.ListMetricsInput{
+		Dimensions: literal,
+		MetricName: &lr.Metric,
+		Namespace:  &lr.Namespace,
+		NextToken:  nil,
+	}
+	pages := 0
+	limitHit := false
+	err := api.ListMetricsPages(&mi, func(mo *cw.ListMetricsOutput, lastPage bool) bool {
+		metrics = append(metrics, mo.Metrics...)
+		pages++
+		if pages > c.GetPagesLimit() {
+			limitHit = true
+			return false
+		}
+		return !lastPage
+	})
+
+	if limitHit {
+		return nil, ErrPagingLimit
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return filterDimensions(metrics, wildcard, dimensionSet, c.GetExpansionLimit())
+}

--- a/cloudwatch/cloudwatch.go
+++ b/cloudwatch/cloudwatch.go
@@ -2,18 +2,19 @@
 package cloudwatch // import "bosun.org/cloudwatch"
 
 import (
-	"bosun.org/opentsdb"
-	"bosun.org/slog"
 	"errors"
 	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"bosun.org/opentsdb"
+	"bosun.org/slog"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	cw "github.com/aws/aws-sdk-go/service/cloudwatch"
 	cwi "github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
 	"github.com/ryanuber/go-glob"
-	"strings"
-	"sync"
-	"time"
 )
 
 var (
@@ -255,7 +256,7 @@ func buildTags(dims []Dimension) opentsdb.TagSet {
 }
 
 // Query performs a CloudWatch request to aws.
-func (c cloudWatchContext) Query(r *Request) (Response, error) {
+func (c *cloudWatchContext) Query(r *Request) (Response, error) {
 	var response Response
 	var dqs []*cw.MetricDataQuery
 	var tagSet = make(map[string]opentsdb.TagSet)
@@ -359,7 +360,7 @@ func filterDimensions(metrics []*cw.Metric, wildcard Wildcards, ds DimensionSet,
 }
 
 // Query performs a CloudWatch request to aws.
-func (c cloudWatchContext) LookupDimensions(lr *LookupRequest) ([][]Dimension, error) {
+func (c *cloudWatchContext) LookupDimensions(lr *LookupRequest) ([][]Dimension, error) {
 	api := c.getProfile(lr.Profile, lr.Region)
 	var metrics []*cw.Metric
 	var literal []*cw.DimensionFilter

--- a/cloudwatch/cloudwatch_test.go
+++ b/cloudwatch/cloudwatch_test.go
@@ -116,7 +116,7 @@ func (c mockCloudWatchClient) ListMetricsPages(li *cloudwatch.ListMetricsInput, 
 		// level and node level values. The below adds a cluster only metric to test this case
 		cn := "Cluster Name"
 		cv := name
-		dimensions := []*cloudwatch.Dimension{&cloudwatch.Dimension{
+		dimensions := []*cloudwatch.Dimension{{
 			Name:  &cn,
 			Value: &cv,
 		}}

--- a/cloudwatch/cloudwatch_test.go
+++ b/cloudwatch/cloudwatch_test.go
@@ -2,13 +2,14 @@ package cloudwatch
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/cloudwatch"
-	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
 )
 
 const namespace = "AWS/Kafka"

--- a/cloudwatch/cloudwatch_test.go
+++ b/cloudwatch/cloudwatch_test.go
@@ -1,0 +1,692 @@
+package cloudwatch
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+const namespace = "AWS/Kafka"
+const metric = "CpuSystem"
+const region = "eu-west-1"
+const profile = "default"
+const largeCluster = 95
+const smallCluster = 15
+const expansionLimit = 100
+const pagesLimit = 10
+
+// Singleton in real function prevents injection of appropriate mocks
+func MockGetContextWithProvider(p ProfileProvider) Context {
+	context = &cloudWatchContext{
+		profileProvider: p,
+		profiles:        make(map[string]cloudwatchiface.CloudWatchAPI),
+		ExpansionLimit:  expansionLimit,
+		PagesLimit:      pagesLimit,
+	}
+	return context
+}
+
+type slowProfileProvider struct {
+	callCount int
+}
+
+func (s *slowProfileProvider) NewProfile(name, region string) cloudwatchiface.CloudWatchAPI {
+	s.callCount += 1
+	time.Sleep(3 * time.Second)
+	return &cloudwatch.CloudWatch{}
+}
+
+func TestGetProfilOnlyCalledOnce(t *testing.T) {
+	wg := sync.WaitGroup{}
+	provider := &slowProfileProvider{}
+
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx, _ := GetContextWithProvider(provider).(*cloudWatchContext)
+			ctx.getProfile("fake-profile", "fake-region")
+		}()
+	}
+
+	wg.Wait()
+
+	if provider.callCount != 1 {
+		t.Errorf("Expected one call to NewProfile, got %d", provider.callCount)
+	}
+}
+
+type mockProfileProvider struct {
+}
+
+type mockCloudWatchClient struct {
+	cloudwatchiface.CloudWatchAPI
+}
+
+func (m *mockProfileProvider) NewProfile(name, region string) cloudwatchiface.CloudWatchAPI {
+	return &mockCloudWatchClient{}
+}
+
+func (c mockCloudWatchClient) ListMetricsPages(li *cloudwatch.ListMetricsInput, callback func(*cloudwatch.ListMetricsOutput, bool) bool) error {
+	var metrics []*cloudwatch.Metric
+	var n = metric
+	var ns = namespace
+
+	clusters := make(map[string]int)
+	if li.Dimensions == nil || (li.Dimensions != nil && *li.Dimensions[0].Value == "big") {
+		clusters["big"] = largeCluster
+	}
+
+	if li.Dimensions == nil || (li.Dimensions != nil && *li.Dimensions[0].Value == "small") {
+		clusters["small"] = smallCluster
+	}
+
+	for name, size := range clusters {
+		for i := 0; i < size; i++ {
+			dn := "Broker ID"
+			dv := strconv.Itoa(i)
+			dim := cloudwatch.Dimension{
+				Name:  &dn,
+				Value: &dv,
+			}
+			dimensions := []*cloudwatch.Dimension{&dim}
+
+			cn := "Cluster Name"
+			cv := name
+			cdim := cloudwatch.Dimension{
+				Name:  &cn,
+				Value: &cv,
+			}
+			dimensions = append(dimensions, &cdim)
+			metric := cloudwatch.Metric{
+				Dimensions: dimensions,
+				MetricName: &n,
+				Namespace:  &ns,
+			}
+			metrics = append(metrics, &metric)
+		}
+
+		// Some aws metrics are logged with varying number of dimensions, to differentiate between cluster
+		// level and node level values. The below adds a cluster only metric to test this case
+		cn := "Cluster Name"
+		cv := name
+		dimensions := []*cloudwatch.Dimension{&cloudwatch.Dimension{
+			Name:  &cn,
+			Value: &cv,
+		}}
+		metric := cloudwatch.Metric{
+			Dimensions: dimensions,
+			MetricName: &n,
+			Namespace:  &ns,
+		}
+		metrics = append(metrics, &metric)
+	}
+
+	lmo := &cloudwatch.ListMetricsOutput{
+		Metrics:   metrics,
+		NextToken: nil,
+	}
+	callback(lmo, true)
+	return nil
+}
+
+func (c mockCloudWatchClient) GetMetricData(input *cloudwatch.GetMetricDataInput) (*cloudwatch.GetMetricDataOutput, error) {
+	var mdr []*cloudwatch.MetricDataResult
+	cwo := &cloudwatch.GetMetricDataOutput{
+		Messages:          nil,
+		MetricDataResults: mdr,
+		NextToken:         nil,
+	}
+
+	if len(input.MetricDataQueries) == 0 {
+		return cwo, nil
+	}
+
+	for i := 0; i < 10; i++ {
+		id := fmt.Sprintf("q{i}")
+		m := cloudwatch.MetricDataResult{
+			Id:         &id,
+			Label:      nil,
+			Messages:   nil,
+			StatusCode: nil,
+			Timestamps: nil,
+			Values:     nil,
+		}
+
+		mdr = append(mdr, &m)
+	}
+
+	cwo.MetricDataResults = mdr
+	return cwo, nil
+}
+
+// Mocks to simulate being rate limited and test error handling
+
+type rateLimitedProfileProvider struct {
+}
+type mockCloudWatchRateLimitedClient struct {
+	cloudwatchiface.CloudWatchAPI
+}
+
+func (m *rateLimitedProfileProvider) NewProfile(name, region string) cloudwatchiface.CloudWatchAPI {
+	return &mockCloudWatchRateLimitedClient{}
+}
+
+func (m *mockCloudWatchRateLimitedClient) GetMetricData(input *cloudwatch.GetMetricDataInput) (*cloudwatch.GetMetricDataOutput, error) {
+	e := fmt.Errorf("Rate Limit exceeded")
+	ae := awserr.New("429", "Rate Limited Exceeded", e)
+	return nil, awserr.NewRequestFailure(ae, 429, "a5442de54s5454")
+}
+
+func (c mockCloudWatchRateLimitedClient) ListMetricsPages(li *cloudwatch.ListMetricsInput, callback func(*cloudwatch.ListMetricsOutput, bool) bool) error {
+	e := fmt.Errorf("Rate Limit exceeded")
+	ae := awserr.New("429", "Rate Limited Exceeded", e)
+	return awserr.NewRequestFailure(ae, 429, "a5442de54s5454")
+}
+
+// -----
+
+// Mocks for checking paging behaviour
+
+type pagingProfileProvider struct {
+}
+type mockCloudWatchPagingClient struct {
+	cloudwatchiface.CloudWatchAPI
+}
+
+func (m *pagingProfileProvider) NewProfile(name, region string) cloudwatchiface.CloudWatchAPI {
+	return &mockCloudWatchPagingClient{}
+}
+
+func (c mockCloudWatchPagingClient) ListMetricsPages(li *cloudwatch.ListMetricsInput, callback func(*cloudwatch.ListMetricsOutput, bool) bool) error {
+	var metrics []*cloudwatch.Metric
+	lmo := &cloudwatch.ListMetricsOutput{
+		Metrics:   metrics,
+		NextToken: nil,
+	}
+	p := 0
+	for callback(lmo, p == pagesLimit) {
+		p++
+	}
+	return nil
+}
+
+// ----------------------------
+
+func TestLookupDimensions(t *testing.T) {
+	c := MockGetContextWithProvider(&mockProfileProvider{})
+
+	lr := LookupRequest{
+		Region:     region,
+		Namespace:  namespace,
+		Metric:     metric,
+		Dimensions: nil,
+		Profile:    profile,
+	}
+
+	var tests = []struct {
+		dims  [][]Dimension
+		count int
+		e     error
+	}{
+		{[][]Dimension{{
+			Dimension{
+				Name:  "Broker ID",
+				Value: "*",
+			}, Dimension{
+				Name:  "Cluster Name",
+				Value: "*",
+			},
+		}}, 0, ErrExpansionLimit},
+		{[][]Dimension{{
+			Dimension{
+				Name:  "Broker ID",
+				Value: "*",
+			}, Dimension{
+				Name:  "Cluster Name",
+				Value: "big",
+			},
+		}}, largeCluster, nil},
+		{[][]Dimension{{
+			Dimension{
+				Name:  "Broker ID",
+				Value: "*",
+			}, Dimension{
+				Name:  "Cluster Name",
+				Value: "small",
+			},
+		}}, smallCluster, nil},
+		{[][]Dimension{{
+			Dimension{
+				Name:  "Irrelevant Dimension",
+				Value: "1234",
+			}, Dimension{
+				Name:  "Cluster Name",
+				Value: "small",
+			},
+		}}, 0, nil},
+	}
+	for _, test := range tests {
+		lr.Dimensions = test.dims
+		res, err := c.LookupDimensions(&lr)
+
+		if err != test.e {
+			t.Error(err)
+		}
+		if len(res) != test.count {
+			t.Errorf("Did not get expected count, wanted %d got %d", test.count, len(res))
+		}
+	}
+
+}
+
+func TestLookupPageLimit(t *testing.T) {
+	c := MockGetContextWithProvider(&pagingProfileProvider{})
+
+	lr := LookupRequest{
+		Region:     region,
+		Namespace:  namespace,
+		Metric:     metric,
+		Dimensions: nil,
+		Profile:    profile,
+	}
+
+	_, err := c.LookupDimensions(&lr)
+	if err != ErrPagingLimit {
+		t.Error("Should have failed from hitting expansion limit")
+	}
+}
+
+func TestLookupDimensionsError(t *testing.T) {
+	c := MockGetContextWithProvider(&rateLimitedProfileProvider{})
+	dims := [][]Dimension{{
+		Dimension{
+			Name:  "Broker ID",
+			Value: "*",
+		}, Dimension{
+			Name:  "Cluster Name",
+			Value: "*",
+		}}}
+
+	lr := LookupRequest{
+		Region:     region,
+		Namespace:  namespace,
+		Metric:     metric,
+		Dimensions: dims,
+		Profile:    profile,
+	}
+	_, err := c.LookupDimensions(&lr)
+	if err == nil {
+		t.Error("Error did not bubble up correctly")
+	}
+}
+
+func TestQuery(t *testing.T) {
+	c := MockGetContextWithProvider(&mockProfileProvider{})
+	start := time.Date(2018, time.January, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2018, time.January, 1, 1, 0, 0, 0, time.UTC)
+
+	dims := [][]Dimension{{
+		Dimension{
+			Name:  "Broker ID",
+			Value: "*",
+		}, Dimension{
+			Name:  "Cluster Name",
+			Value: "grappler-msk-A",
+		}}}
+
+	tests := []struct {
+		r    Request
+		err  error
+		size int
+	}{
+		{
+			r: Request{
+				Start:      &start,
+				End:        &end,
+				Region:     region,
+				Namespace:  namespace,
+				Metric:     metric,
+				Period:     60,
+				Statistic:  "Sum",
+				Dimensions: dims,
+				Profile:    profile,
+			},
+			err:  nil,
+			size: 10,
+		},
+		{
+			r: Request{
+				Start:      &start,
+				End:        &end,
+				Region:     region,
+				Namespace:  namespace,
+				Metric:     metric,
+				Period:     60,
+				Statistic:  "Sum",
+				Dimensions: nil,
+				Profile:    profile,
+			},
+			err:  nil,
+			size: 10,
+		},
+		{
+			r: Request{
+				Start:      &start,
+				End:        &end,
+				Region:     region,
+				Namespace:  namespace,
+				Metric:     metric,
+				Period:     0,
+				Statistic:  "Sum",
+				Dimensions: nil,
+				Profile:    profile,
+			},
+			err:  ErrInvalidPeriod,
+			size: 0,
+		},
+	}
+	for _, test := range tests {
+		res, err := c.Query(&test.r)
+		if err != test.err {
+			t.Errorf("Query failed, expect error to be %v, got %v", test.err, err)
+		}
+		if len(res.Raw.MetricDataResults) != test.size {
+			t.Errorf("Query returned wrong number of results, expected %d, got %d", test.size, len(res.Raw.MetricDataResults))
+		}
+	}
+
+}
+
+func TestQueryError(t *testing.T) {
+	c := MockGetContextWithProvider(&rateLimitedProfileProvider{})
+	start := time.Date(2018, time.January, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2018, time.January, 1, 1, 0, 0, 0, time.UTC)
+
+	dims := [][]Dimension{{
+		Dimension{
+			Name:  "Broker ID",
+			Value: "*",
+		}, Dimension{
+			Name:  "Cluster Name",
+			Value: "grappler-msk-A",
+		}}}
+
+	r := Request{
+		Start:      &start,
+		End:        &end,
+		Region:     region,
+		Namespace:  namespace,
+		Metric:     metric,
+		Period:     60,
+		Statistic:  "Sum",
+		Dimensions: dims,
+		Profile:    profile,
+	}
+	_, err := c.Query(&r)
+	if err == nil {
+		t.Error("Error did not bubble properly", err)
+	}
+
+}
+
+func TestFilterDimensions(t *testing.T) {
+
+	metric := "FreeableMemory"
+	namespace := "AWS/ElastiCache"
+
+	d1 := "CacheClusterId"
+	v1 := "grappler-cluster-1"
+
+	d2 := "CacheNodeId"
+	v2 := "0001"
+
+	v3 := "not-cluster-1"
+
+	wildcards := make(Wildcards)
+	wildcards[d1] = "grappler-cluster-1"
+	wildcards[d2] = "0*"
+
+	// set dimensions that are present in the query and we expect to be in results set
+	ds := make(DimensionSet)
+	ds[d1] = true
+	ds[d2] = true
+
+	// example of elasticache node level metric
+	metric1 := cloudwatch.Metric{
+		Dimensions: []*cloudwatch.Dimension{
+			{
+				Name:  &d1,
+				Value: &v1,
+			},
+			{
+				Name:  &d2,
+				Value: &v2,
+			},
+		},
+		MetricName: &metric,
+		Namespace:  &namespace,
+	}
+
+	// cluster level metric
+	metric2 := cloudwatch.Metric{
+
+		Dimensions: []*cloudwatch.Dimension{
+			{
+				Name:  &d1,
+				Value: &v1,
+			}},
+		MetricName: &metric,
+		Namespace:  &namespace,
+	}
+
+	// account level metric
+	metric3 := cloudwatch.Metric{
+
+		Dimensions: nil,
+		MetricName: &metric,
+		Namespace:  &namespace,
+	}
+
+	// different cluster than the one we're searching for
+	metric4 := cloudwatch.Metric{
+		Dimensions: []*cloudwatch.Dimension{
+			{
+				Name:  &d1,
+				Value: &v3,
+			},
+			{
+				Name:  &d2,
+				Value: &v2,
+			},
+		},
+		MetricName: &metric,
+		Namespace:  &namespace,
+	}
+
+	metrics := []*cloudwatch.Metric{&metric1, &metric2, &metric3, &metric4}
+
+	m, err := filterDimensions(metrics, wildcards, ds, expansionLimit)
+	if err != nil {
+		t.Error(err)
+	}
+	// only  the node level metric should match the filter criteria
+	if len(m) != 1 || m[0][0].Value != v1 || m[0][1].Value != v2 {
+		t.Error("Filter didn't select correct metric")
+	}
+
+}
+
+func TestCacheKeyMatch(t *testing.T) {
+	start := time.Date(2018, 7, 4, 17, 0, 0, 0, time.UTC)
+	end := time.Date(2018, 7, 4, 18, 0, 0, 0, time.UTC)
+	var tests = []struct {
+		req Request
+		key string
+	}{
+		{req: Request{
+			Start:     &start,
+			End:       &end,
+			Region:    "eu-west-1",
+			Namespace: "AWS/EC2",
+			Metric:    "CPUUtilization",
+			Period:    60, Statistic: "Sum",
+			DimensionString: "InstanceId:i-0106b4d25c54baac7",
+			Profile:         "prod",
+		},
+			key: "cloudwatch-1530723600-1530727200-eu-west-1-AWS/EC2-CPUUtilization-60-Sum-InstanceId:i-0106b4d25c54baac7-prod"},
+	}
+
+	for _, u := range tests {
+		calculatedKey := u.req.CacheKey()
+		if u.key != calculatedKey {
+			t.Errorf("Cache key doesn't match, expected '%s' got '%s' ", u.key, calculatedKey)
+		}
+	}
+
+}
+
+func TestCacheKeyMisMatch(t *testing.T) {
+
+	start := time.Date(2018, 7, 4, 17, 0, 0, 0, time.UTC)
+	end := time.Date(2018, 7, 4, 18, 0, 0, 0, time.UTC)
+	exampleRequest := Request{
+		Start:           &start,
+		End:             &end,
+		Region:          "eu-west-1",
+		Namespace:       "AWS/EC2",
+		Metric:          "CPUUtilization",
+		Period:          60,
+		Statistic:       "Sum",
+		DimensionString: "InstanceId:i-0106b4d25c54baac7",
+		Profile:         "prod",
+	}
+
+	exampleKey := exampleRequest.CacheKey()
+
+	variantStart := time.Date(2018, 7, 4, 17, 30, 0, 0, time.UTC)
+	variantEnd := time.Date(2018, 7, 4, 18, 30, 0, 0, time.UTC)
+	var tests = []Request{
+		{
+			Start:           &start,
+			End:             &end,
+			Region:          "eu-west-1",
+			Namespace:       "AWS/EC2",
+			Metric:          "CPUUtilization",
+			Period:          60,
+			Statistic:       "Sum",
+			DimensionString: "InstanceId:i-0106b4d25*",
+			Profile:         "prod",
+		},
+		{
+			Start:           &variantStart,
+			End:             &end,
+			Region:          "eu-west-1",
+			Namespace:       "AWS/EC2",
+			Metric:          "CPUUtilization",
+			Period:          60,
+			Statistic:       "Sum",
+			DimensionString: "InstanceId:i-0106b4d25c54baac7",
+			Profile:         "prod",
+		},
+		{
+			Start:           &start,
+			End:             &variantEnd,
+			Region:          "eu-west-1",
+			Namespace:       "AWS/EC2",
+			Metric:          "CPUUtilization",
+			Period:          60,
+			Statistic:       "Sum",
+			DimensionString: "InstanceId:i-0106b4d25c54baac7",
+			Profile:         "prod",
+		},
+		{
+			Start:           &start,
+			End:             &end,
+			Region:          "eu-central-1",
+			Namespace:       "AWS/EC2",
+			Metric:          "CPUUtilization",
+			Period:          60,
+			Statistic:       "Sum",
+			DimensionString: "InstanceId:i-0106b4d25c54baac7",
+			Profile:         "prod",
+		},
+		{
+			Start:           &start,
+			End:             &end,
+			Region:          "eu-west-1",
+			Namespace:       "AWS/ECS",
+			Metric:          "CPUUtilization",
+			Period:          60,
+			Statistic:       "Sum",
+			DimensionString: "InstanceId:i-0106b4d25c54baac7",
+			Profile:         "prod",
+		},
+		{
+			Start:           &start,
+			End:             &end,
+			Region:          "eu-west-1",
+			Namespace:       "AWS/EC2",
+			Metric:          "MemoryUsage",
+			Period:          60,
+			Statistic:       "Sum",
+			DimensionString: "InstanceId:i-0106b4d25c54baac7",
+			Profile:         "prod",
+		},
+		{
+			Start:           &start,
+			End:             &end,
+			Region:          "eu-west-1",
+			Namespace:       "AWS/EC2",
+			Metric:          "CPUUtilization",
+			Period:          300,
+			Statistic:       "Sum",
+			DimensionString: "InstanceId:i-0106b4d25c54baac7",
+			Profile:         "prod",
+		},
+		{
+			Start:           &start,
+			End:             &end,
+			Region:          "eu-west-1",
+			Namespace:       "AWS/EC2",
+			Metric:          "CPUUtilization",
+			Period:          60,
+			Statistic:       "Avg",
+			DimensionString: "InstanceId:i-0106b4d25c54baac7",
+			Profile:         "prod",
+		},
+		{
+			Start:           &start,
+			End:             &end,
+			Region:          "eu-west-1",
+			Namespace:       "AWS/EC2",
+			Metric:          "CPUUtilization",
+			Period:          300,
+			Statistic:       "Sum",
+			DimensionString: "InstanceId:i-01064646d6d6baac7",
+			Profile:         "prod",
+		},
+		{
+			Start:           &start,
+			End:             &end,
+			Region:          "eu-west-1",
+			Namespace:       "AWS/EC2",
+			Metric:          "CPUUtilization",
+			Period:          60,
+			Statistic:       "Sum",
+			DimensionString: "InstanceId:i-0106b4d25c54baac7",
+			Profile:         "sandbox",
+		},
+	}
+	for _, u := range tests {
+		calculatedKey := u.CacheKey()
+		if exampleKey == calculatedKey {
+			t.Errorf("Calculated key shouldn't match example but does. '%s' == '%s' ", calculatedKey, exampleKey)
+		}
+	}
+}

--- a/cmd/bosun/bosun.example.toml
+++ b/cmd/bosun/bosun.example.toml
@@ -123,6 +123,15 @@ ExampleExpression = 'avg(q("avg:rate:os.cpu{host=*bosun*}", "5m", "")) > 80'
 	Timeout = "5m"
 	UnsafeSSL = true
 
+# Configuration to enable the CloudWatch backend
+[CloudWatchConf]
+       Enabled = true
+       PagesLimit = 10
+       ExpansionLimit = 500
+       Concurrency = 2
+
 [PromConf]
 	[PromConf.default]
 		URL = "http://127.0.0.1:9090"
+
+

--- a/cmd/bosun/conf/conf.go
+++ b/cmd/bosun/conf/conf.go
@@ -12,8 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/influxdata/influxdb/client/v2"
-
+	"bosun.org/cloudwatch"
 	"bosun.org/cmd/bosun/conf/template"
 	"bosun.org/cmd/bosun/expr"
 	"bosun.org/cmd/bosun/expr/parse"
@@ -21,6 +20,7 @@ import (
 	"bosun.org/models"
 	"bosun.org/opentsdb"
 	"bosun.org/slog"
+	"github.com/influxdata/influxdb/client/v2"
 )
 
 // SystemConfProvider providers all the information about the system configuration.
@@ -82,6 +82,7 @@ type SystemConfProvider interface {
 	GetInfluxContext() client.HTTPConfig
 	GetElasticContext() expr.ElasticHosts
 	GetAzureMonitorContext() expr.AzureMonitorClients
+	GetCloudWatchContext() cloudwatch.Context
 	GetPromContext() expr.PromClients
 	AnnotateEnabled() bool
 

--- a/cmd/bosun/conf/rule/rule.go
+++ b/cmd/bosun/conf/rule/rule.go
@@ -683,6 +683,9 @@ func (c *Conf) GetFuncs(backends conf.EnabledBackends) map[string]eparse.Func {
 	if backends.Prom {
 		merge(expr.Prom)
 	}
+	if backends.CloudWatch {
+		merge(expr.CloudWatch)
+	}
 	return funcs
 }
 

--- a/cmd/bosun/conf/system_test.go
+++ b/cmd/bosun/conf/system_test.go
@@ -63,4 +63,11 @@ func TestSystemToml(t *testing.T) {
 		Timeout:   Duration{time.Minute * 5},
 		UnsafeSSL: true,
 	})
+	assert.Equal(t, sc.CloudWatchConf, CloudWatchConf{
+		Enabled:        true,
+		PagesLimit:     10,
+		ExpansionLimit: 500,
+		Concurrency:    2,
+	}, "CloudwatchConf does not match")
+
 }

--- a/cmd/bosun/expr/cloudwatch.go
+++ b/cmd/bosun/expr/cloudwatch.go
@@ -1,0 +1,270 @@
+package expr
+
+import (
+	"bosun.org/cloudwatch"
+	"bosun.org/cmd/bosun/expr/parse"
+	"bosun.org/models"
+	"bosun.org/opentsdb"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+// cloudwatch defines functions for use with amazon cloudwatch api
+var CloudWatch = map[string]parse.Func{
+
+	"cw": {
+		Args: []models.FuncType{models.TypeString, models.TypeString, models.TypeString, models.TypeString,
+			models.TypeString, models.TypeString, models.TypeString, models.TypeString},
+		Return:        models.TypeSeriesSet,
+		Tags:          cloudwatchTagQuery,
+		F:             CloudWatchQuery,
+		PrefixEnabled: true,
+	},
+}
+
+var PeriodParseError = errors.New("Could not parse the period value")
+var StartParseError = errors.New("Could not parse the start value")
+var EndParseError = errors.New("Could not parse the end value")
+
+var isNumber = regexp.MustCompile("^\\d+$")
+
+func parseCloudWatchResponse(req *cloudwatch.Request, s *cloudwatch.Response, multiRegion bool) ([]*Result, error) {
+	const parseErrFmt = "cloudwatch ParseError (%s): %s"
+	var dps Series
+	if s == nil {
+		return nil, fmt.Errorf(parseErrFmt, req.Metric, "empty response")
+	}
+	results := make([]*Result, 0)
+
+	for _, result := range s.Raw.MetricDataResults {
+		if len(result.Timestamps) == 0 {
+			continue
+		}
+		tags := make(opentsdb.TagSet)
+		for k, v := range s.TagSet[*result.Id] {
+			tags[k] = v
+		}
+		dps = make(Series)
+		for x, t := range result.Timestamps {
+			dps[*t] = *result.Values[x]
+		}
+
+		r := Result{
+			Value: dps,
+			Group: tags,
+		}
+
+		if multiRegion {
+			r.Group["bosun-region"] = req.Region
+		}
+
+		results = append(results, &r)
+	}
+
+	return results, nil
+}
+
+func hasWildcardDimension(dimensions string) bool {
+	return strings.Contains(dimensions, "*")
+}
+
+func parseDimensions(dimensions string) [][]cloudwatch.Dimension {
+	dl := make([][]cloudwatch.Dimension, 0)
+	if len(strings.TrimSpace(dimensions)) == 0 {
+		return dl
+	}
+	dims := strings.Split(dimensions, ",")
+
+	l := make([]cloudwatch.Dimension, 0)
+	for _, row := range dims {
+		dim := strings.Split(row, ":")
+		l = append(l, cloudwatch.Dimension{Name: dim[0], Value: dim[1]})
+	}
+	dl = append(dl, l)
+
+	return dl
+}
+
+func parseDurations(s, e, p string) (start, end, period opentsdb.Duration, err error) {
+
+	start, err = opentsdb.ParseDuration(s)
+	if err != nil {
+		return start, end, period, StartParseError
+	}
+	end = opentsdb.Duration(0)
+	if e != "" {
+		end, err = opentsdb.ParseDuration(e)
+		if err != nil {
+			return start, end, period, EndParseError
+		}
+	}
+
+	// to maintain backwards compatibility assume that period without time unit is seconds
+	if isNumber.MatchString(p) {
+		p += "s"
+	}
+	period, err = opentsdb.ParseDuration(p)
+	if err != nil {
+		return start, end, period, PeriodParseError
+	}
+	return
+}
+
+func CloudWatchQuery(prefix string, e *State, region, namespace, metric, period, statistic, dimensions, sduration, eduration string) (*Results, error) {
+
+	r := new(Results)
+
+	regions := strings.Split(region, ",")
+	if len(regions) == 0 {
+		return r, nil
+	}
+
+	var wg sync.WaitGroup
+	queryResults := []*Results{}
+
+	// reqCh (Request Channel) is populated with cloudwatch requests for each region
+	reqCh := make(chan cloudwatch.Request, len(regions))
+	// resCh (Result Channel) contains the timeseries responses for requests for region
+	resCh := make(chan *Results, len(regions))
+	// errCh (Error Channel) contains any request errors
+	errCh := make(chan error, len(regions))
+
+	// a worker makes a getMetricData request for a region
+	worker := func() {
+		for req := range reqCh {
+			res := []*Result{}
+			data, err := getCloudwatchData(e, &req)
+			if err == nil {
+				res, err = parseCloudWatchResponse(&req, &data, len(regions) > 1)
+				resCh <- &Results{Results: res,}
+			}
+			errCh <- err
+		}
+		defer wg.Done()
+	}
+
+	// Create N workers to parallelize multiple requests at once since each region requires an HTTP request
+	for i := 0; i < e.CloudWatchContext.GetConcurrency(); i++ {
+		wg.Add(1)
+		go worker()
+	}
+
+	sd, ed, p, err := parseDurations(sduration, eduration, period)
+	if err != nil {
+		return r, err
+	}
+
+	timingString := fmt.Sprintf(`querying %d regions for metric:"%v"`, len(regions), metric)
+	e.Timer.StepCustomTiming("cloudwatch", "query", timingString, func() {
+		// Feed region queries into the request channel which the workers will consume
+
+		for _, r := range regions {
+
+			// The times are rounded to a whole period. This improves
+			// both the caching of the query results as well as the query performance for
+			// the reasons outlined in the aws sdk docs here
+			// https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricData.html
+
+			// round down start time
+			st := e.now.Add(-time.Duration(sd)).Truncate(time.Duration(p))
+			// round up end time
+			et := e.now.Add(-time.Duration(ed)).Truncate(time.Duration(p)).Add(time.Duration(p))
+
+			req := cloudwatch.Request{
+				Start:           &st,
+				End:             &et,
+				Region:          r,
+				Namespace:       namespace,
+				Metric:          metric,
+				Period:          int64(p.Seconds()),
+				Statistic:       statistic,
+				DimensionString: dimensions,
+				Profile:         prefix,
+			}
+			reqCh <- req
+		}
+		close(reqCh)
+		wg.Wait() // Wait for all the workers to finish
+	})
+	close(resCh)
+	close(errCh)
+
+	// Gather errors from the request and return an error if any of the requests failled
+	errs := []string{}
+	for err := range errCh {
+		if err == nil {
+			continue
+		}
+		errs = append(errs, err.Error())
+	}
+	if len(errs) > 0 {
+		return r, fmt.Errorf(strings.Join(errs, " :: "))
+	}
+	// Gather all the query results
+	for res := range resCh {
+		queryResults = append(queryResults, res)
+	}
+	if len(queryResults) == 1 { // no need to merge if there is only one item
+		return queryResults[0], nil
+	}
+	// Merge the query results into a single seriesSet
+	r, err = Merge(e, queryResults...)
+	return r, err
+
+}
+
+func getCloudwatchData(e *State, req *cloudwatch.Request) (resp cloudwatch.Response, err error) {
+	e.cloudwatchQueries = append(e.cloudwatchQueries, *req)
+
+	key := req.CacheKey()
+	getFn := func() (interface{}, error) {
+
+		d := parseDimensions(req.DimensionString)
+
+		if hasWildcardDimension(req.DimensionString) {
+			lr := cloudwatch.LookupRequest{
+				Region:     req.Region,
+				Namespace:  req.Namespace,
+				Metric:     req.Metric,
+				Dimensions: d,
+				Profile:    req.Profile,
+			}
+			d, err = e.CloudWatchContext.LookupDimensions(&lr)
+			if err != nil {
+				return resp, err
+			}
+			if len(d) == 0 {
+				return resp, fmt.Errorf("Wildcard dimension did not match any cloudwatch metrics in region %s", req.Region)
+			}
+		}
+		req.Dimensions = d
+		return e.CloudWatchContext.Query(req)
+	}
+
+	var val interface{}
+	var hit bool
+	val, err, hit = e.Cache.Get(key, getFn)
+
+	collectCacheHit(e.Cache, "cloudwatch", hit)
+	resp = val.(cloudwatch.Response)
+
+	return
+}
+
+func cloudwatchTagQuery(args []parse.Node) (parse.Tags, error) {
+	t := make(parse.Tags)
+	n := args[5].(*parse.StringNode)
+	for _, s := range strings.Split(n.Text, ",") {
+		if s != "" {
+			g := strings.Split(s, ":")
+			if g[0] != "" {
+				t[g[0]] = struct{}{}
+			}
+		}
+	}
+	return t, nil
+}

--- a/cmd/bosun/expr/cloudwatch.go
+++ b/cmd/bosun/expr/cloudwatch.go
@@ -1,16 +1,17 @@
 package expr
 
 import (
-	"bosun.org/cloudwatch"
-	"bosun.org/cmd/bosun/expr/parse"
-	"bosun.org/models"
-	"bosun.org/opentsdb"
 	"errors"
 	"fmt"
 	"regexp"
 	"strings"
 	"sync"
 	"time"
+
+	"bosun.org/cloudwatch"
+	"bosun.org/cmd/bosun/expr/parse"
+	"bosun.org/models"
+	"bosun.org/opentsdb"
 )
 
 // cloudwatch defines functions for use with amazon cloudwatch api
@@ -140,7 +141,7 @@ func CloudWatchQuery(prefix string, e *State, region, namespace, metric, period,
 			data, err := getCloudwatchData(e, &req)
 			if err == nil {
 				res, err = parseCloudWatchResponse(&req, &data, len(regions) > 1)
-				resCh <- &Results{Results: res,}
+				resCh <- &Results{Results: res}
 			}
 			errCh <- err
 		}

--- a/cmd/bosun/expr/cloudwatch_test.go
+++ b/cmd/bosun/expr/cloudwatch_test.go
@@ -1,0 +1,267 @@
+package expr
+
+import (
+	"testing"
+	"time"
+
+	"bosun.org/cloudwatch"
+	"bosun.org/cmd/bosun/expr/parse"
+	"bosun.org/opentsdb"
+	"github.com/MiniProfiler/go/miniprofiler"
+	cw "github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
+)
+
+type mockCloudWatchClient struct {
+	cloudwatchiface.CloudWatchAPI
+}
+
+type mockProfileProvider struct{}
+
+func (m *mockProfileProvider) NewProfile(name, region string) cloudwatchiface.CloudWatchAPI {
+	return &mockCloudWatchClient{}
+}
+
+const metric = "CPUUtilzation"
+const namespace = "AWS/EC2"
+
+func (c mockCloudWatchClient) ListMetricsPages(li *cw.ListMetricsInput, callback func(*cw.ListMetricsOutput, bool) bool) error {
+	var metrics []*cw.Metric
+	var n = metric
+	var ns = namespace
+
+	var instances []string
+	if li.Dimensions == nil || (li.Dimensions != nil && *li.Dimensions[0].Value == "0106b4d25c54baac7") {
+		instances = append(instances, "0106b4d25c54baac7")
+	}
+
+	if li.Dimensions == nil {
+		instances = append(instances, "5306b4d25c546577l")
+		instances = append(instances, "910asdasd25c5477l")
+	}
+
+	for _, inst := range instances {
+		dn := "InstanceId"
+		dv := inst
+		dim := cw.Dimension{
+			Name:  &dn,
+			Value: &dv,
+		}
+		dimensions := []*cw.Dimension{&dim}
+		metric := cw.Metric{
+			Dimensions: dimensions,
+			MetricName: &n,
+			Namespace:  &ns,
+		}
+		metrics = append(metrics, &metric)
+	}
+
+	lmo := &cw.ListMetricsOutput{
+		Metrics:   metrics,
+		NextToken: nil,
+	}
+
+	callback(lmo, false)
+	return nil
+}
+
+func (m *mockCloudWatchClient) GetMetricData(cwi *cw.GetMetricDataInput) (*cw.GetMetricDataOutput, error) {
+	var mdr []*cw.MetricDataResult
+	var r cw.MetricDataResult
+	var timestamps []*time.Time
+	var values []*float64
+
+	for _, mdq := range cwi.MetricDataQueries {
+		for j := 0; j < 600; j = j + int(*mdq.MetricStat.Period) {
+			time := cwi.StartTime.Add(time.Second * time.Duration(j))
+			timestamps = append(timestamps, &time)
+			val := float64(j)
+			values = append(values, &val)
+		}
+		r = cw.MetricDataResult{
+			Id:         mdq.Id,
+			Label:      nil,
+			Messages:   nil,
+			StatusCode: nil,
+			Timestamps: timestamps,
+			Values:     values,
+		}
+		mdr = append(mdr, &r)
+	}
+
+	o := cw.GetMetricDataOutput{
+		Messages:          nil,
+		MetricDataResults: mdr,
+		NextToken:         nil,
+	}
+	return &o, nil
+}
+
+func TestCloudWatchQuery(t *testing.T) {
+	c := cloudwatch.GetContextWithProvider(&mockProfileProvider{})
+
+	e := State{
+		now: time.Date(2018, time.January, 1, 0, 0, 0, 0, time.UTC),
+		Backends: &Backends{
+			CloudWatchContext: c,
+		},
+		BosunProviders: &BosunProviders{
+			Squelched: func(tags opentsdb.TagSet) bool {
+				return false
+			},
+		},
+		Timer: new(miniprofiler.Profile),
+	}
+
+	var tests = []struct {
+		region     string
+		namespace  string
+		metric     string
+		period     string
+		statistics string
+		dimensions string
+		start      string
+		end        string
+		expected   string
+	}{
+		{"eu-west-1", "AWS/EC2", "CPUUtilization", "60s", "Sum", "InstanceId:i-0106b4d25c54baac7", "2h", "1h", "{InstanceId=i-0106b4d25c54baac7}"},
+		{"eu-west-1", "AWS/EC2", "CPUUtilization", "1m", "Average", "InstanceId:i-0106b4d25c54baac7", "2h", "1h", "{InstanceId=i-0106b4d25c54baac7}"},
+		{"eu-west-1", "AWS/EC2", "CPUUtilization", "60", "Maximum", "InstanceId:i-0106b4d25c54baac7", "2h", "1h", "{InstanceId=i-0106b4d25c54baac7}"},
+		{"eu-west-1", "AWS/EC2", "CPUUtilization", "60", "Minimum", "InstanceId:i-0106b4d25c54baac7", "2h", "1h", "{InstanceId=i-0106b4d25c54baac7}"},
+		{"eu-west-1", "AWS/EC2", "CPUUtilization", "60", "Minimum", "InstanceId:*", "2h", "1h", "{InstanceId=910asdasd25c5477l}"},
+	}
+	for _, u := range tests {
+
+		results, err := CloudWatchQuery("default", &e, u.region,
+			u.namespace, u.metric, u.period, u.statistics,
+			u.dimensions, u.start, u.end)
+
+		if err != nil {
+			t.Errorf("Query Failure: %s ", err)
+		} else if results.Results[0].Group.String() != u.expected {
+			t.Errorf("Group mismatch got %s , expected %s", results.Results[0].Group.String(), u.expected)
+		}
+	}
+}
+
+func TestDateParseFail(t *testing.T) {
+	c := cloudwatch.GetContextWithProvider(&mockProfileProvider{})
+
+	e := State{
+		now: time.Date(2018, time.January, 1, 0, 0, 0, 0, time.UTC),
+		Backends: &Backends{
+			CloudWatchContext: c,
+		},
+		BosunProviders: &BosunProviders{
+			Squelched: func(tags opentsdb.TagSet) bool {
+				return false
+			},
+		},
+		Timer: new(miniprofiler.Profile),
+	}
+
+	var tests = []struct {
+		period string
+		start  string
+		end    string
+		err    error
+	}{
+		{"60s", "2h", "1h", nil},
+		{"60x", "2h", "1h", PeriodParseError},
+		{"60s", "2x", "1h", StartParseError},
+		{"60s", "2h", "1x", EndParseError},
+	}
+	for _, u := range tests {
+
+		_, err := CloudWatchQuery("default", &e, "eu-west-1", "AWS/EC2", "CPUUtilization", u.period,
+			"Sum", "InstanceId:i-0106b4d25c54baac7", u.start, u.end)
+
+		if err != u.err {
+			t.Errorf("Query Failure:  expected error to be %v, got %v", u.err, err)
+		}
+	}
+}
+
+func TestMultiRegion(t *testing.T) {
+	c := cloudwatch.GetContextWithProvider(&mockProfileProvider{})
+
+	e := State{
+		now: time.Date(2018, time.January, 1, 0, 0, 0, 0, time.UTC),
+		Backends: &Backends{
+			CloudWatchContext: c,
+		},
+		BosunProviders: &BosunProviders{
+			Squelched: func(tags opentsdb.TagSet) bool {
+				return false
+			},
+		},
+		Timer: new(miniprofiler.Profile),
+	}
+
+	var tests = []struct {
+		dimension string
+		expected  int
+	}{
+		{"eu-west-1", 1},
+		{"eu-central-1,eu-west-1", 2},
+		{"eu-west-1,eu-west-2,eu-central-1,ap-southeast-1", 4},
+	}
+	for _, u := range tests {
+
+		res, err := CloudWatchQuery("default", &e, u.dimension, "AWS/EC2", "CPUUtilization", "1m",
+			"Sum", "InstanceId:i-0106b4d25c54baac7", "1h", "")
+		if err != nil {
+			t.Errorf("Query Failure: %v", err)
+		} else if len(res.Results) != u.expected {
+			t.Errorf("Unexpected result set size, wanted %d, got %d results", u.expected, len(res.Results))
+		}
+	}
+}
+
+func TestCloudWatchQueryWithoutDimensions(t *testing.T) {
+	c := cloudwatch.GetContextWithProvider(&mockProfileProvider{})
+	e := State{
+		now: time.Date(2018, time.January, 1, 0, 0, 0, 0, time.UTC),
+		Backends: &Backends{
+			CloudWatchContext: c,
+		},
+		BosunProviders: &BosunProviders{
+			Squelched: func(tags opentsdb.TagSet) bool {
+				return false
+			},
+		},
+		Timer: new(miniprofiler.Profile),
+	}
+
+	results, err := CloudWatchQuery("default", &e, "eu-west-1", "AWS/EC2", "CPUUtilization", "60", "Sum", " ", "2h", "1h")
+	if err != nil {
+		t.Errorf("Query Failure: %s ", err)
+	} else if results.Results[0].Group.String() != "{}" {
+		t.Errorf("Dimensions not parsed correctly, expected '%s' , got '%s' ", "{}", results.Results[0].Group.String())
+	}
+}
+func TestCloudWatchTagQuery(t *testing.T) {
+	var tests = []struct {
+		dimensions string
+		tags       parse.Tags
+	}{
+		{"InstanceId:i-0106b4d25c54baac7", parse.Tags{"InstanceId": {}}},
+		{"InstanceId:i-0106b4d25c54baac7,AutoScalingGroupName:asg123", parse.Tags{"AutoScalingGroupName": {}, "InstanceId": {}}},
+		{"", parse.Tags{}},
+	}
+
+	args := make([]parse.Node, 8)
+
+	for _, u := range tests {
+		n := new(parse.StringNode)
+		n.Text = u.dimensions
+		args[5] = n
+		tags, err := cloudwatchTagQuery(args)
+		if err != nil {
+			t.Errorf("Error parsing tags %s", err)
+		}
+		if !tags.Equal(u.tags) {
+			t.Errorf("Missmatching tags, expected '%s' , got '%s' ", u.tags, tags)
+		}
+	}
+}

--- a/cmd/bosun/expr/cloudwatch_test.go
+++ b/cmd/bosun/expr/cloudwatch_test.go
@@ -1,6 +1,7 @@
 package expr
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -240,6 +241,33 @@ func TestCloudWatchQueryWithoutDimensions(t *testing.T) {
 		t.Errorf("Dimensions not parsed correctly, expected '%s' , got '%s' ", "{}", results.Results[0].Group.String())
 	}
 }
+
+func TestParseDimensions(t *testing.T) {
+
+	var tests = []struct {
+		dimensionString string
+		dims            [][]cloudwatch.Dimension
+		err             error
+	}{
+		{"foo:bar", [][]cloudwatch.Dimension{{cloudwatch.Dimension{
+			Name:  "foo",
+			Value: "bar",
+		}}}, nil},
+		{"invalid", nil, DimensionParseError},
+	}
+	for _, test := range tests {
+		dims, err := parseDimensions(test.dimensionString)
+		if !reflect.DeepEqual(dims, test.dims) {
+			t.Errorf("Expected %+v, got %+v ", test.dims, dims)
+
+		}
+		if err != test.err {
+			t.Errorf("Expected %s, got %s ", test.err, err)
+		}
+	}
+
+}
+
 func TestCloudWatchTagQuery(t *testing.T) {
 	var tests = []struct {
 		dimensions string

--- a/cmd/bosun/expr/expr.go
+++ b/cmd/bosun/expr/expr.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"bosun.org/annotate/backend"
+	"bosun.org/cloudwatch"
 	"bosun.org/cmd/bosun/cache"
 	"bosun.org/cmd/bosun/expr/parse"
 	"bosun.org/cmd/bosun/search"
@@ -49,16 +50,20 @@ type State struct {
 
 	// OpenTSDB
 	tsdbQueries []opentsdb.Request
+
+	// CloudWatch
+	cloudwatchQueries []cloudwatch.Request
 }
 
 type Backends struct {
-	TSDBContext     opentsdb.Context
-	GraphiteContext graphite.Context
-	ElasticHosts    ElasticHosts
-	InfluxConfig    client.HTTPConfig
-	ElasticConfig   ElasticConfig
-	AzureMonitor    AzureMonitorClients
-	PromConfig      PromClients
+	TSDBContext       opentsdb.Context
+	GraphiteContext   graphite.Context
+	ElasticHosts      ElasticHosts
+	InfluxConfig      client.HTTPConfig
+	ElasticConfig     ElasticConfig
+	AzureMonitor      AzureMonitorClients
+	CloudWatchContext cloudwatch.Context
+	PromConfig        PromClients
 }
 
 type BosunProviders struct {

--- a/cmd/bosun/sched/check.go
+++ b/cmd/bosun/sched/check.go
@@ -70,12 +70,13 @@ func (s *Schedule) NewRunHistory(start time.Time, cache *cache.Cache) *RunHistor
 		Events:   make(map[models.AlertKey]*models.Event),
 		schedule: s,
 		Backends: &expr.Backends{
-			TSDBContext:     s.SystemConf.GetTSDBContext(),
-			GraphiteContext: s.SystemConf.GetGraphiteContext(),
-			InfluxConfig:    s.SystemConf.GetInfluxContext(),
-			ElasticHosts:    s.SystemConf.GetElasticContext(),
-			AzureMonitor:    s.SystemConf.GetAzureMonitorContext(),
-			PromConfig:      s.SystemConf.GetPromContext(),
+			TSDBContext:       s.SystemConf.GetTSDBContext(),
+			GraphiteContext:   s.SystemConf.GetGraphiteContext(),
+			InfluxConfig:      s.SystemConf.GetInfluxContext(),
+			ElasticHosts:      s.SystemConf.GetElasticContext(),
+			AzureMonitor:      s.SystemConf.GetAzureMonitorContext(),
+			PromConfig:        s.SystemConf.GetPromContext(),
+			CloudWatchContext: s.SystemConf.GetCloudWatchContext(),
 		},
 	}
 	return r

--- a/cmd/bosun/web/chart.go
+++ b/cmd/bosun/web/chart.go
@@ -240,12 +240,13 @@ func ExprGraph(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (in
 	}
 	// it may not strictly be necessary to recreate the contexts each time, but we do to be safe
 	backends := &expr.Backends{
-		TSDBContext:     schedule.SystemConf.GetTSDBContext(),
-		GraphiteContext: schedule.SystemConf.GetGraphiteContext(),
-		InfluxConfig:    schedule.SystemConf.GetInfluxContext(),
-		ElasticHosts:    schedule.SystemConf.GetElasticContext(),
-		AzureMonitor:    schedule.SystemConf.GetAzureMonitorContext(),
-		PromConfig:      schedule.SystemConf.GetPromContext(),
+		TSDBContext:       schedule.SystemConf.GetTSDBContext(),
+		GraphiteContext:   schedule.SystemConf.GetGraphiteContext(),
+		InfluxConfig:      schedule.SystemConf.GetInfluxContext(),
+		ElasticHosts:      schedule.SystemConf.GetElasticContext(),
+		AzureMonitor:      schedule.SystemConf.GetAzureMonitorContext(),
+		PromConfig:        schedule.SystemConf.GetPromContext(),
+		CloudWatchContext: schedule.SystemConf.GetCloudWatchContext(),
 	}
 	providers := &expr.BosunProviders{
 		Cache:     cacheObj,

--- a/cmd/bosun/web/expr.go
+++ b/cmd/bosun/web/expr.go
@@ -82,12 +82,13 @@ func Expr(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (v inter
 	}
 	// it may not strictly be necessary to recreate the contexts each time, but we do to be safe
 	backends := &expr.Backends{
-		TSDBContext:     schedule.SystemConf.GetTSDBContext(),
-		GraphiteContext: schedule.SystemConf.GetGraphiteContext(),
-		InfluxConfig:    schedule.SystemConf.GetInfluxContext(),
-		ElasticHosts:    schedule.SystemConf.GetElasticContext(),
-		AzureMonitor:    schedule.SystemConf.GetAzureMonitorContext(),
-		PromConfig:      schedule.SystemConf.GetPromContext(),
+		TSDBContext:       schedule.SystemConf.GetTSDBContext(),
+		GraphiteContext:   schedule.SystemConf.GetGraphiteContext(),
+		InfluxConfig:      schedule.SystemConf.GetInfluxContext(),
+		ElasticHosts:      schedule.SystemConf.GetElasticContext(),
+		AzureMonitor:      schedule.SystemConf.GetAzureMonitorContext(),
+		PromConfig:        schedule.SystemConf.GetPromContext(),
+		CloudWatchContext: schedule.SystemConf.GetCloudWatchContext(),
 	}
 	providers := &expr.BosunProviders{
 		Cache:     cacheObj,

--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -729,6 +729,75 @@ Returns:
 }
 ```
 
+# CloudWatch Query Functions (Beta)
+ These functions are available when cloudwatch is enabled via Bosun's configuration.		 
+ Query syntax is potentially subject to change in later releases
+
+### cw(region string, namespace string, metric string, period scalar, statistic string, dimensions string, startDuration string, endDuration string) seriesSet
+{: .exprFunc}
+
+The parameters are as follows:
+
+* `region` The amazon region(s) for the service metrics you are interested in. e.g. `eu-west-1,eu-central-1` 
+* `namespace` The [CloudWatch namespace](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/aws-namespaces.html) which the metric you want to query exists under e.g `AWS/S3`
+* `metric` The [CloudWatch metric](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CW_Support_For_AWS.html) you wish to query, e.g. `NumberOfObjects`
+* `dimension` A string containing dimension key value pairs separated by : 
+* `period` size of bucket to use for grouping data-points expressed as a time string e.g. `"1m"`
+* `statistic` Which [aggregator](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Statistic) to use to combine the datapoints in each bucket. e.g. `Sum`
+* `startDuration` and `endDuration` set the time window from now - see the OpenTSDB q() function for more details
+
+A complete example returning the counts of infrequent access objects in our s3 bucket over the last hour.
+```
+$region = "eu-west-1"
+$namespace = "AWS/S3"
+$metric = "NumberOfObjects"
+$period = "1m"
+$statistics = "Average"
+$dimensions = "BucketName:my-s3-bucket,StorageType:STANDARD_IA"
+$objectCount = cw($region, $namespace, $metric, $period, $statistics, $dimensions, "1h" ,"")
+```
+
+You can use * as a wildcard character in dimensions to match multiple series 
+```
+$region = "eu-west-1,eu-central-1"
+$namespace = "AWS/ELB"
+$metric = "HealthyHostCount"
+$period = "5m"
+$statistics = "Minimum"
+$dimensions = "LoadBalancerName:web-*,AvailabilityZone:*"
+$cpuUsage = cw($region, $namespace, $metric, $period, $statistics, $dimensions, "7d" ,"")
+```
+
+
+### PrefixKey
+PrefixKey is a quoted string used to query different aws accounts by passing the name of the profile from the amazon credentials file.  If omitted the query will be made using the default credentials chain.
+
+Credentials file example:
+```
+[prod]
+aws_access_key_id=AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+
+[test]
+aws_access_key_id=BKyfyfIAIDNN7EXAMPLE
+aws_secret_access_key=Ays6tnFEMI/ASD7D6/bPxRfiCYEXAMPLEKEY
+```
+
+Example of querying using multiple accounts
+```
+$region = "eu-west-1"
+$namespace = "AWS/EC2"
+$metric = "CPUUtilization"
+$period = "1m"
+$statistics = "Average"
+
+$prodDim = "InstanceId":"i-1234567890abcdef0"
+$testDim = "InstanceId":"i-0598c7d356eba48d7"
+
+$p = ["prod"]cw($region, $namespace, $metric, $period, $statistics, $prodDim, "1h" ,"")
+$t = ["test"]cw($region, $namespace, $metric, $period, $statistics, $testDim, "1h" ,"")
+```
+
 # Reduction Functions
 
 All reduction functions take a seriesSet and return a numberSet with one element per unique group.

--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -641,6 +641,78 @@ The result has the following Properties:
 
  Examples: `promtags("up", "10", "")`, `["it"]promtags("container_memory_working_set_bytes")`.
 
+
+## CloudWatch Query Functions (Beta)
+ These functions are available when cloudwatch is enabled via Bosun's configuration.		 
+ Query syntax is potentially subject to change in later releases
+
+### cw(region, namespace, metric, period, statistic, dimensions, startDuration, endDuration string) seriesSet
+{: .exprFunc}
+
+The parameters are as follows:
+
+* `region` The amazon region(s) for the service metrics you are interested in. e.g. `eu-west-1,eu-central-1` 
+* `namespace` The [CloudWatch namespace](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/aws-namespaces.html) which the metric you want to query exists under e.g `AWS/S3`
+* `metric` The [CloudWatch metric](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CW_Support_For_AWS.html) you wish to query, e.g. `NumberOfObjects`
+* `dimension` A string containing dimension key value pairs separated by : 
+* `period` size of bucket to use for grouping data-points expressed as a time string e.g. `1m`
+* `statistic` Which [aggregator](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Statistic) to use to combine the datapoints in each bucket. e.g. `Sum`
+* `startDuration` and `endDuration` set the time window from now - see the OpenTSDB q() function for more details
+
+A complete example returning the counts of infrequent access objects in our s3 bucket over the last hour.
+```
+$region = "eu-west-1"
+$namespace = "AWS/S3"
+$metric = "NumberOfObjects"
+$period = "1m"
+$statistics = "Average"
+$dimensions = "BucketName:my-s3-bucket,StorageType:STANDARD_IA"
+$objectCount = cw($region, $namespace, $metric, $period, $statistics, $dimensions, "1h" ,"")
+```
+
+You can use * as a wildcard character in dimensions to match multiple series 
+```
+$region = "eu-west-1,eu-central-1"
+$namespace = "AWS/ELB"
+$metric = "HealthyHostCount"
+$period = "5m"
+$statistics = "Minimum"
+$dimensions = "LoadBalancerName:web-*,AvailabilityZone:*"
+$cpuUsage = cw($region, $namespace, $metric, $period, $statistics, $dimensions, "7d" ,"")
+```
+
+
+### PrefixKey
+PrefixKey is a quoted string used to query different aws accounts by passing the name of the profile from the amazon credentials file.  If omitted the query will be made using the default credentials chain.
+
+Credentials file example:
+```
+[prod]
+aws_access_key_id=AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+
+[test]
+aws_access_key_id=BKyfyfIAIDNN7EXAMPLE
+aws_secret_access_key=Ays6tnFEMI/ASD7D6/bPxRfiCYEXAMPLEKEY
+```
+
+Example of querying using multiple accounts
+```
+$region = "eu-west-1"
+$namespace = "AWS/EC2"
+$metric = "CPUUtilization"
+$period = "1m"
+$statistics = "Average"
+
+$prodDim = "InstanceId":"i-1234567890abcdef0"
+$testDim = "InstanceId":"i-0598c7d356eba48d7"
+
+$p = ["prod"]cw($region, $namespace, $metric, $period, $statistics, $prodDim, "1h" ,"")
+$t = ["test"]cw($region, $namespace, $metric, $period, $statistics, $testDim, "1h" ,"")
+```
+
+
+
 # Annotation Query Functions
 These function are available when annotate is enabled via Bosun's configuration.
 
@@ -729,74 +801,6 @@ Returns:
 }
 ```
 
-# CloudWatch Query Functions (Beta)
- These functions are available when cloudwatch is enabled via Bosun's configuration.		 
- Query syntax is potentially subject to change in later releases
-
-### cw(region string, namespace string, metric string, period scalar, statistic string, dimensions string, startDuration string, endDuration string) seriesSet
-{: .exprFunc}
-
-The parameters are as follows:
-
-* `region` The amazon region(s) for the service metrics you are interested in. e.g. `eu-west-1,eu-central-1` 
-* `namespace` The [CloudWatch namespace](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/aws-namespaces.html) which the metric you want to query exists under e.g `AWS/S3`
-* `metric` The [CloudWatch metric](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CW_Support_For_AWS.html) you wish to query, e.g. `NumberOfObjects`
-* `dimension` A string containing dimension key value pairs separated by : 
-* `period` size of bucket to use for grouping data-points expressed as a time string e.g. `"1m"`
-* `statistic` Which [aggregator](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Statistic) to use to combine the datapoints in each bucket. e.g. `Sum`
-* `startDuration` and `endDuration` set the time window from now - see the OpenTSDB q() function for more details
-
-A complete example returning the counts of infrequent access objects in our s3 bucket over the last hour.
-```
-$region = "eu-west-1"
-$namespace = "AWS/S3"
-$metric = "NumberOfObjects"
-$period = "1m"
-$statistics = "Average"
-$dimensions = "BucketName:my-s3-bucket,StorageType:STANDARD_IA"
-$objectCount = cw($region, $namespace, $metric, $period, $statistics, $dimensions, "1h" ,"")
-```
-
-You can use * as a wildcard character in dimensions to match multiple series 
-```
-$region = "eu-west-1,eu-central-1"
-$namespace = "AWS/ELB"
-$metric = "HealthyHostCount"
-$period = "5m"
-$statistics = "Minimum"
-$dimensions = "LoadBalancerName:web-*,AvailabilityZone:*"
-$cpuUsage = cw($region, $namespace, $metric, $period, $statistics, $dimensions, "7d" ,"")
-```
-
-
-### PrefixKey
-PrefixKey is a quoted string used to query different aws accounts by passing the name of the profile from the amazon credentials file.  If omitted the query will be made using the default credentials chain.
-
-Credentials file example:
-```
-[prod]
-aws_access_key_id=AKIAIOSFODNN7EXAMPLE
-aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-
-[test]
-aws_access_key_id=BKyfyfIAIDNN7EXAMPLE
-aws_secret_access_key=Ays6tnFEMI/ASD7D6/bPxRfiCYEXAMPLEKEY
-```
-
-Example of querying using multiple accounts
-```
-$region = "eu-west-1"
-$namespace = "AWS/EC2"
-$metric = "CPUUtilization"
-$period = "1m"
-$statistics = "Average"
-
-$prodDim = "InstanceId":"i-1234567890abcdef0"
-$testDim = "InstanceId":"i-0598c7d356eba48d7"
-
-$p = ["prod"]cw($region, $namespace, $metric, $period, $statistics, $prodDim, "1h" ,"")
-$t = ["test"]cw($region, $namespace, $metric, $period, $statistics, $testDim, "1h" ,"")
-```
 
 # Reduction Functions
 

--- a/docs/system_configuration.md
+++ b/docs/system_configuration.md
@@ -587,13 +587,12 @@ User agent that Bosun should identify itself as when querying Influx.
 	UnsafeSSL = true
 ```
 
-		 ### CloudWatchConf
+### CloudWatchConf
  Enables querying CloudWatch metrics and exposes the query functions to the expression language.
  This functionality relies on bosun having assumed an iam role with the following capabilities
  ```
  ListMetrics
  GetMetricData
- GetMetricStatistics
  ```
  You can supply credentials using any of the standard methods such as passing an iam role to the ec2 instance bosun is running on, 
  in the aws shared credentials file or via environment variables.
@@ -601,26 +600,24 @@ User agent that Bosun should identify itself as when querying Influx.
   For complete details see the `Specifying Credentials` section of the [aws documentation](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html)
 
  
-  #### Enabled
+#### Enabled
  Should the cloudwatch functionality be loaded.
 
-  #### PagesLimit
+#### PagesLimit
  If wildcards are used in a dimension string bosun must call the [ListMetrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_ListMetrics.html) api to try and find
  matches. This parameter controls how many pages of results bosun will iterate through before giving up and throwing an error.
  1 page corresponds to 500 metrics
  
-  #### ExpansionLimit
+#### ExpansionLimit
  When using wildcards, the expansion limit controls the maximum number of metrics that will be requested using the 
  [getMetricData()](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricData.html) api.
  For example if you have a large infrastructure which uses spot instances and make a query with a dimension of `InstanceId:*` 
  it would match 1000s of metrics. This will both be slow and expensive as you will be billed for each series you request from
- the cloudwatch API. The PagesLimit and ExpansionLimit act as a safety valves to stop users inadvertently making very large requests
- to the api
+ the cloudwatch API. The PagesLimit and ExpansionLimit act as a safety valves to stop users inadvertently making very large requests.
 
-  #### Concurrency
- The number of simultaneous queries to make to the cloudwatch api. Increasing this number can improve perfomance of queries 
- which contain a large number of metrics but may result in rate limiting if you call the cloudwatch api too frequently.
- #### Example:
+#### Concurrency
+ The number of simultaneous queries to make to the cloudwatch api.
+#### Example:
 
   ```
 [CloudWatchConf]

--- a/docs/system_configuration.md
+++ b/docs/system_configuration.md
@@ -587,6 +587,49 @@ User agent that Bosun should identify itself as when querying Influx.
 	UnsafeSSL = true
 ```
 
+		 ### CloudWatchConf
+ Enables querying CloudWatch metrics and exposes the query functions to the expression language.
+ This functionality relies on bosun having assumed an iam role with the following capabilities
+ ```
+ ListMetrics
+ GetMetricData
+ GetMetricStatistics
+ ```
+ You can supply credentials using any of the standard methods such as passing an iam role to the ec2 instance bosun is running on, 
+ in the aws shared credentials file or via environment variables.
+
+  For complete details see the `Specifying Credentials` section of the [aws documentation](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html)
+
+ 
+  #### Enabled
+ Should the cloudwatch functionality be loaded.
+
+  #### PagesLimit
+ If wildcards are used in a dimension string bosun must call the [ListMetrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_ListMetrics.html) api to try and find
+ matches. This parameter controls how many pages of results bosun will iterate through before giving up and throwing an error.
+ 1 page corresponds to 500 metrics
+ 
+  #### ExpansionLimit
+ When using wildcards, the expansion limit controls the maximum number of metrics that will be requested using the 
+ [getMetricData()](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricData.html) api.
+ For example if you have a large infrastructure which uses spot instances and make a query with a dimension of `InstanceId:*` 
+ it would match 1000s of metrics. This will both be slow and expensive as you will be billed for each series you request from
+ the cloudwatch API. The PagesLimit and ExpansionLimit act as a safety valves to stop users inadvertently making very large requests
+ to the api
+
+  #### Concurrency
+ The number of simultaneous queries to make to the cloudwatch api. Increasing this number can improve perfomance of queries 
+ which contain a large number of metrics but may result in rate limiting if you call the cloudwatch api too frequently.
+ #### Example:
+
+  ```
+[CloudWatchConf]
+       Enabled = true
+       PagesLimit = 10
+       ExpansionLimit = 500
+       Concurrency = 2
+ ```
+
 ### AuthConf
 Bosun authentication settings. If not specified, your instance will have
 no authentication, and will be open to anybody. When using Auth, TLS

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 // indirect
 	github.com/alicebob/miniredis v2.5.0+incompatible // indirect
 	github.com/andybalholm/cascadia v0.0.0-20150730174459-3ad29d1ad1c4 // indirect
-	github.com/aws/aws-sdk-go v1.1.33
+	github.com/aws/aws-sdk-go v1.30.7
 	github.com/aymerick/douceur v0.2.1-0.20150827151352-7176f1467381
 	github.com/bosun-monitor/statusio v0.0.0-20160516160816-ab1583139762
 	github.com/bradfitz/slice v0.0.0-20140430145140-a665b5dbaad5
@@ -67,7 +67,7 @@ require (
 	github.com/mjibson/esc v0.1.0
 	github.com/olivere/elastic v6.1.23-0.20180523141205-33ad30f61610+incompatible
 	github.com/pelletier/go-toml v1.6.0 // indirect
-	github.com/pkg/errors v0.8.1-0.20170505043639-c605e284fe17
+	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v0.9.3-0.20190106165022-d2ead2588477
 	github.com/prometheus/common v0.1.0
@@ -77,7 +77,7 @@ require (
 	github.com/siddontang/goredis v0.0.0-20150324035039-760763f78400 // indirect
 	github.com/siddontang/ledisdb v0.0.0-20190202134119-8ceb77e66a92
 	github.com/siddontang/rdb v0.0.0-20150307021120-fc89ed2e418d // indirect
-	github.com/stretchr/testify v1.2.2
+	github.com/stretchr/testify v1.5.1
 	github.com/syndtr/goleveldb v0.0.0-20150819051622-1a9d62f03ea9 // indirect
 	github.com/tatsushid/go-fastping v0.0.0-20150818125950-06cac0fecdc2
 	github.com/twinj/uuid v0.0.0-20151029044442-89173bcdda19

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/andybalholm/cascadia v0.0.0-20150730174459-3ad29d1ad1c4 h1:I6VYmq9mpk
 github.com/andybalholm/cascadia v0.0.0-20150730174459-3ad29d1ad1c4/go.mod h1:3I+3V7B6gTBYfdpYgIG2ymALS9H+5VDKUl3lHH7ToM4=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/aws/aws-sdk-go v0.0.0-20180507225419-00862f899353/go.mod h1:ZRmQr0FajVIyZ4ZzBYKG5P3ZqPz9IHG41ZoMu1ADI3k=
-github.com/aws/aws-sdk-go v1.1.33 h1:AebOM+6ucC+bSl36BQrYkwShiqruxxJrZKduAvXSD1A=
-github.com/aws/aws-sdk-go v1.1.33/go.mod h1:ZRmQr0FajVIyZ4ZzBYKG5P3ZqPz9IHG41ZoMu1ADI3k=
+github.com/aws/aws-sdk-go v1.30.7 h1:IaXfqtioP6p9SFAnNfsqdNczbR5UNbYqvcZUSsCAdTY=
+github.com/aws/aws-sdk-go v1.30.7/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aymerick/douceur v0.2.1-0.20150827151352-7176f1467381 h1:TvvArQ5hYFgPFFRT8BB/gKaVvxjC9qVZG/3jxYuNACQ=
 github.com/aymerick/douceur v0.2.1-0.20150827151352-7176f1467381/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
@@ -69,6 +69,7 @@ github.com/coreos/go-systemd v0.0.0-20160202211425-7b2428fec400 h1:hCPDBaGzL6ZFs
 github.com/coreos/go-systemd v0.0.0-20160202211425-7b2428fec400/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/cupcake/rdb v0.0.0-20130607152045-3454dcabd33c h1:s2lHsI48anlMdjMab4mFEFbrIXH6yVZVe+qmRzuby30=
 github.com/cupcake/rdb v0.0.0-20130607152045-3454dcabd33c/go.mod h1:vYwsqCOLxGiisLwp9rITslkFNpZD5rz43tf41QFkTWY=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v0.0.0-20161101193935-9ed569b5d1ac/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
@@ -112,6 +113,7 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-ole/go-ole v1.2.1 h1:2lOsA72HgjxAuMlKpFiCbHTvu44PIVkZ5hqm3RSdI/E=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gocarina/gocsv v0.0.0-20190927101021-3ecffd272576 h1:nDMaZgjBNKhsVJEWN1wAnqUJWwWGxFdDlt8U17KqMQ8=
@@ -184,6 +186,8 @@ github.com/jinzhu/now v0.0.0-20151001141511-ce80572eb55a h1:E3/FQGI4lCWmMwCgJCQz
 github.com/jinzhu/now v0.0.0-20151001141511-ce80572eb55a/go.mod h1:oHTiXerJ20+SfYcrdlBO7rzZRJWGwSTQ0iUY2jI6Gfc=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7 h1:SMvOWPJCES2GdFracYbBQh93GXac8fq7HeN6JnpduB8=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
+github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jmoiron/jsonq v0.0.0-20150511023944-e874b168d07e h1:ZZCvgaRDZg1gC9/1xrsgaJzQUCQgniKtw0xjWywWAOE=
 github.com/jmoiron/jsonq v0.0.0-20150511023944-e874b168d07e/go.mod h1:+rHyWac2R9oAZwFe1wGY2HBzFJJy++RHBg1cU23NkD8=
 github.com/jordan-wright/email v0.0.0-20151016173557-f61123ea07e1 h1:t9N9joT8+GL35qGegwt+eOgR5RMTaNiIxjzUf7XQQsE=
@@ -257,8 +261,8 @@ github.com/peterbourgon/diskv v0.0.0-20180312054125-0646ccaebea1/go.mod h1:uqqh8
 github.com/peterbourgon/g2s v0.0.0-20170223122336-d4e7ad98afea/go.mod h1:1VcHEd3ro4QMoHfiNl/j7Jkln9+KQuorp0PItHMJYNg=
 github.com/petermattis/goid v0.0.0-20170504144140-0ded85884ba5/go.mod h1:jvVRKCrJTQWu0XVbaOlby/2lO20uSCHEMzzplHXte1o=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.8.1-0.20170505043639-c605e284fe17 h1:+adyfd5YBtuLL2FbDEn0GitOinGeMH0levy3o62TMF0=
-github.com/pkg/errors v0.8.1-0.20170505043639-c605e284fe17/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -307,9 +311,12 @@ github.com/smartystreets/goconvey v0.0.0-20180222194500-ef6db91d284a/go.mod h1:X
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/syndtr/goleveldb v0.0.0-20150819051622-1a9d62f03ea9 h1:kjhuMOV0muyKY5oCiYL8Vw3kL6d2/WrTqjDWSMjmwcU=
 github.com/syndtr/goleveldb v0.0.0-20150819051622-1a9d62f03ea9/go.mod h1:Z4AUp2Km+PwemOoO/VB5AOx9XSsIItzFjoJlOSiYmn0=
 github.com/tatsushid/go-fastping v0.0.0-20150818125950-06cac0fecdc2 h1:e8bQZseYLULpqsibTeQVvO/UakfoNW/Q6ErAIkNeo/8=
@@ -338,6 +345,7 @@ golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20181217023233-e147a9138326 h1:iCzOf0xz39Tstp+Tu/WwyGjUXCk34QhQORRxBeXXTA4=
 golang.org/x/net v0.0.0-20181217023233-e147a9138326/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZVDP2S5ou6y0gSgXHu8=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20160608215109-65a8d08c6292 h1:HXWhxjZW2BJxGm1bt3b3Au7QNJc+/D8pjM1tfdDLlm8=
@@ -400,6 +408,7 @@ gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa
 gopkg.in/yaml.v2 v2.2.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 k8s.io/api v0.0.0-20180628040859-072894a440bd/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=


### PR DESCRIPTION
<!--
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like
-->

---

# Description

<!--
Please describe your contribution in an issue first, to see if it fits the roadmap of the project. This makes it easier 
for us and you to accept your contribution without requiring too much rework.
Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context. 
List any dependencies that are required for this change. 
-->


Replaces PR  #2262 . 
Internal version of this functionality had diverged sufficiently from original PR that it is cleaner to start afresh

Requires a role with the ListMetrics and GetMetricData capabilities.
Role can be supplied using either the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables or by attaching it to the EC2 instance on which bosun runs.

## Type of change

<!--
From the following, please check the options that are relevant.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

<!--
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration
-->

- [x] CloudWatch query functionality had good unit test coverage
- [x] Has been used in production in Skyscanner for several years

# Checklist:

- [x] This contribution follows the project's [code of conduct](https://github.com/bosun-monitor/bosun/blob/master/CODE_OF_CONDUCT.md)
- [x] This contribution follows the project's [contributing guidelines](https://github.com/bosun-monitor/bosun/blob/master/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules