### PR TITLE
Enable scheduled web cache cleanup

### DIFF
--- a/cmd/bosun/cache/cache.go
+++ b/cmd/bosun/cache/cache.go
@@ -50,3 +50,14 @@ func (c *Cache) Get(key string, getFn func() (interface{}, error)) (i interface{
 	})
 	return
 }
+
+func (c *Cache) Clear() {
+	c.Lock()
+	defer c.Unlock()
+
+	c.lru.Clear()
+}
+
+func (c *Cache) Length() int {
+	return c.lru.Len()
+}

--- a/cmd/bosun/conf/system.go
+++ b/cmd/bosun/conf/system.go
@@ -77,6 +77,9 @@ type SystemConf struct {
 	CommandHookPath string
 	RuleFilePath    string
 	md              toml.MetaData
+
+	ScheduledClearWebCache         bool     // enable scheduled web cache clear task, web cache is `var cacheObj = cache.New("web", 100)`
+	ScheduledClearWebCacheDuration Duration // the frequency of scheduled web cache clear task
 }
 
 // EnabledBackends stores which query backends supported by bosun are enabled
@@ -345,8 +348,10 @@ func newSystemConf() *SystemConf {
 			ResponseLimit: 1 << 20, // 1MB
 			Version:       opentsdb.Version2_1,
 		},
-		SearchSince:      Duration{time.Duration(opentsdb.Day) * 3},
-		UnknownThreshold: 5,
+		SearchSince:                    Duration{time.Duration(opentsdb.Day) * 3},
+		UnknownThreshold:               5,
+		ScheduledClearWebCache:         false,
+		ScheduledClearWebCacheDuration: Duration{Duration: time.Hour * 24},
 	}
 }
 
@@ -747,6 +752,17 @@ func (sc *SystemConf) GetAzureMonitorContext() expr.AzureMonitorClients {
 		allClients[prefix] = cc
 	}
 	return allClients
+}
+
+// GetScheduledClearWebCache returns if the scheduled clear web cache task is enabled or not
+// web cache is `var cacheObj = cache.New("web", 100)`
+func (sc *SystemConf) GetScheduledClearWebCache() bool {
+	return sc.ScheduledClearWebCache
+}
+
+// GetScheduledClearWebCache returns the frequency of the scheduled clear web cache task
+func (sc *SystemConf) GetScheduledClearWebCacheDuration() time.Duration {
+	return sc.ScheduledClearWebCacheDuration.Duration
 }
 
 // azureLogRequest outputs HTTP requests to Azure to the logs

--- a/cmd/bosun/main.go
+++ b/cmd/bosun/main.go
@@ -313,6 +313,11 @@ func main() {
 		base := filepath.Join("web", "static", "js")
 		watch(base, "*.ts", web.RunTsc)
 	}
+
+	if systemConf.GetScheduledClearWebCache() {
+		go web.ClearWebCache(systemConf.GetScheduledClearWebCacheDuration())
+	}
+
 	select {}
 }
 

--- a/cmd/bosun/web/expr.go
+++ b/cmd/bosun/web/expr.go
@@ -21,6 +21,7 @@ import (
 	"bosun.org/cmd/bosun/sched"
 	"bosun.org/models"
 	"bosun.org/opentsdb"
+	"bosun.org/slog"
 	"github.com/MiniProfiler/go/miniprofiler"
 	"github.com/bradfitz/slice"
 )
@@ -30,6 +31,16 @@ import (
 // the only risk is that if you query your store for data -5m to now and your store doesn't have the latest points up to date,
 // and then 5m from now you query -10min to -5m you'll get the same cached data, including the incomplete last points
 var cacheObj = cache.New("web", 100)
+
+// ClearWebCache clears web cache by schedule
+func ClearWebCache(t time.Duration) {
+	for {
+		time.Sleep(t)
+		slog.Infof("Start cleaning web cache, the number of entries: %d", cacheObj.Length())
+		cacheObj.Clear()
+		slog.Info("Done cleaning web cache")
+	}
+}
 
 func Expr(t miniprofiler.Timer, w http.ResponseWriter, r *http.Request) (v interface{}, err error) {
 	defer func() {


### PR DESCRIPTION
<!--
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like
-->

---

# Description

<!--
Please describe your contribution in an issue first, to see if it fits the roadmap of the project. This makes it easier 
for us and you to accept your contribution without requiring too much rework.
Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context. 
List any dependencies that are required for this change. 
-->

`var cacheObj = cache.New("web", 100)` is a cache for web requests. For some heavy Graphite queries, due to the existence of cache, the memory used by json unmarshalling cannot be released for long time.
Create a schedule task to clear the cache.


## Type of change

<!--
From the following, please check the options that are relevant.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

<!--
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration
-->
This has been running with the following configuration in production.

```bosun.toml
......
# Enable scheduled web cache clear task. Default is false.
ScheduledClearWebCache = true

# The frequency of scheduled web cache clear task. Default is "24h".
ScheduledClearWebCacheDuration = "24h"
......
```

# Checklist:

- [x] This contribution follows the project's [code of conduct](https://github.com/bosun-monitor/bosun/blob/master/CODE_OF_CONDUCT.md)
- [x] This contribution follows the project's [contributing guidelines](https://github.com/bosun-monitor/bosun/blob/master/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
