### PR TITLE
chore: unnecessary use of fmt.Sprintf

### DIFF
--- a/cloudwatch/cloudwatch.go
+++ b/cloudwatch/cloudwatch.go
@@ -269,7 +269,7 @@ func (c *cloudWatchContext) Query(r *Request) (Response, error) {
 	}
 	// custom metrics can have no dimensions
 	if len(r.Dimensions) == 0 {
-		id = fmt.Sprintf("q0")
+		id = "q0"
 		dq := buildQuery(r, id, nil)
 		dqs = append(dqs, &dq)
 		tagSet[id] = buildTags(nil)

--- a/cloudwatch/cloudwatch_test.go
+++ b/cloudwatch/cloudwatch_test.go
@@ -149,7 +149,7 @@ func (c mockCloudWatchClient) GetMetricData(input *cloudwatch.GetMetricDataInput
 	}
 
 	for i := 0; i < 10; i++ {
-		id := fmt.Sprintf("q{i}")
+		id := "q{i}"
 		m := cloudwatch.MetricDataResult{
 			Id:         &id,
 			Label:      nil,

--- a/cmd/bosun/database/sentinel/sentinel.go
+++ b/cmd/bosun/database/sentinel/sentinel.go
@@ -92,7 +92,7 @@ func (ns NoSentinelsAvailable) Error() string {
 	if ns.lastError != nil {
 		return fmt.Sprintf("redigo: no sentinels available; last error: %s", ns.lastError.Error())
 	}
-	return fmt.Sprintf("redigo: no sentinels available")
+	return "redigo: no sentinels available"
 }
 
 // putToTop puts Sentinel address to the top of address list - this means


### PR DESCRIPTION
<!--
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like
-->

---

# Description
unnecessary use of fmt.Sprintf
<!--
Please describe your contribution in an issue first, to see if it fits the roadmap of the project. This makes it easier 
for us and you to accept your contribution without requiring too much rework.
Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context. 
List any dependencies that are required for this change. 
-->

Fixes #0000 (fill in)

## Type of change

<!--
From the following, please check the options that are relevant.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

<!--
Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Please also list any relevant details for your test configuration
-->

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] This contribution follows the project's [code of conduct](https://github.com/bosun-monitor/bosun/blob/master/CODE_OF_CONDUCT.md)
- [ ] This contribution follows the project's [contributing guidelines](https://github.com/bosun-monitor/bosun/blob/master/CONTRIBUTING.md)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
