### PR TITLE
Update the documentation for dropbool

### DIFF
--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -1130,7 +1130,7 @@ Remove any NaN or Inf values from a series. Will error if this operation results
 ## dropbool(seriesSet, seriesSet) seriesSet
 {: .exprFunc}
 
-Drop datapoints where the corresponding value in the second series set is non-zero. (See Series Operations for what corresponding means). The following example drops tr_avg (avg response time per bucket) datapoints if the count in that bucket was + or - 100 from the average count over the time period.
+Drop datapoints where the corresponding value in the second series set is zero. (See Series Operations for what corresponding means). The following example drops tr_avg (avg response time per bucket) datapoints if the count in that bucket was + or - 100 from the average count over the time period.
 
 Example:
 


### PR DESCRIPTION
<!--
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like
-->

---

# Description

<!--
Please describe your contribution in an issue first, to see if it fits the roadmap of the project. This makes it easier 
for us and you to accept your contribution without requiring too much rework.
Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context. 
List any dependencies that are required for this change. 
-->

Fixes the documentation which described the behaviour of `dropbool`
incorrectly.
`dropbool()` currently drops the values where the value in the second
series set IS zero instead of, as described, dropping those where the
value IS NOT zero. To avoid a breaking change which would give the
function the more intuitive behaviour from its name, this only updates
the documentation.

We should consider fixing this with a breaking change in a future
release.

Fixes #2496

## Type of change

<!--
From the following, please check the options that are relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How has this been tested?

<!--
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration
-->

- Query `dropbool(series("foo=bar", 0, 1, 1, 1, 2, 1, 3, 1), series("", 0, 1, 1, 2, 2, 3, 3, 2) != 2)` returns `{"0": 1, "2": 1}`
- Query `dropbool(series("foo=bar", 0, 1, 1, 1, 2, 1, 3, 1), series("", 0, 1, 1, 2, 2, 3, 3, 2))` returns `{"1": 1, "2": 1, "3": 1}`

The behaviour is the inverse of the previously described behaviour. The description is fixed with this PR.

# Checklist:

- [x] This contribution follows the project's [code of conduct](https://github.com/bosun-monitor/bosun/blob/master/CODE_OF_CONDUCT.md)
- [x] This contribution follows the project's [contributing guidelines](https://github.com/bosun-monitor/bosun/blob/master/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
